### PR TITLE
test: anchor the documentation tests to the repo root

### DIFF
--- a/tests/test_documentation/test_documentation.py
+++ b/tests/test_documentation/test_documentation.py
@@ -14,6 +14,30 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Anchored to this file, not to the cwd: a relative "docs" glob run from
+# anywhere but the repo root yields nothing, and these tests then pass while
+# checking zero files (issue #937).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+
+
+def _markdown_files(root: Path) -> list[Path]:
+    """Every markdown file under ``root``, never an empty list.
+
+    Two ``parametrize`` calls consume this at import time, where an empty list
+    silently collapses to zero test cases instead of failing. Raising here
+    turns that into a collection error naming the directory we looked in.
+    """
+    files = sorted(root.rglob("*.md"))
+    if not files:
+        raise RuntimeError(f"no markdown files found under {root} - the documentation tests would check nothing")
+    return files
+
+
+def _doc_id(fpath: Path) -> str:
+    """Repo-relative test id, so ids do not carry an absolute machine path."""
+    return fpath.relative_to(REPO_ROOT).as_posix()
+
 
 # We need this to test DokuExtender
 class DokuExtender(Extender):
@@ -82,14 +106,14 @@ def run_md_file_isolated(fpath: Path) -> None:
 
 @pytest.mark.timeout(120)
 def test_files_good() -> None:
-    run_md_files_isolated(sorted(Path("docs").glob("**/*.md")))
+    run_md_files_isolated(_markdown_files(DOCS_DIR))
 
 
 CODE_BLOCK_PATTERN = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
 TEST_IMPORT_PATTERN = re.compile(r"^\s*from\s+tests\..*$", re.MULTILINE)
 
 
-@pytest.mark.parametrize("fpath", sorted(Path("docs/docs").rglob("*.md")), ids=str)
+@pytest.mark.parametrize("fpath", _markdown_files(DOCS_DIR / "docs"), ids=_doc_id)
 def test_no_test_imports_in_docs(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     violations = []
@@ -114,7 +138,7 @@ def test_test_imports_in_illustrative_blocks_are_scanned() -> None:
     )
 
 
