### PR TITLE
fix: match the nested-feature key through DefaultOptionKeys, not a literal

### DIFF
--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -60,7 +60,11 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
     """
     processed: dict[str, Any] = {}
     for key, value in options.items():
-        if key == "in_features" and isinstance(value, dict):
+        # str() on both sides: the enum value is the option key, so comparing
+        # through it rather than a literal keeps this branch matching if that
+        # value is renamed. Not `key == DefaultOptionKeys.in_features`, which
+        # holds only while DefaultOptionKeys mixes in str (see #1063).
+        if str(key) == str(DefaultOptionKeys.in_features) and isinstance(value, dict):
             processed[key] = build_nested_feature(value)
         elif isinstance(value, dict):
             # Recursively process nested dicts

--- a/tests/test_core/test_api/feature_config/test_feature_config_loader.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_loader.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from mloda.user import Feature
-from mloda.core.api.feature_config.loader import load_features_from_config
+from mloda.core.api.feature_config.loader import load_features_from_config, process_nested_features
 from mloda.provider import DefaultOptionKeys
 
 
@@ -634,3 +634,42 @@ def test_load_adds_in_features_to_in_features_option() -> None:
     in_features_value = result[1].options.context.get(DefaultOptionKeys.in_features)
     assert isinstance(in_features_value, frozenset)
     assert in_features_value == frozenset({"latitude", "longitude"})
+
+
+def test_nested_feature_branch_follows_the_enum_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Renaming DefaultOptionKeys.in_features must move the nested-build branch with it (issue #1067).
+
+    The DefaultOptionKeys docstring treats the enum value as both the option key
+    and the default column name, so a rename is an expected kind of change. While
+    process_nested_features compared against the literal "in_features", a rename
+    silently stopped converting nested dicts into Feature objects and nothing
+    failed. Repointing the enum value here is the only way to catch that: a test
+    that merely spells the key through the enum passes either way.
+    """
+    monkeypatch.setattr(DefaultOptionKeys.in_features, "_value_", "mloda_source_feature")
+    renamed = str(DefaultOptionKeys.in_features)
+    assert renamed == "mloda_source_feature", "the rename did not take effect"
+
+    processed = process_nested_features({renamed: {"name": "nested_feature"}})
+
+    assert isinstance(processed[renamed], Feature), (
+        f"a nested dict under {renamed!r} was left as a plain dict, so the branch is still "
+        "matching a hardcoded key rather than DefaultOptionKeys.in_features"
+    )
+    assert processed[renamed].name == "nested_feature"
+
+
+def test_nested_feature_dict_becomes_a_feature_under_the_current_key() -> None:
+    """The same branch, under the key as it is spelled today."""
+    processed = process_nested_features({str(DefaultOptionKeys.in_features): {"name": "nested_feature"}})
+
+    built = processed[str(DefaultOptionKeys.in_features)]
+    assert isinstance(built, Feature)
+    assert built.name == "nested_feature"
+
+
+def test_unrelated_dict_options_are_still_recursed_not_built() -> None:
+    """A dict under any other key keeps recursing rather than becoming a Feature."""
+    processed = process_nested_features({"scaler": {"nested": {"name": "not_a_source"}}})
+
+    assert processed["scaler"] == {"nested": {"name": "not_a_source"}}


### PR DESCRIPTION
Closes #1067.

`process_nested_features` compared `key == "in_features"` against a literal, while every other reader in `loader.py` (`:76`, `:90`, `:91`, `:141`, `:157`) goes through `DefaultOptionKeys`. Since the enum value is documented as both the option key and the default column name, a rename is an expected kind of change — and after one, this branch silently stops converting nested dicts into `Feature` objects.

## The comparison

```python
if str(key) == str(DefaultOptionKeys.in_features) and isinstance(value, dict):
```

`str()` on both sides per the DoD, not `key == DefaultOptionKeys.in_features` — that holds only while `DefaultOptionKeys` mixes in `str`, which is exactly the assumption #1063 was about.

## The test that catches divergence

This is the part worth reviewing. A test that simply spells the key through the enum passes against the literal too, so it proves nothing. The regression test repoints the enum value and asserts the branch follows:

```python
monkeypatch.setattr(DefaultOptionKeys.in_features, "_value_", "mloda_source_feature")
processed = process_nested_features({renamed: {"name": "nested_feature"}})
assert isinstance(processed[renamed], Feature)
```

**Revert-verified** — against the pre-fix loader:

```
AssertionError: a nested dict under 'mloda_source_feature' was left as a plain dict, so the
branch is still matching a hardcoded key rather than DefaultOptionKeys.in_features
 +  where False = isinstance({'name': 'nested_feature'}, Feature)
```

`monkeypatch` restores `_value_` at teardown; I checked for leakage by running all of `tests/test_core/test_api/` in both declared and random order — 580 passed either way, same result.

Two companion tests: the current-key path builds a `Feature`, and a dict under any other key still recurses rather than being built.

## Verification

- `tests/test_core/test_api/feature_config/test_feature_config_loader.py` — 34 passed
- `tests/test_core/test_api/` — 580 passed, in both orders
- Pre-existing local failures, reproduced on a clean tree and unrelated: `test_stream_run.py` (2)

## Gates

`ruff format --check --line-length 120 .` → 984 files already formatted; `ruff check .` → all checks passed; `mypy --strict --ignore-missing-imports` clean on the changed module and its test. (Run from the repo's own `.tox/python310` env.)
