### PR TITLE
fix: share one criteria probe across both match seams

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -27,7 +27,7 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 
 Containment covers plugin raises only: a framework-owned raise (a two-readers conflict, a forwarded value contradicting the feature name, a rejected effective-options build) still aborts the whole resolution, because it reports a misconfiguration you have to fix.
 
-Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
+Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters`, as is a typed decline the matcher records; a framework-owned raise still aborts.
 
 The probe runs per feature, but a matched filter attaches to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset).
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -213,8 +213,8 @@ return `True` explicitly to keep it.
 
 If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, or returns a
 value whose truthiness test raises, that filter is a non-match for that probe, like a `False`
-return, and the drop is recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still
-aborts.
+return, and the drop is recorded in `GlobalFilter.dropped_filters`. A typed decline the matcher
+records lands in the same ledger, at DEBUG. A framework-owned raise still aborts.
 
 The option divergence warning fires only for a filter that actually attaches, once per distinct
 message per setup. A filter that matches no FeatureGroup at all is reported once after setup

--- a/mloda/core/abstract_plugins/components/match_hook.py
+++ b/mloda/core/abstract_plugins/components/match_hook.py
@@ -7,7 +7,7 @@ Each keeps only its own recording and rollback now, driven by the outcome this h
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -20,7 +20,7 @@ from mloda.core.abstract_plugins.components.match_rejection import (
     record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.utils import is_match_abort
+from mloda.core.abstract_plugins.components.utils import is_match_abort, safe_field
 
 if TYPE_CHECKING:
     from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -72,7 +72,7 @@ class CriteriaProbeOutcome:
     returned: Any
     # Disjoint: the one contained raise is a typed decline (value_rejection) or the candidate's own defect.
     matcher_error: Optional[Exception]
-    value_rejection: Optional[Exception]
+    value_rejection: Optional[PropertyValueRejection]
     rejection: Optional[MatchRejection]
 
 
@@ -81,28 +81,19 @@ def probe_match_criteria(
     feature_name: FeatureName | str,
     options: Options,
     data_access_collection: Optional[DataAccessCollection] = None,
-    *,
-    hook: Optional[
-        Callable[[type[FeatureGroup], FeatureName | str, Options, Optional[DataAccessCollection]], MatchHookOutcome]
-    ] = None,
 ) -> CriteriaProbeOutcome:
-    """Ask one candidate under its own rejection window; a marked abort propagates, the finally only resets.
-
-    ``hook`` exists for the seams: each passes its own module binding of ``call_match_hook``, so the seam
-    tests can intercept the route there.
-    """
+    """Ask one candidate under its own rejection window; a marked abort propagates, the finally only resets."""
     token = MATCH_REJECTION_REASONS.set({})
     try:
-        outcome = (
-            call_match_hook(feature_group, feature_name, options, data_access_collection)
-            if hook is None
-            else hook(feature_group, feature_name, options, data_access_collection)
-        )
+        outcome = call_match_hook(feature_group, feature_name, options, data_access_collection)
         value_rejection = outcome.error if isinstance(outcome.error, PropertyValueRejection) else None
         matcher_error = outcome.error if value_rejection is None else None
         if value_rejection is not None:
-            # Parity with the canonical seam: the class name owns the record and the reason is str(exc).
-            record_match_rejection(feature_group.get_class_name(), str(value_rejection))
+            # Parity with the canonical seam: the class name owns the record and the reason is str(exc);
+            # the owner name is harvested by value, never by key, so a degraded name is harmless.
+            owner = safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>")
+            reason = safe_field(functools.partial(str, value_rejection), type(value_rejection).__name__)
+            record_match_rejection(owner, reason)
         recorded = MATCH_REJECTION_REASONS.get() or {}
         # Harvest only on a non-match; the first recorded reason wins (insertion order).
         rejection = next(iter(recorded.values())) if not outcome.matched and recorded else None

--- a/mloda/core/abstract_plugins/components/match_hook.py
+++ b/mloda/core/abstract_plugins/components/match_hook.py
@@ -1,4 +1,5 @@
-"""One home for the match-hook call: the containment, the marked-abort re-raise and the return coercion.
+"""One home for the match-hook call and the shared criteria probe: the containment, the marked-abort
+re-raise and the return coercion.
 
 Both match seams held their own try around ``match_feature_group_criteria`` and drifted apart twice (#991).
 Each keeps only its own recording and rollback now, driven by the outcome this helper hands back.
@@ -6,11 +7,18 @@ Each keeps only its own recording and rollback now, driven by the outcome this h
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.match_rejection import (
+    MATCH_REJECTION_REASONS,
+    MatchRejection,
+    record_match_rejection,
+)
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import is_match_abort
 
@@ -54,3 +62,50 @@ def call_match_hook(
         # The outcome outlives this except block, and the traceback's frames pin the plugin class and its raw
         # return. with_traceback, not the attribute: a frozen-dataclass exception rejects the assignment.
         return MatchHookOutcome(False, None, exc.with_traceback(None))
+
+
+@dataclass(frozen=True)
+class CriteriaProbeOutcome:
+    """One probed match: verdict, raw return, the contained raise split by kind, the first harvested rejection."""
+
+    matched: bool
+    returned: Any
+    # Disjoint: the one contained raise is a typed decline (value_rejection) or the candidate's own defect.
+    matcher_error: Optional[Exception]
+    value_rejection: Optional[Exception]
+    rejection: Optional[MatchRejection]
+
+
+def probe_match_criteria(
+    feature_group: type[FeatureGroup],
+    feature_name: FeatureName | str,
+    options: Options,
+    data_access_collection: Optional[DataAccessCollection] = None,
+    *,
+    hook: Optional[
+        Callable[[type[FeatureGroup], FeatureName | str, Options, Optional[DataAccessCollection]], MatchHookOutcome]
+    ] = None,
+) -> CriteriaProbeOutcome:
+    """Ask one candidate under its own rejection window; a marked abort propagates, the finally only resets.
+
+    ``hook`` exists for the seams: each passes its own module binding of ``call_match_hook``, so the seam
+    tests can intercept the route there.
+    """
+    token = MATCH_REJECTION_REASONS.set({})
+    try:
+        outcome = (
+            call_match_hook(feature_group, feature_name, options, data_access_collection)
+            if hook is None
+            else hook(feature_group, feature_name, options, data_access_collection)
+        )
+        value_rejection = outcome.error if isinstance(outcome.error, PropertyValueRejection) else None
+        matcher_error = outcome.error if value_rejection is None else None
+        if value_rejection is not None:
+            # Parity with the canonical seam: the class name owns the record and the reason is str(exc).
+            record_match_rejection(feature_group.get_class_name(), str(value_rejection))
+        recorded = MATCH_REJECTION_REASONS.get() or {}
+        # Harvest only on a non-match; the first recorded reason wins (insertion order).
+        rejection = next(iter(recorded.values())) if not outcome.matched and recorded else None
+        return CriteriaProbeOutcome(outcome.matched, outcome.returned, matcher_error, value_rejection, rejection)
+    finally:
+        MATCH_REJECTION_REASONS.reset(token)

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -13,7 +13,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.match_hook import call_match_hook
+from mloda.core.abstract_plugins.components.match_hook import call_match_hook, probe_match_criteria
 from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
@@ -36,7 +36,7 @@ class GlobalFilter:
            names and the uuid to the used single filter. This is used to track which features are associated with which filters for a specific feature group.
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
-        3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
+        3. `dropped_filters`: maps (feature group, filter feature name) to the reason a matcher defect or a typed decline dropped it.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
         5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once this setup.
 
@@ -237,22 +237,38 @@ class GlobalFilter:
     ) -> bool:
         """A raising match hook is a non-match for this filter only, mirroring the resolution seam (#845).
 
-        The drop is recorded in `dropped_filters` and kept as text, never an exception object whose traceback
-        would pin the plugin class. The level ignores the exception type, unlike the seam, because nothing else
-        surfaces the reason here. No option rollback: the hook sees a per-match deepcopy.
+        The shared probe owns the window and the containment; this seam keeps the filter policy: no option
+        rollback (the hook sees a per-match deepcopy) and a defect outranks a harvested decline.
 
         Mark-or-contain policy: see call_match_hook.
         """
-        outcome = call_match_hook(
-            feature_group, filter.filter_feature.name, filter.filter_feature.options, data_access_collection
+        probe = probe_match_criteria(
+            feature_group,
+            filter.filter_feature.name,
+            filter.filter_feature.options,
+            data_access_collection,
+            hook=call_match_hook,
         )
-        if outcome.error is not None:
-            reason = contained_raise_reason(outcome.error)
+        if probe.matcher_error is not None:
+            reason = contained_raise_reason(probe.matcher_error)
             self._record_dropped_filter(feature_group, str(filter.filter_feature.name), reason)
             return False
-        if not outcome.matched and not isinstance(outcome.returned, bool):
-            self._report_falsy_match(feature_group, str(filter.filter_feature.name), outcome.returned)
-        return outcome.matched
+        if probe.rejection is not None:
+            self._record_rejected_filter(feature_group, str(filter.filter_feature.name), probe.rejection.reason)
+            return False
+        if not probe.matched and not isinstance(probe.returned, bool):
+            self._report_falsy_match(feature_group, str(filter.filter_feature.name), probe.returned)
+        return probe.matched
+
+    def _record_rejected_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
+        """Record a typed decline in the same ledger at DEBUG: a deliberate rejection is a near-miss, not a defect."""
+        self.dropped_filters.setdefault((feature_group, filter_feature_name), reason)
+        logger.debug(
+            "%s rejected filter feature '%s': %s; dropping that filter for this feature group.",
+            feature_group.get_class_name(),
+            filter_feature_name,
+            reason,
+        )
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
         """Record the drop: WARNING on a key's first drop, DEBUG after, as the hook is probed per served feature."""

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -13,7 +13,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.match_hook import call_match_hook, probe_match_criteria
+from mloda.core.abstract_plugins.components.match_hook import probe_match_criteria
 from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
@@ -36,7 +36,7 @@ class GlobalFilter:
            names and the uuid to the used single filter. This is used to track which features are associated with which filters for a specific feature group.
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
-        3. `dropped_filters`: maps (feature group, filter feature name) to the reason a matcher defect or a typed decline dropped it.
+        3. `dropped_filters`: maps (feature group, filter feature name) to the reason a matcher defect or a typed decline dropped it; a defect's reason outranks a stored decline's.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
         5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once this setup.
 
@@ -51,6 +51,8 @@ class GlobalFilter:
         self._warned_divergences: set[str] = set()
         # Own state, not dropped_filters: a falsy non-bool is an ordinary non-match, never a recorded drop.
         self._reported_falsy_matches: set[tuple[type[FeatureGroup], str]] = set()
+        # WARNING dedupe for defect drops; the ledger itself no longer decides first-ness.
+        self._warned_drops: set[tuple[type[FeatureGroup], str]] = set()
 
     def reset_match_tracking(self) -> None:
         """Match and divergence-warning tracking is scoped to one engine setup."""
@@ -238,7 +240,10 @@ class GlobalFilter:
         """A raising match hook is a non-match for this filter only, mirroring the resolution seam (#845).
 
         The shared probe owns the window and the containment; this seam keeps the filter policy: no option
-        rollback (the hook sees a per-match deepcopy) and a defect outranks a harvested decline.
+        rollback (the hook sees a per-match deepcopy) and a defect outranks a harvested decline. A matcher
+        defect warns whatever its exception type, unlike the resolution seam, because nothing else surfaces
+        it here. A typed decline can flip an attachment verdict, since the default hook's owned-reader veto
+        gates under the probe's window.
 
         Mark-or-contain policy: see call_match_hook.
         """
@@ -247,17 +252,17 @@ class GlobalFilter:
             filter.filter_feature.name,
             filter.filter_feature.options,
             data_access_collection,
-            hook=call_match_hook,
         )
         if probe.matcher_error is not None:
             reason = contained_raise_reason(probe.matcher_error)
             self._record_dropped_filter(feature_group, str(filter.filter_feature.name), reason)
             return False
+        # value_rejection is excluded: its returned is the containment's synthetic None, not the hook's.
+        if probe.value_rejection is None and not probe.matched and not isinstance(probe.returned, bool):
+            self._report_falsy_match(feature_group, str(filter.filter_feature.name), probe.returned)
         if probe.rejection is not None:
             self._record_rejected_filter(feature_group, str(filter.filter_feature.name), probe.rejection.reason)
             return False
-        if not probe.matched and not isinstance(probe.returned, bool):
-            self._report_falsy_match(feature_group, str(filter.filter_feature.name), probe.returned)
         return probe.matched
 
     def _record_rejected_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
@@ -265,16 +270,19 @@ class GlobalFilter:
         self.dropped_filters.setdefault((feature_group, filter_feature_name), reason)
         logger.debug(
             "%s rejected filter feature '%s': %s; dropping that filter for this feature group.",
-            feature_group.get_class_name(),
+            # A plugin-owned read past the hook call's containment, so it degrades instead of escaping the seam.
+            safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
             filter_feature_name,
             reason,
         )
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
-        """Record the drop: WARNING on a key's first drop, DEBUG after, as the hook is probed per served feature."""
+        """Record the drop: defect drops warn once per key and take the key from a stored decline."""
         key = (feature_group, filter_feature_name)
-        first = key not in self.dropped_filters
-        self.dropped_filters.setdefault(key, reason)
+        first = key not in self._warned_drops
+        self._warned_drops.add(key)
+        if first:
+            self.dropped_filters[key] = reason
         logger.log(
             logging.WARNING if first else logging.DEBUG,
             "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -30,7 +30,7 @@ from mloda.core.abstract_plugins.components.match_rejection import (
     INPUT_DATA_STAGE,
     MatchRejection,
 )
-from mloda.core.abstract_plugins.components.match_hook import call_match_hook, probe_match_criteria
+from mloda.core.abstract_plugins.components.match_hook import probe_match_criteria
 from mloda.core.abstract_plugins.components.utils import (
     as_str,
     contained_raise_log_level,
@@ -602,9 +602,7 @@ class IdentifyFeatureGroupClass:
         # Shallow copies, taken per candidate so an earlier match's write survives a later candidate's raise.
         group_before = dict(feature.options.group)
         context_before = dict(feature.options.context)
-        probe = probe_match_criteria(
-            feature_group, feature.name, feature.options, data_access_collection, hook=call_match_hook
-        )
+        probe = probe_match_criteria(feature_group, feature.name, feature.options, data_access_collection)
         if probe.matcher_error is not None or probe.value_rejection is not None:
             # Only the contained branch rolls back: a matcher that returns True keeps its write,
             # which is how a matched reader is linked through mloda.

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -25,15 +25,12 @@ from mloda.core.prepare.resolution_failure_renderer import (
 )
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.domain import Domain
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.match_rejection import (
     INPUT_DATA_OWNED_STAGE,
     INPUT_DATA_STAGE,
-    MATCH_REJECTION_REASONS,
     MatchRejection,
-    record_match_rejection,
 )
-from mloda.core.abstract_plugins.components.match_hook import call_match_hook
+from mloda.core.abstract_plugins.components.match_hook import call_match_hook, probe_match_criteria
 from mloda.core.abstract_plugins.components.utils import (
     as_str,
     contained_raise_log_level,
@@ -596,54 +593,49 @@ class IdentifyFeatureGroupClass:
     ) -> bool:
         """A raise out of the match hook is a non-match for that candidate only, not a run-wide abort (#845).
 
-        A contained raise is kept as text, never as an exception object whose traceback would pin the plugin
-        class. The recording runs inside the per-candidate rejection window, reset in the finally, which keys
-        reasons by candidate class.
+        The shared probe owns the per-candidate window and the containment; this seam keeps only its own
+        policy: the option rollback on a contained raise and the per-candidate recording, never as an
+        exception object whose traceback would pin the plugin class.
 
         Mark-or-contain policy: see call_match_hook.
         """
-        token = MATCH_REJECTION_REASONS.set({})
         # Shallow copies, taken per candidate so an earlier match's write survives a later candidate's raise.
         group_before = dict(feature.options.group)
         context_before = dict(feature.options.context)
-        try:
-            outcome = call_match_hook(feature_group, feature.name, feature.options, data_access_collection)
-            exc = outcome.error
-            if exc is not None:
-                # Only the contained branch rolls back: a matcher that returns True keeps its write,
-                # which is how a matched reader is linked through mloda.
-                feature.options.group.clear()
-                feature.options.group.update(group_before)
-                feature.options.context.clear()
-                feature.options.context.update(context_before)
-                if isinstance(exc, PropertyValueRejection):
-                    # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
-                    logger.debug(
-                        "%s rejected an option value while matching '%s': %s",
-                        feature_group.get_class_name(),
-                        feature.name,
-                        safe_field(functools.partial(str, exc), type(exc).__name__),
-                    )
-                    record_match_rejection(feature_group.get_class_name(), str(exc))
-                else:
-                    reason = contained_raise_reason(exc)
-                    logger.log(
-                        contained_raise_log_level(exc),
-                        "%s %s while matching '%s'; treating it as a non-match.",
-                        feature_group.get_class_name(),
-                        reason,
-                        feature.name,
-                    )
-                    self._matcher_errors[feature_group] = reason
-            # Inside the try, where outcome is bound: only the reset belongs on a path the body never reached.
-            recorded = MATCH_REJECTION_REASONS.get() or {}
-            if not outcome.matched and recorded:
-                # Everything recorded during this candidate's window belongs to this candidate, whatever
-                # owner name an inner delegation stamped; first recorded reason wins (insertion order).
-                self._match_rejections[feature_group] = next(iter(recorded.values()))
-            return outcome.matched
-        finally:
-            MATCH_REJECTION_REASONS.reset(token)
+        probe = probe_match_criteria(
+            feature_group, feature.name, feature.options, data_access_collection, hook=call_match_hook
+        )
+        if probe.matcher_error is not None or probe.value_rejection is not None:
+            # Only the contained branch rolls back: a matcher that returns True keeps its write,
+            # which is how a matched reader is linked through mloda.
+            feature.options.group.clear()
+            feature.options.group.update(group_before)
+            feature.options.context.clear()
+            feature.options.context.update(context_before)
+        if probe.value_rejection is not None:
+            exc = probe.value_rejection
+            # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
+            logger.debug(
+                "%s rejected an option value while matching '%s': %s",
+                feature_group.get_class_name(),
+                feature.name,
+                safe_field(functools.partial(str, exc), type(exc).__name__),
+            )
+        elif probe.matcher_error is not None:
+            reason = contained_raise_reason(probe.matcher_error)
+            logger.log(
+                contained_raise_log_level(probe.matcher_error),
+                "%s %s while matching '%s'; treating it as a non-match.",
+                feature_group.get_class_name(),
+                reason,
+                feature.name,
+            )
+            self._matcher_errors[feature_group] = reason
+        if not probe.matched and probe.rejection is not None:
+            # Everything recorded during this candidate's window belongs to this candidate, whatever
+            # owner name an inner delegation stamped.
+            self._match_rejections[feature_group] = probe.rejection
+        return probe.matched
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         """Decision-side domain gate: unguarded, so a raising get_domain() still fails the engine loudly."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
@@ -19,18 +19,17 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components import match_hook as match_hook_module
 from mloda.core.abstract_plugins.components.match_hook import MatchHookOutcome, call_match_hook
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.filter import global_filter as global_filter_module
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.global_filter import GlobalFilter
-from mloda.core.prepare import identify_feature_group as identify_feature_group_module
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 
 
-# The name each seam must hold in its own namespace, so a spy can observe the one call it makes.
+# The probe's module binding of the helper: the one point where a spy can intercept the hook call.
 HELPER_NAME = "call_match_hook"
 
 PROBE_CLASS_NAME = "MatchHookProbeFG991"
@@ -380,13 +379,13 @@ class _Spy:
 
 
 def test_the_filter_seam_calls_the_helper_once_per_filter(monkeypatch: pytest.MonkeyPatch) -> None:
-    """identify_matched_filters asks the shared helper once per registered filter, and reaches the hook no other way."""
-    assert hasattr(global_filter_module, HELPER_NAME), (
-        f"{global_filter_module.__name__} must import {HELPER_NAME} into its own namespace and route the hook "
-        "call through it; nothing here can observe a call the seam makes itself."
+    """The filter seam routes through the probe, whose module binding is the interception point, once per filter."""
+    assert hasattr(match_hook_module, HELPER_NAME), (
+        f"{match_hook_module.__name__} must hold {HELPER_NAME}, the binding the probe routes the hook call "
+        "through; nothing here can observe a call the probe makes itself."
     )
     spy = _Spy()
-    monkeypatch.setattr(global_filter_module, HELPER_NAME, spy)
+    monkeypatch.setattr(match_hook_module, HELPER_NAME, spy)
     fg = _make_probe_fg(lambda: True)
     global_filter = GlobalFilter()
     global_filter.add_filter(FILTER_FEATURE_A, FilterType.EQUAL, {"value": 1})
@@ -410,13 +409,13 @@ def test_the_filter_seam_calls_the_helper_once_per_filter(monkeypatch: pytest.Mo
 
 
 def test_the_resolution_seam_calls_the_helper_once_per_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The resolution seam asks the same helper, once per candidate, and reaches the hook no other way."""
-    assert hasattr(identify_feature_group_module, HELPER_NAME), (
-        f"{identify_feature_group_module.__name__} must import {HELPER_NAME} into its own namespace and route "
-        "the hook call through it; nothing here can observe a call the seam makes itself."
+    """The resolution seam routes through the probe, whose module binding is the interception point, per candidate."""
+    assert hasattr(match_hook_module, HELPER_NAME), (
+        f"{match_hook_module.__name__} must hold {HELPER_NAME}, the binding the probe routes the hook call "
+        "through; nothing here can observe a call the probe makes itself."
     )
     spy = _Spy()
-    monkeypatch.setattr(identify_feature_group_module, HELPER_NAME, spy)
+    monkeypatch.setattr(match_hook_module, HELPER_NAME, spy)
     fg = _make_probe_fg(lambda: True)
     identifier = IdentifyFeatureGroupClass()
     verdict: Any = None

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_rejection.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_rejection.py
@@ -21,13 +21,12 @@ from typing import Any
 import pytest
 
 from mloda import provider
-from mloda.core.abstract_plugins.components import match_rejection
+from mloda.core.abstract_plugins.components import match_hook, match_rejection
 from mloda.core.abstract_plugins.components.feature_chainer import feature_chain_parser
 from mloda.core.abstract_plugins.components.match_rejection import (
     MATCH_REJECTION_REASONS,
     record_match_rejection,
 )
-from mloda.core.prepare import identify_feature_group
 from mloda.provider import record_match_rejection as provider_record_match_rejection
 
 
@@ -57,8 +56,8 @@ class TestNeutralModuleOwnsTheChannel:
         assert getattr(feature_chain_parser, "record_match_rejection") is match_rejection.record_match_rejection
 
     def test_the_engine_harvests_through_the_new_home(self) -> None:
-        """identify_feature_group uses the neutral module's contextvar object, so the harvest still works."""
-        assert getattr(identify_feature_group, "MATCH_REJECTION_REASONS") is match_rejection.MATCH_REJECTION_REASONS
+        """The shared probe both seams read uses the neutral module's contextvar object, so the harvest works."""
+        assert getattr(match_hook, "MATCH_REJECTION_REASONS") is match_rejection.MATCH_REJECTION_REASONS
 
 
 class TestRecording:

--- a/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
+++ b/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
@@ -45,6 +45,8 @@ RECORD_THEN_VALUE_CLASS_NAME = "RtxRecordThenValueRaiseFG728"
 STAGE_DECLINE_CLASS_NAME = "RtxStageDeclineFG728"
 RECORD_THEN_ERROR_CLASS_NAME = "RtxRecordThenErrorFG728"
 OWNED_VETO_CLASS_NAME = "RtxOwnedVetoFG728"
+FALSY_DECLINE_CLASS_NAME = "RtxFalsyDeclineFG728"
+DECLINE_THEN_DEFECT_CLASS_NAME = "RtxDeclineThenDefectFG728"
 
 VALUE_REJECT_MESSAGE = "rtx_value_rejected_728"
 REASON_A = "rtx_reason_a_728"
@@ -55,6 +57,14 @@ ESCALATE_MESSAGE = "rtx_escalated_728"
 OWNED_REASON = "rtx_owned_veto_reason_728"
 VALUE_REJECTION_STAGE = "value_rejection"
 VALUE_REJECTION_TYPE_NAME = "PropertyValueRejection"
+DEFECT_MESSAGE = "rtx_defect_after_decline_728"
+HOSTILE_STR_MESSAGE = "rtx_hostile_str_boom_728"
+MARKER_KEY = "rtx_marker_key_728"
+MARKER_VALUE = "rtx_marker_value_728"
+UNNAMEABLE_MESSAGE = "rtx_unnameable_boom_728"
+OUTER_OWNER = "rtx_outer_owner_728"
+OUTER_REASON = "rtx_outer_reason_728"
+FALSY_REPORT_FRAGMENT = "falsy non-bool"
 
 T = TypeVar("T")
 
@@ -319,6 +329,145 @@ def _make_plain_error_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
     return RtxPlainErrorFG728, _window_not_observed
 
 
+def _make_falsy_decline_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records a rejection for the filter feature and returns None."""
+    gc.collect()
+
+    class RtxFalsyDeclineFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> Any:  # Any, not bool: the falsy non-bool return beside the recorded decline is the case under test.
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, REASON_A)
+                return None
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxFalsyDeclineFG728, _window_not_observed
+
+
+def _make_decline_then_defect_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook declines with a recorded reason once, then raises on the next ask."""
+    gc.collect()
+
+    class RtxDeclineThenDefectFG728(FeatureGroup):
+        declined: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                if not cls.declined:
+                    cls.declined = True
+                    record_match_rejection(cls.__name__, REASON_A)
+                    return False
+                raise RuntimeError(DEFECT_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxDeclineThenDefectFG728, _window_not_observed
+
+
+class RtxHostileStrRejection728(PropertyValueRejection):
+    """A typed rejection whose reason text raises when read; __repr__ is fixed so snapshots stay safe."""
+
+    def __str__(self) -> str:
+        raise RuntimeError(HOSTILE_STR_MESSAGE)
+
+    def __repr__(self) -> str:
+        return "<RtxHostileStrRejection728>"
+
+
+def _make_marking_hostile_str_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook writes a marker option, then raises the unreadable rejection."""
+    gc.collect()
+
+    class RtxMarkingHostileStrFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                options.add_to_group(MARKER_KEY, MARKER_VALUE)
+                raise RtxHostileStrRejection728(VALUE_REJECT_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxMarkingHostileStrFG728, _window_not_observed
+
+
+def _make_unnameable_decline_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records a rejection and returns False, but cannot say what it is called."""
+    gc.collect()
+
+    class RtxUnnameableDeclineFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        # The @final on get_class_name is a mypy pin; a plugin can still install this override at runtime.
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            raise RuntimeError(UNNAMEABLE_MESSAGE)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, REASON_A)
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxUnnameableDeclineFG728, _window_not_observed
+
+
+def _make_plain_decline_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook returns a literal False for the filter feature, recording nothing."""
+    gc.collect()
+
+    class RtxPlainDeclineFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxPlainDeclineFG728, _window_not_observed
+
+
 @dataclass(frozen=True)
 class _RtxCriteriaSnapshot:
     """Plain-data readout of one criteria call. Holds no class and no exception object."""
@@ -333,15 +482,19 @@ class _RtxCriteriaSnapshot:
     window_active: bool
 
 
-def _drive_criteria(make: _RtxFactory, caplog: pytest.LogCaptureFixture) -> _RtxCriteriaSnapshot:
-    """Call criteria once on a fresh GlobalFilter; the finally unbinds every name that pins the class."""
+def _drive_criteria(make: _RtxFactory, caplog: pytest.LogCaptureFixture, calls: int = 1) -> _RtxCriteriaSnapshot:
+    """Call criteria `calls` times on ONE fresh GlobalFilter; the finally unbinds every name that pins the class."""
     caplog.clear()
     fg, read_window = make()
     global_filter = GlobalFilter()
     items: list[tuple[Any, Any]] = []
     try:
+        value: Any = None
+        escaped: str | None = None
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
-            value, escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+            for _ in range(calls):
+                value, call_escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+                escaped = escaped or call_escaped
         items = sorted(global_filter.dropped_filters.items(), key=lambda item: str(item[0]))
         return _RtxCriteriaSnapshot(
             is_false=value is False,
@@ -355,6 +508,57 @@ def _drive_criteria(make: _RtxFactory, caplog: pytest.LogCaptureFixture) -> _Rtx
         )
     finally:
         del fg, read_window, global_filter, items
+        gc.collect()
+
+
+@dataclass(frozen=True)
+class _RtxCountedSnapshot:
+    """Criteria readout as counts only: reading a ledger key back would call the hostile class name."""
+
+    is_false: bool
+    escaped: str | None
+    drops: int
+
+
+def _drive_criteria_counted(make: _RtxFactory) -> _RtxCountedSnapshot:
+    """Call criteria once, reading only len(dropped_filters); the finally unbinds every name pinning the class."""
+    fg, read_window = make()
+    global_filter = GlobalFilter()
+    try:
+        value, escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+        return _RtxCountedSnapshot(
+            is_false=value is False,
+            escaped=escaped,
+            drops=len(global_filter.dropped_filters),
+        )
+    finally:
+        del fg, read_window, global_filter
+        gc.collect()
+
+
+@dataclass(frozen=True)
+class _RtxResolutionSnapshot:
+    """Plain-data readout of one _filter_feature_group_by_criteria call. Holds no class."""
+
+    is_false: bool
+    escaped: str | None
+    option_keys: tuple[str, ...]
+
+
+def _drive_resolution(make: _RtxFactory) -> _RtxResolutionSnapshot:
+    """Call the resolution seam directly; the finally unbinds the identifier, which keys records by class."""
+    fg, read_window = make()
+    identifier = IdentifyFeatureGroupClass()
+    feature = Feature(FILTER_FEATURE)
+    try:
+        value, escaped = _capture(partial(identifier._filter_feature_group_by_criteria, fg, feature, None))
+        return _RtxResolutionSnapshot(
+            is_false=value is False,
+            escaped=escaped,
+            option_keys=tuple(sorted(str(key) for key in feature.options.keys())),
+        )
+    finally:
+        del fg, read_window, identifier, feature
         gc.collect()
 
 
@@ -540,6 +744,26 @@ class TestMatchAndEscalationLeaveNoDrop:
         assert entry_count == 0, f"a propagating abort is not a drop, got {entry_count} entries"
         assert window_active, "the seam must give the matcher an active rejection window"
 
+    def test_the_window_is_reset_after_the_abort_escapes(self) -> None:
+        """The probe's finally owns the reset, so even a propagating abort leaves no open window behind."""
+        marker = escalate_match_abort(PropertyValueRejection(ESCALATE_MESSAGE))
+        fg, read_window = _make_escalating_rejection_fg(marker)
+        global_filter = GlobalFilter()
+        caught: BaseException | None = None
+        try:
+            global_filter.criteria(fg, _single(FILTER_FEATURE), None)
+        except BaseException as exc:  # noqa: BLE001  (the escape itself is the fact under test)
+            caught = exc
+        is_marker = caught is marker
+        window_after_is_none = MATCH_REJECTION_REASONS.get() is None
+        # Drop the retained traceback: its frames pin the throwaway class through the hook's `cls`.
+        marker.__traceback__ = None
+        del fg, read_window, global_filter, caught
+        gc.collect()
+
+        assert is_marker, "the marked abort must escape criteria for the reset to be the fact under test"
+        assert window_after_is_none, "the probe must reset MATCH_REJECTION_REASONS even on the abort path"
+
 
 class TestOwnedVetoParity:
     """The default hook's owned-veto gate sees the filter seam's active window."""
@@ -655,3 +879,99 @@ class TestCriteriaProbeOutcome:
 
         assert snapshot.matched is False, "a declining matcher is a non-match"
         assert snapshot.window_after_is_none, "the probe must reset MATCH_REJECTION_REASONS on exit"
+
+
+class TestDeclineDefectAndReportCompose:
+    """A recorded decline must neither eat the falsy report nor shield its key from a later defect."""
+
+    def test_a_falsy_non_bool_decline_still_reports_the_detached_filter(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One hook call, two facts: the typed decline is recorded AND the falsy non-bool return still warns."""
+        snapshot = _drive_criteria(_make_falsy_decline_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a recorded decline with a falsy return is a non-match for that filter"
+        assert len(snapshot.warnings) == 1, (
+            f"the falsy non-bool report must survive the recorded decline, got: {snapshot.warnings}"
+        )
+        message = snapshot.warnings[0]
+        assert FALSY_REPORT_FRAGMENT in message, f"the warning must call the return a falsy non-bool: {message}"
+        assert FALSY_DECLINE_CLASS_NAME in message, f"the warning must name the feature group: {message}"
+        assert FILTER_FEATURE in message, f"the warning must name the filter feature: {message}"
+        assert snapshot.entries == ((FALSY_DECLINE_CLASS_NAME, FILTER_FEATURE),), (
+            f"the typed decline must still be recorded, got: {snapshot.entries}"
+        )
+        assert snapshot.reasons == (REASON_A,), f"the drop must hold the recorded reason, got: {snapshot.reasons}"
+        assert any(REASON_A in line for line in snapshot.debugs), (
+            f"the decline's DEBUG line must still be present, got: {snapshot.debugs}"
+        )
+
+    def test_a_defect_after_a_decline_still_warns_and_takes_the_ledger(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A later crash is worse news than the decline before it: it must own the key's reason and its WARNING."""
+        snapshot = _drive_criteria(_make_decline_then_defect_fg, caplog, calls=2)
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a raising hook is a non-match for that filter"
+        assert snapshot.entries == ((DECLINE_THEN_DEFECT_CLASS_NAME, FILTER_FEATURE),), (
+            f"exactly one entry for the key, got: {snapshot.entries}"
+        )
+        reason = snapshot.reasons[0]
+        assert RUNTIME_TYPE_NAME in reason, f"the defect must take the key's reason from the decline, got: {reason}"
+        assert DEFECT_MESSAGE in reason, f"the reason must carry the defect message: {reason}"
+        assert len(snapshot.warnings) == 1, (
+            f"the defect must warn even though the decline held the key first, got: {snapshot.warnings}"
+        )
+        assert DEFECT_MESSAGE in snapshot.warnings[0], (
+            f"the WARNING must carry the defect message: {snapshot.warnings[0]}"
+        )
+
+
+class TestHostilePluginReadsStayContained:
+    """A hostile plugin-owned read (a rejection's __str__, get_class_name) degrades instead of escaping a seam."""
+
+    def test_a_hostile_rejection_str_does_not_skip_the_resolution_rollback(self) -> None:
+        """The probe reads str(exc) unguarded today, escaping before the seam's option rollback runs."""
+        snapshot = _drive_resolution(_make_marking_hostile_str_fg)
+
+        assert snapshot.escaped is None, (
+            f"an unreadable rejection text must not cross the resolution seam: {snapshot.escaped}"
+        )
+        assert snapshot.is_false, "a value rejection is a non-match for that candidate"
+        assert MARKER_KEY not in snapshot.option_keys, (
+            f"the write must not survive the contained rejection, got: {snapshot.option_keys}"
+        )
+
+    def test_an_unnameable_group_still_gets_its_decline_recorded(self) -> None:
+        """The decline's DEBUG report reads get_class_name, a plugin-owned field that must degrade, not raise."""
+        snapshot = _drive_criteria_counted(_make_unnameable_decline_fg)
+
+        assert snapshot.escaped is None, f"reporting a decline must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a recorded decline is a non-match for that filter"
+        assert snapshot.drops == 1, f"the decline must still be recorded, got {snapshot.drops} entries"
+
+
+class TestAnOuterWindowSurvivesTheProbe:
+    """The probe stacks its own window: an outer recording is neither harvested nor lost."""
+
+    def test_an_outer_record_is_not_harvested_and_survives(self) -> None:
+        token = MATCH_REJECTION_REASONS.set({})
+        try:
+            record_match_rejection(OUTER_OWNER, OUTER_REASON)
+            fg, read_window = _make_plain_decline_fg()
+            global_filter = GlobalFilter()
+            try:
+                value, escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+                drops = len(global_filter.dropped_filters)
+                outer = MATCH_REJECTION_REASONS.get() or {}
+                outer_entries = tuple(sorted((owner, rejection.reason) for owner, rejection in outer.items()))
+            finally:
+                del fg, read_window, global_filter
+                gc.collect()
+        finally:
+            MATCH_REJECTION_REASONS.reset(token)
+
+        assert escaped is None, f"nothing may cross GlobalFilter.criteria: {escaped}"
+        assert value is False, "a plain decline is a non-match for that filter"
+        assert drops == 0, f"the outer record must not be harvested as this probe's rejection, got {drops} entries"
+        assert outer_entries == ((OUTER_OWNER, OUTER_REASON),), (
+            f"the outer window must still hold exactly its own record, got: {outer_entries}"
+        )

--- a/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
+++ b/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
@@ -1,0 +1,657 @@
+"""Issue #728: GlobalFilter.criteria shares the canonical criteria probe, so a PropertyValueRejection or a
+recorded match rejection becomes a typed DEBUG drop carrying the same reason text on both seams, while a plain
+matcher error keeps its WARNING. Probe classes live inside factory functions and are dropped before any assert
+runs, so a failing assert never pins a throwaway FeatureGroup and trips the no-leak fixture in tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, is_dataclass
+from functools import partial
+from typing import Any, ClassVar, TypeVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_OWNED_STAGE,
+    INPUT_DATA_STAGE,
+    MATCH_REJECTION_REASONS,
+    MatchRejection,
+    match_rejection_owners,
+    record_match_rejection,
+)
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_types import EvaluationResult
+from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, SingleFilter
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+GF_LOGGER_NAME = "mloda.core.filter.global_filter"
+
+HOST_FEATURE = "rtx_host_feat_728"  # the resolved feature the filters are matched against
+FILTER_FEATURE = "rtx_filter_feat_728"  # the declared filter feature every probe is asked about
+
+VALUE_REJECTION_CLASS_NAME = "RtxValueRejectionFG728"
+RECORDED_DECLINE_CLASS_NAME = "RtxRecordedDeclineFG728"
+RECORD_THEN_VALUE_CLASS_NAME = "RtxRecordThenValueRaiseFG728"
+STAGE_DECLINE_CLASS_NAME = "RtxStageDeclineFG728"
+RECORD_THEN_ERROR_CLASS_NAME = "RtxRecordThenErrorFG728"
+OWNED_VETO_CLASS_NAME = "RtxOwnedVetoFG728"
+
+VALUE_REJECT_MESSAGE = "rtx_value_rejected_728"
+REASON_A = "rtx_reason_a_728"
+REASON_B = "rtx_reason_b_728"
+RUNTIME_MESSAGE = "rtx_runtime_boom_728"
+RUNTIME_TYPE_NAME = "RuntimeError"
+ESCALATE_MESSAGE = "rtx_escalated_728"
+OWNED_REASON = "rtx_owned_veto_reason_728"
+VALUE_REJECTION_STAGE = "value_rejection"
+VALUE_REJECTION_TYPE_NAME = "PropertyValueRejection"
+
+T = TypeVar("T")
+
+# A factory handing back the throwaway class and a reader for its window observation, so no drive types the class.
+_RtxFactory = Callable[[], tuple[type[FeatureGroup], Callable[[], bool]]]
+
+
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (red-phase probe: an escape is the fact under test)
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _exception_text(exc: BaseException | None) -> str | None:
+    """Type and message of a contained exception, or None. Reads no traceback."""
+    return None if exc is None else f"{type(exc).__name__}: {exc}"
+
+
+def _single(filter_feature_name: str) -> SingleFilter:
+    """A minimal EQUAL filter on one feature name."""
+    return SingleFilter(filter_feature_name, FilterType.EQUAL, {"value": 1})
+
+
+def _messages(caplog: pytest.LogCaptureFixture, level: int) -> tuple[str, ...]:
+    """Formatted messages GlobalFilter logged at exactly that level."""
+    records = [record for record in caplog.records if record.name == GF_LOGGER_NAME and record.levelno == level]
+    return tuple(record.getMessage() for record in records)
+
+
+def _stage_reason(stage: str) -> str:
+    """The stage-specific reason text one stage-recording probe stores."""
+    return f"rtx_stage_reason_728_{stage}"
+
+
+def _window_not_observed() -> bool:
+    """Reader for probes that never record: their tests assert nothing about the window."""
+    return False
+
+
+def _make_value_rejection_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook raises PropertyValueRejection for the filter feature."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class RtxValueRejectionFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                raise PropertyValueRejection(VALUE_REJECT_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxValueRejectionFG728, _window_not_observed
+
+
+def _make_recorded_decline_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records a rejection for the filter feature and returns False."""
+    gc.collect()
+
+    class RtxRecordedDeclineFG728(FeatureGroup):
+        window_active: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, REASON_A)
+                cls.window_active = cls.__name__ in match_rejection_owners()
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxRecordedDeclineFG728, lambda: RtxRecordedDeclineFG728.window_active
+
+
+def _make_record_then_value_raise_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records reason A, then raises PropertyValueRejection(B)."""
+    gc.collect()
+
+    class RtxRecordThenValueRaiseFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, REASON_A)
+                raise PropertyValueRejection(REASON_B)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxRecordThenValueRaiseFG728, _window_not_observed
+
+
+def _make_stage_decline_fg(stage: str) -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records with the caller's stage for the filter feature and returns False."""
+    gc.collect()
+
+    class RtxStageDeclineFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, _stage_reason(stage), stage=stage)
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxStageDeclineFG728, _window_not_observed
+
+
+def _make_record_then_error_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records reason A, then raises a plain RuntimeError."""
+    gc.collect()
+
+    class RtxRecordThenErrorFG728(FeatureGroup):
+        window_active: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, REASON_A)
+                cls.window_active = cls.__name__ in match_rejection_owners()
+                raise RuntimeError(RUNTIME_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxRecordThenErrorFG728, lambda: RtxRecordThenErrorFG728.window_active
+
+
+def _make_owned_veto_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group supporting the filter name whose hook records an owned veto, then defers to super."""
+    gc.collect()
+
+    class RtxOwnedVetoFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            record_match_rejection(cls.__name__, OWNED_REASON, stage=INPUT_DATA_OWNED_STAGE)
+            return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+    return RtxOwnedVetoFG728, _window_not_observed
+
+
+def _make_record_but_match_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records a rejection for the filter feature and still returns True."""
+    gc.collect()
+
+    class RtxRecordButMatchFG728(FeatureGroup):
+        window_active: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, REASON_A)
+                cls.window_active = cls.__name__ in match_rejection_owners()
+                return True
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxRecordButMatchFG728, lambda: RtxRecordButMatchFG728.window_active
+
+
+def _make_escalating_rejection_fg(marker: BaseException) -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook records reason A, then raises the caller's own marked exception object."""
+    gc.collect()
+
+    class RtxEscalatingRejectionFG728(FeatureGroup):
+        window_active: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            record_match_rejection(cls.__name__, REASON_A)
+            cls.window_active = cls.__name__ in match_rejection_owners()
+            raise marker
+
+    return RtxEscalatingRejectionFG728, lambda: RtxEscalatingRejectionFG728.window_active
+
+
+def _make_plain_error_fg() -> tuple[type[FeatureGroup], Callable[[], bool]]:
+    """A throwaway group whose hook raises a plain RuntimeError for the filter feature, recording nothing."""
+    gc.collect()
+
+    class RtxPlainErrorFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                raise RuntimeError(RUNTIME_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RtxPlainErrorFG728, _window_not_observed
+
+
+@dataclass(frozen=True)
+class _RtxCriteriaSnapshot:
+    """Plain-data readout of one criteria call. Holds no class and no exception object."""
+
+    is_false: bool
+    is_true: bool
+    escaped: str | None
+    entries: tuple[tuple[str, str], ...]  # (feature group class name, filter feature name), sorted
+    reasons: tuple[str, ...]  # reason text per entry, aligned with entries
+    warnings: tuple[str, ...]
+    debugs: tuple[str, ...]
+    window_active: bool
+
+
+def _drive_criteria(make: _RtxFactory, caplog: pytest.LogCaptureFixture) -> _RtxCriteriaSnapshot:
+    """Call criteria once on a fresh GlobalFilter; the finally unbinds every name that pins the class."""
+    caplog.clear()
+    fg, read_window = make()
+    global_filter = GlobalFilter()
+    items: list[tuple[Any, Any]] = []
+    try:
+        with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
+            value, escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+        items = sorted(global_filter.dropped_filters.items(), key=lambda item: str(item[0]))
+        return _RtxCriteriaSnapshot(
+            is_false=value is False,
+            is_true=value is True,
+            escaped=escaped,
+            entries=tuple((str(key[0].get_class_name()), str(key[1])) for key, _ in items),
+            reasons=tuple(str(reason) for _, reason in items),
+            warnings=_messages(caplog, logging.WARNING),
+            debugs=_messages(caplog, logging.DEBUG),
+            window_active=read_window(),
+        )
+    finally:
+        del fg, read_window, global_filter, items
+        gc.collect()
+
+
+@dataclass(frozen=True)
+class _CanonicalSnapshot:
+    """Plain-data readout of one evaluate() pass. Holds no class and no Elimination object."""
+
+    escaped: str | None
+    identified: tuple[str, ...]
+    eliminations: tuple[tuple[str, str, str], ...]
+
+
+def _canonical_snapshot(result: EvaluationResult | None, escaped: str | None) -> _CanonicalSnapshot:
+    """Fold one evaluate() outcome to plain data."""
+    if result is None:
+        return _CanonicalSnapshot(escaped=escaped, identified=(), eliminations=())
+    return _CanonicalSnapshot(
+        escaped=escaped,
+        identified=tuple(sorted(g.get_class_name() for g in result.identified)),
+        eliminations=tuple(
+            sorted((g.get_class_name(), str(e.stage), str(e.reason)) for g, e in result.eliminations.items())
+        ),
+    )
+
+
+def _drive_canonical(make: _RtxFactory) -> _CanonicalSnapshot:
+    """Evaluate the filter feature against the probe alone and fold the eliminations to plain tuples."""
+    fg, read_window = make()
+    plugins: FeatureGroupEnvironmentMapping = {fg: {PythonDictFramework}}
+    result = None
+    try:
+        result, escaped = _capture(partial(IdentifyFeatureGroupClass.evaluate, Feature(FILTER_FEATURE), plugins, None))
+        snapshot = _canonical_snapshot(result, escaped)
+        del result
+        result = None
+        return snapshot
+    finally:
+        del fg, read_window, plugins, result
+        gc.collect()
+
+
+class TestValueRejectionIsATypedDrop:
+    """A PropertyValueRejection out of the matcher is a typed verdict drop, not a contained defect."""
+
+    def test_criteria_contains_it_and_stores_exactly_the_rejection_text(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The drop holds str(exc) itself, not the 'raised PropertyValueRejection: ...' defect wrapper."""
+        snapshot = _drive_criteria(_make_value_rejection_fg, caplog)
+
+        assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a rejected value is a non-match for that filter"
+        assert snapshot.entries == ((VALUE_REJECTION_CLASS_NAME, FILTER_FEATURE),), (
+            f"exactly one drop, keyed by group and filter feature, got: {snapshot.entries}"
+        )
+        assert snapshot.reasons == (VALUE_REJECT_MESSAGE,), (
+            f"the drop must hold exactly str(exc), no 'raised' prefix, got: {snapshot.reasons}"
+        )
+
+    def test_the_drop_logs_debug_and_never_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A value rejection is the candidate's verdict, so it reports at DEBUG like the resolution seam."""
+        snapshot = _drive_criteria(_make_value_rejection_fg, caplog)
+
+        assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.warnings == (), f"a value rejection is a verdict, not a defect, got: {snapshot.warnings}"
+        assert len(snapshot.debugs) == 1, f"the drop must still be visible at DEBUG, got: {snapshot.debugs}"
+
+    def test_the_canonical_seam_reports_the_same_reason(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Reason parity: one raise message, one reason text, on both seams."""
+        filter_side = _drive_criteria(_make_value_rejection_fg, caplog)
+        canonical = _drive_canonical(_make_value_rejection_fg)
+
+        assert canonical.escaped is None, f"nothing may cross evaluate: {canonical.escaped}"
+        assert canonical.identified == (), f"a rejected value must win nothing, got: {canonical.identified}"
+        assert len(canonical.eliminations) == 1, f"exactly one elimination, got: {canonical.eliminations}"
+        name, stage, reason = canonical.eliminations[0]
+        assert name == VALUE_REJECTION_CLASS_NAME, f"the elimination must name the candidate, got: {name}"
+        assert stage == VALUE_REJECTION_STAGE, f"a value rejection owns the stage, got: {stage}"
+        assert filter_side.reasons == (reason,), (
+            f"both seams must store one reason text for one raise, got {filter_side.reasons} vs {reason!r}"
+        )
+
+
+class TestRecordedRejectionIsATypedDrop:
+    """A rejection recorded through the shared window lands in dropped_filters as its own reason."""
+
+    def test_a_recorded_decline_lands_in_dropped_filters(self, caplog: pytest.LogCaptureFixture) -> None:
+        """record_match_rejection plus a False return is a typed drop, reported at DEBUG."""
+        snapshot = _drive_criteria(_make_recorded_decline_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a recorded decline is a non-match for that filter"
+        assert snapshot.entries == ((RECORDED_DECLINE_CLASS_NAME, FILTER_FEATURE),), (
+            f"a recorded decline is a typed drop, got: {snapshot.entries}"
+        )
+        assert snapshot.reasons == (REASON_A,), f"the drop must hold the recorded reason, got: {snapshot.reasons}"
+        assert snapshot.warnings == (), f"a recorded decline is a verdict, not a defect, got: {snapshot.warnings}"
+        assert len(snapshot.debugs) == 1, f"the drop must still be visible at DEBUG, got: {snapshot.debugs}"
+
+    @pytest.mark.parametrize("stage", [INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE])
+    def test_both_input_data_stages_flow_through(self, stage: str, caplog: pytest.LogCaptureFixture) -> None:
+        """A rejection recorded under either input-data stage still surfaces as a typed drop."""
+        snapshot = _drive_criteria(partial(_make_stage_decline_fg, stage), caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a recorded decline is a non-match for that filter"
+        assert snapshot.entries == ((STAGE_DECLINE_CLASS_NAME, FILTER_FEATURE),), (
+            f"a stage-recorded decline is a typed drop, got: {snapshot.entries}"
+        )
+        assert snapshot.reasons == (_stage_reason(stage),), (
+            f"the drop must hold the stage-recorded reason, got: {snapshot.reasons}"
+        )
+
+
+class TestHarvestPrecedence:
+    """The first recorded reason wins over a later value rejection; a matcher error outranks both."""
+
+    def test_the_first_recorded_reason_outranks_a_later_value_rejection(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_criteria(_make_record_then_value_raise_fg, caplog)
+
+        assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "the rejection is still a non-match for that filter"
+        assert snapshot.entries == ((RECORD_THEN_VALUE_CLASS_NAME, FILTER_FEATURE),), (
+            f"exactly one drop, keyed by group and filter feature, got: {snapshot.entries}"
+        )
+        assert snapshot.reasons == (REASON_A,), (
+            f"the FIRST recorded reason wins the drop, not the raise and not a wrapper, got: {snapshot.reasons}"
+        )
+
+    def test_a_matcher_error_outranks_the_recorded_reason_and_still_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A plain raise is the candidate's own defect: contained-raise text, WARNING policy unchanged."""
+        snapshot = _drive_criteria(_make_record_then_error_fg, caplog)
+
+        assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "a raising hook is a non-match for that filter"
+        assert snapshot.window_active, "the seam must give the matcher an active rejection window"
+        assert snapshot.entries == ((RECORD_THEN_ERROR_CLASS_NAME, FILTER_FEATURE),), (
+            f"exactly one drop, keyed by group and filter feature, got: {snapshot.entries}"
+        )
+        reason = snapshot.reasons[0]
+        assert RUNTIME_TYPE_NAME in reason, f"the reason must name the exception type: {reason}"
+        assert RUNTIME_MESSAGE in reason, f"the reason must carry the raise message: {reason}"
+        assert REASON_A not in reason, f"the contained raise outranks the recorded reason: {reason}"
+        assert len(snapshot.warnings) == 1, f"a matcher defect must still warn once, got: {snapshot.warnings}"
+
+
+class TestMatchAndEscalationLeaveNoDrop:
+    """A match and a marked abort both leave the ledger empty, recorded rejection or not."""
+
+    def test_a_recording_matcher_that_matches_attaches_without_a_drop(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Harvest only on non-match: a recorded reason must not detach a filter the matcher accepted."""
+        snapshot = _drive_criteria(_make_record_but_match_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.window_active, "the seam must give the matcher an active rejection window"
+        assert snapshot.is_true, "a True return is a match, whatever was recorded before it"
+        assert snapshot.entries == (), f"a match is never a drop, got: {snapshot.entries}"
+        assert snapshot.warnings == (), f"a match must not warn, got: {snapshot.warnings}"
+
+    def test_an_escalated_value_rejection_still_escapes_and_records_no_drop(self) -> None:
+        """An escalate_match_abort-marked raise crosses the seam as the SAME object and is not a drop."""
+        marker = escalate_match_abort(PropertyValueRejection(ESCALATE_MESSAGE))
+        fg, read_window = _make_escalating_rejection_fg(marker)
+        global_filter = GlobalFilter()
+        caught: BaseException | None = None
+        try:
+            global_filter.criteria(fg, _single(FILTER_FEATURE), None)
+        except BaseException as exc:  # noqa: BLE001  (the escape itself is the fact under test)
+            caught = exc
+        is_marker = caught is marker
+        type_name = None if caught is None else type(caught).__name__
+        message = None if caught is None else str(caught)
+        entry_count = len(global_filter.dropped_filters)
+        window_active = read_window()
+        # Drop the retained traceback: its frames pin the throwaway class through the hook's `cls`.
+        marker.__traceback__ = None
+        del fg, read_window, global_filter, caught
+        gc.collect()
+
+        assert is_marker, f"the marked exception itself must escape, got: {type_name}: {message}"
+        assert type_name == VALUE_REJECTION_TYPE_NAME
+        assert message == ESCALATE_MESSAGE
+        assert entry_count == 0, f"a propagating abort is not a drop, got {entry_count} entries"
+        assert window_active, "the seam must give the matcher an active rejection window"
+
+
+class TestOwnedVetoParity:
+    """The default hook's owned-veto gate sees the filter seam's active window."""
+
+    def test_the_default_hooks_owned_veto_gate_sees_the_filter_seams_window(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An owned-stage recording before super() must veto a name the group otherwise supports."""
+        snapshot = _drive_criteria(_make_owned_veto_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.is_false, "the owned veto must gate the default hook's name rules"
+        assert snapshot.entries == ((OWNED_VETO_CLASS_NAME, FILTER_FEATURE),), (
+            f"the veto is a typed drop, keyed by group and filter feature, got: {snapshot.entries}"
+        )
+        assert snapshot.reasons == (OWNED_REASON,), f"the drop must hold the veto's reason, got: {snapshot.reasons}"
+        assert snapshot.warnings == (), f"an owned veto is a verdict, not a defect, got: {snapshot.warnings}"
+
+
+@dataclass(frozen=True)
+class _ProbeSnapshot:
+    """Plain-data readout of one probe_match_criteria call. Holds no class and no exception object."""
+
+    matched: bool
+    matcher_error: str | None  # 'Type: message' of the contained plain raise, or None
+    value_rejection: str | None  # 'Type: message' of the contained PropertyValueRejection, or None
+    has_rejection: bool  # outcome.rejection is a MatchRejection
+    rejection_reason: str | None
+    rejection_stage: str | None
+    window_after_is_none: bool
+
+
+def _drive_probe(make: _RtxFactory) -> _ProbeSnapshot:
+    """Probe one throwaway matcher; the import lives here so a missing probe fails only these tests."""
+    from mloda.core.abstract_plugins.components.match_hook import probe_match_criteria
+
+    fg, read_window = make()
+    try:
+        outcome = probe_match_criteria(fg, FILTER_FEATURE, Options(), None)
+        snapshot = _ProbeSnapshot(
+            matched=outcome.matched,
+            matcher_error=_exception_text(outcome.matcher_error),
+            value_rejection=_exception_text(outcome.value_rejection),
+            has_rejection=isinstance(outcome.rejection, MatchRejection),
+            rejection_reason=None if outcome.rejection is None else str(outcome.rejection.reason),
+            rejection_stage=None if outcome.rejection is None else str(outcome.rejection.stage),
+            window_after_is_none=MATCH_REJECTION_REASONS.get() is None,
+        )
+        del outcome
+        return snapshot
+    finally:
+        del fg, read_window
+        gc.collect()
+
+
+class TestCriteriaProbeOutcome:
+    """The shared probe as a unit: one call, one structured outcome, window reset on exit."""
+
+    def test_the_shared_probe_api_exists(self) -> None:
+        """Both seams will import the probe and its frozen outcome type from match_hook."""
+        from mloda.core.abstract_plugins.components.match_hook import CriteriaProbeOutcome, probe_match_criteria
+
+        assert callable(probe_match_criteria), "probe_match_criteria must be the shared callable probe"
+        assert is_dataclass(CriteriaProbeOutcome), "CriteriaProbeOutcome must be a dataclass"
+
+    def test_a_plain_matcher_error_is_probed_as_matcher_error(self) -> None:
+        """A plain raise with no recording: matcher_error set, no value rejection, no match."""
+        snapshot = _drive_probe(_make_plain_error_fg)
+
+        assert snapshot.matched is False, "a raising matcher is a non-match"
+        assert snapshot.value_rejection is None, f"a plain raise is no value rejection: {snapshot.value_rejection}"
+        assert snapshot.matcher_error == f"{RUNTIME_TYPE_NAME}: {RUNTIME_MESSAGE}", (
+            f"the contained raise must come back as matcher_error, got: {snapshot.matcher_error}"
+        )
+
+    def test_a_value_rejection_is_probed_with_a_harvested_rejection(self) -> None:
+        """A PropertyValueRejection raise: value_rejection set and harvested as a MatchRejection."""
+        snapshot = _drive_probe(_make_value_rejection_fg)
+
+        assert snapshot.matched is False, "a rejecting matcher is a non-match"
+        assert snapshot.matcher_error is None, f"a value rejection is no matcher defect: {snapshot.matcher_error}"
+        assert snapshot.value_rejection == f"{VALUE_REJECTION_TYPE_NAME}: {VALUE_REJECT_MESSAGE}", (
+            f"the contained rejection must come back as value_rejection, got: {snapshot.value_rejection}"
+        )
+        assert snapshot.has_rejection, "the raise must be harvested into outcome.rejection"
+        assert snapshot.rejection_reason == VALUE_REJECT_MESSAGE, (
+            f"the harvested reason must be str(exc), got: {snapshot.rejection_reason}"
+        )
+        assert snapshot.rejection_stage == VALUE_REJECTION_STAGE, (
+            f"a value rejection owns the harvested stage, got: {snapshot.rejection_stage}"
+        )
+
+    def test_an_owned_stage_recording_keeps_its_stage(self) -> None:
+        snapshot = _drive_probe(partial(_make_stage_decline_fg, INPUT_DATA_OWNED_STAGE))
+
+        assert snapshot.matched is False, "a declining matcher is a non-match"
+        assert snapshot.has_rejection, "the recorded rejection must be harvested on a non-match"
+        assert snapshot.rejection_stage == INPUT_DATA_OWNED_STAGE, (
+            f"the recorded stage must survive the harvest, got: {snapshot.rejection_stage}"
+        )
+
+    def test_a_recording_match_harvests_nothing(self) -> None:
+        """Harvest only on non-match: a matching probe hands back no rejection."""
+        snapshot = _drive_probe(_make_record_but_match_fg)
+
+        assert snapshot.matched is True, "a True return is a match"
+        assert not snapshot.has_rejection, f"a match harvests nothing, got: {snapshot.rejection_reason}"
+        assert snapshot.rejection_reason is None
+        assert snapshot.rejection_stage is None
+
+    def test_the_window_is_reset_after_the_probe(self) -> None:
+        snapshot = _drive_probe(_make_recorded_decline_fg)
+
+        assert snapshot.matched is False, "a declining matcher is a non-match"
+        assert snapshot.window_after_is_none, "the probe must reset MATCH_REJECTION_REASONS on exit"

--- a/tests/test_core/test_prepare/test_match_hook_call_site.py
+++ b/tests/test_core/test_prepare/test_match_hook_call_site.py
@@ -32,7 +32,7 @@ FILTER_SEAM = ("mloda/core/filter/global_filter.py", "criteria")
 RESOLUTION_SEAM = ("mloda/core/prepare/identify_feature_group.py", "_filter_feature_group_by_criteria")
 SEAMS = (FILTER_SEAM, RESOLUTION_SEAM)
 
-# The context var whose per-candidate window the resolution seam opens, and resets in its finally.
+# The context var whose per-candidate window the shared probe opens, and resets in its finally.
 CONTEXT_VAR = "MATCH_REJECTION_REASONS"
 
 SUPPRESS = "suppress"
@@ -230,9 +230,9 @@ def test_neither_seam_drops_an_exception_without_an_except(module: str, function
     )
 
 
-def test_the_resolution_seam_keeps_only_the_context_var_reset_in_its_finally() -> None:
+def test_the_probe_keeps_only_the_context_var_reset_in_its_finally() -> None:
     """``outcome`` is bound only where nothing raised, so every read of it belongs inside the same try."""
-    module, function = RESOLUTION_SEAM
+    module, function = HELPER_MODULE, "probe_match_criteria"
     definition = _definition(module, function)
     blocks = [node for node in ast.walk(definition) if isinstance(node, ast.Try) and node.finalbody]
 


### PR DESCRIPTION
## What

`GlobalFilter.criteria` duplicated the canonical criteria gate containment and truthiness handling and drifted where the resolution seam grew its rejection taxonomy (#728): a `PropertyValueRejection` raised by `match_feature_group_criteria` landed in `dropped_filters` as a generic contained-raise string at WARNING, hook-recorded declines were invisible, and the rejection window was never opened on the filter path.

`probe_match_criteria` in `match_hook.py` now owns the per-probe rejection window and the containment classification for both seams. Each seam keeps only its policy:

- Resolution seam: option rollback on a contained raise, per-candidate `_matcher_errors` and `_match_rejections` recording. No observable change.
- Filter seam: enrichment on a per-match deepcopy (unchanged); matcher defects keep the warn-once drop and now take a ledger key even when a decline already holds it; typed declines (a raised `PropertyValueRejection` or a hook-recorded rejection, both input_data stages included) record in `dropped_filters` with the taxonomy reason text at DEBUG; the falsy non-bool report is unchanged and survives a recorded decline.

Because the window is now active during filter probes, the default hook owned-reader veto gates filter attachment the same way it gates resolution, and hook-internal recordings no longer leak into any outer window.

## Robustness

The probe degrades an unreadable rejection text or group name via `safe_field` instead of aborting setup, which also keeps the resolution seam rollback reachable behind a hostile `__str__`.

## Tests

New pinning suite `tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py`: typed drops with reason parity against the canonical elimination, first-recorded-wins harvesting, both input_data stages, defect precedence, owned-veto gating, hostile plugin reads, abort escalation, window reset and outer-window isolation, probe outcome pins. The window-shape structural pin moved with the window to the probe. Full tox green.