-DOCS_ROOT = Path("docs/docs")
+DOCS_ROOT = DOCS_DIR / "docs"
 ABSOLUTE_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(https://mloda-ai\.github\.io/mloda/[^)]*\)")
 MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
 HEADING_PATTERN = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
@@ -132,14 +156,14 @@ def _extract_headings(md_path: Path) -> set[str]:
     return {_heading_to_anchor(m.group(1)) for m in HEADING_PATTERN.finditer(text)}
 
 
-@pytest.mark.parametrize("fpath", sorted(DOCS_ROOT.rglob("*.md")), ids=str)
+@pytest.mark.parametrize("fpath", _markdown_files(DOCS_ROOT), ids=_doc_id)
 def test_no_absolute_site_links(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     matches = ABSOLUTE_LINK_PATTERN.findall(text)
     assert not matches, f"{fpath} contains absolute mloda-ai.github.io links (should be relative): {matches}"
 
 
-@pytest.mark.parametrize("fpath", sorted(DOCS_ROOT.rglob("*.md")), ids=str)
+@pytest.mark.parametrize("fpath", _markdown_files(DOCS_ROOT), ids=_doc_id)
 def test_internal_link_targets_exist(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     errors: list[str] = []

--- a/tests/test_documentation/test_mkdocs_config.py
+++ b/tests/test_documentation/test_mkdocs_config.py
@@ -6,7 +6,11 @@ from typing import Any
 import yaml
 
 
-MKDOCS_YML = Path("docs/mkdocs.yml")
+# Anchored to this file, not to the cwd. Run from anywhere but the repo root, a
+# relative path here died with a bare FileNotFoundError that named the symptom
+# rather than the cause (issue #937).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MKDOCS_YML = REPO_ROOT / "docs" / "mkdocs.yml"
 
 
 def _load_mkdocs_config() -> dict[str, Any]:

--- a/tests/test_documentation/test_near_miss_labels_in_docs.py
+++ b/tests/test_documentation/test_near_miss_labels_in_docs.py
@@ -17,8 +17,24 @@ from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, render
 from mloda.core.prepare.resolution_types import Elimination, EliminationStage, EvaluationResult
 
 
-DOCS_ROOT = Path("docs/docs")
+# Anchored to this file, not to the cwd: a relative glob run from anywhere but
+# the repo root yields nothing and these guards pass vacuously (issue #937).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "docs" / "docs"
 FENCE_PATTERN = re.compile(r"^\s*```")
+
+
+def _docs_pages() -> list[Path]:
+    """Every published page, never an empty list.
+
+    ``parametrize`` runs at import time, where an empty list collapses to zero
+    cases instead of failing, so an empty glob must raise rather than return.
+    """
+    pages = sorted(DOCS_ROOT.rglob("*.md"))
+    if not pages:
+        raise RuntimeError(f"no documentation pages found under {DOCS_ROOT} - this guard would check nothing")
+    return pages
+
 
 # Derived, never restated: a renamed label moves this set with it, and a label no page quotes costs nothing.
 ALLOWED_LABELS: frozenset[str] = frozenset(_STAGE_LABELS.values())
@@ -52,7 +68,7 @@ def _near_miss_bullets(text: str) -> Iterator[tuple[int, re.Match[str]]]:
             yield number, match
 
 
-@pytest.mark.parametrize("fpath", sorted(DOCS_ROOT.rglob("*.md")), ids=str)
+@pytest.mark.parametrize("fpath", _docs_pages(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
 def test_rendered_near_miss_bullets_carry_a_current_stage_label(fpath: Path) -> None:
     """Every label a page reproduces in a near-miss bullet is still a value of ``_STAGE_LABELS``."""
     stale = [

--- a/tests/test_plugins/test_pattern_consistency.py
+++ b/tests/test_plugins/test_pattern_consistency.py
@@ -10,12 +10,22 @@ import pathlib
 import re
 
 
-PLUGIN_DIR = pathlib.Path("mloda_plugins/feature_group/experimental")
+# Anchored to this file, not to the cwd: a relative glob run from anywhere but
+# the repo root yields nothing and both scans below pass vacuously (issue #937).
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "mloda_plugins" / "feature_group" / "experimental"
 
 
 def _collect_python_files() -> list[pathlib.Path]:
-    """Collect all Python files under the experimental plugins directory."""
-    return sorted(PLUGIN_DIR.rglob("*.py"))
+    """Collect all Python files under the experimental plugins directory.
+
+    Never returns an empty list: scanning nothing would let both guards pass
+    while reading no plugin at all.
+    """
+    files = sorted(PLUGIN_DIR.rglob("*.py"))
+    if not files:
+        raise RuntimeError(f"no plugin modules found under {PLUGIN_DIR} - these scans would check nothing")
+    return files
 
 
 class TestNoPatternAttribute:


### PR DESCRIPTION
Closes #937.

## Reproduced

```
$ cd tests && pytest test_documentation/test_documentation.py
2 passed, 3 skipped
```

Green while reading zero files. `Path("docs/docs").rglob("*.md")` is evaluated at import time by `parametrize`, so an empty glob collapses to zero cases instead of failing, and `test_files_good` checked zero markdown files. `test_mkdocs_config.py` failed there, but with a bare `FileNotFoundError` that named the symptom rather than the cause (5 failures).

`tox` always runs from the repo root, so the gate itself was never affected — this bites during local iteration, which is exactly when a green run is most trusted.

## Change

Each module derives `REPO_ROOT = Path(__file__).resolve().parents[2]` and builds its paths from it. Every glob feeding a `parametrize` or a whole-tree scan goes through a helper that **raises** on an empty result, naming the directory it looked in:

```
RuntimeError: no markdown files found under <...>/docs - the documentation tests would check nothing
```

Raising (rather than asserting inside a test) is deliberate: at import time an empty list produces zero cases, so there is no test left to carry the assertion. A collection error is the loud failure.

Applied to all four modules the issue names, plus a fifth:

| module | was |
|---|---|
| `test_documentation.py` | `Path("docs")`, `Path("docs/docs")` ×3, `DOCS_ROOT` |
| `test_mkdocs_config.py` | `Path("docs/mkdocs.yml")` |
| `test_pattern_consistency.py` | `Path("mloda_plugins/feature_group/experimental")` |
| **`test_near_miss_labels_in_docs.py`** | `Path("docs/docs")` — same package, same pattern, not in the issue's list but the same bug |

`grep -rEn 'Path\("[a-z_]+/' tests/` is now empty.

## One behaviour change worth flagging

Parametrize ids move from `ids=str` to a repo-relative posix path. Without that, anchoring would have put an absolute machine path in every id. The new ids are byte-identical to today's on Linux CI (`docs/docs/foo.md`) and, as a bonus, no longer differ on Windows (`docs\docs\foo.md`).

## Verification

Collection from the repo root and from `tests/` now yields **the same 164 items**, and the docs are genuinely read from both:

```
repo root : 1 failed, 163 passed
tests/    : 2 failed, 162 passed
```

The empty-glob guard, exercised directly:

```
REPO_ROOT  : .../mloda
docs found : 36
plugins    : 54
empty glob raises: no markdown files found under <tmpdir> - the documentation tests would check nothing
```

**Pre-existing local failures, all reproduced on a clean tree and unrelated to this change** — optional doc-snippet dependencies missing in my environment:

- `test_documentation.py::test_files_good` (fails on clean tree from the repo root too)
- `test_doc_example_isolation.py::test_doc_snippets_unaffected_by_leaked_test_feature_groups` (fails on clean tree from `tests/` too)

## Gates

`ruff format --check --line-length 120 .` → 984 files already formatted; `ruff check .` → all checks passed; `mypy --strict --ignore-missing-imports` clean on all six touched/adjacent modules. (Run from the repo's own `.tox/python310` env, i.e. the pinned ruff 0.15.13.)
