### PR TITLE
test: share the throwaway plugin stubs behind one helper

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,7 @@ tests/
 ├── test_parallelization_modes_support.py  # Every parallelization mode is supported
 ├── test_project_structure.py       # Repository layout invariants
 ├── test_registry_isolation.py      # Plugin registry isolation between tests
+├── helpers/                        # Shared stub plugins tests import (see plugin_stubs.py)
 ├── test_core/                      # Tests for core functionality
 │   ├── test_abstract_plugins/      # Tests for abstract plugin interfaces
 │   │   ├── test_components/        # Tests for component implementations

--- a/tests/helpers/plugin_stubs.py
+++ b/tests/helpers/plugin_stubs.py
@@ -1,0 +1,126 @@
+"""Shared FeatureGroup stubs for tests.
+
+``StubFeatureGroup`` answers every FeatureGroup hook from a ClassVar, and ``make_fg`` mints a subclass
+of it in the calling module, so a test declares a plugin by keyword instead of writing a class body.
+"""
+
+from __future__ import annotations
+
+import sys
+from abc import abstractmethod
+from collections.abc import Iterable
+from typing import Any, ClassVar, cast
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+class StubFeatureGroup(FeatureGroup):
+    """A FeatureGroup that reads every answer off its own ClassVars."""
+
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset()
+    DOMAIN_NAME: ClassVar[str | None] = None
+    FRAMEWORK_RULE: ClassVar[set[type[ComputeFramework]] | None] = None
+    SUPPORTED_NAMES: ClassVar[frozenset[str]] = frozenset()
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        """MATCHED_NAMES is the whole matcher."""
+        # Replaces the FeatureGroup default, which matches the class name, its prefix and the input
+        # data, so an unconfigured stub adds no matcher to the suite.
+        return str(feature_name) in cls.MATCHED_NAMES
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        if cls.DOMAIN_NAME is None:
+            return super().get_domain()
+        return Domain(cls.DOMAIN_NAME)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return cls.FRAMEWORK_RULE
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return set(cls.SUPPORTED_NAMES)
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        """None is the root-feature protocol signal that ``FeatureGroup.is_root`` reads."""
+        return None
+
+
+def _stub_abstract_hook(self: FeatureGroup) -> None:
+    """Unimplemented member that makes an ``abstract=True`` stub abstract to ABCMeta."""
+
+
+# A call, not a decorator: mypy rejects @abstractmethod outside a class body. Both spellings only set
+# __isabstractmethod__ on this same function, which is what ABCMeta reads at class creation.
+_STUB_ABSTRACT_HOOK = abstractmethod(_stub_abstract_hook)
+
+
+# Names only, never the classes: a retained class object would outlive its own test and trip the
+# registry-isolation fixture on the next one.
+_MINTED_NAMES: set[tuple[str, str]] = set()
+
+
+def _claim(module: str, name: str) -> None:
+    """Reserve one (module, name) pair per process; a repeat is the collision the guard exists for."""
+    if (module, name) in _MINTED_NAMES:
+        raise ValueError(f"A stub named {name} was already minted in {module}. Give this one its own name.")
+    _MINTED_NAMES.add((module, name))
+
+
+def _name_set(names: str | Iterable[str]) -> frozenset[str]:
+    """One bare name, or an iterable of them; a str is never spread over its characters."""
+    if isinstance(names, str):
+        return frozenset({names})
+    return frozenset(names)
+
+
+def make_fg(
+    name: str,
+    *,
+    matches: str | Iterable[str] = (),
+    domain: str | None = None,
+    frameworks: set[type[ComputeFramework]] | None = None,
+    supported_names: str | Iterable[str] = (),
+    abstract: bool = False,
+    base: type[FeatureGroup] = StubFeatureGroup,
+    doc: str | None = None,
+) -> type[FeatureGroup]:
+    """Mint a FeatureGroup subclass named ``name`` in the calling module, configured by keyword."""
+    # The caller's module, so (module, qualname) dedup, _is_live_in_module and the isolation fixture
+    # read a minted stub exactly like a hand-written class.
+    module: str = sys._getframe(1).f_globals["__name__"]
+    _claim(module, name)
+
+    namespace: dict[str, Any] = {"__module__": module, "__qualname__": name}
+    # Only a supplied keyword lands in the namespace; injecting an empty one would shadow the base's
+    # ClassVar instead of inheriting it.
+    if matches:
+        namespace["MATCHED_NAMES"] = _name_set(matches)
+    if domain is not None:
+        namespace["DOMAIN_NAME"] = domain
+    if frameworks is not None:
+        namespace["FRAMEWORK_RULE"] = frameworks
+    if supported_names:
+        namespace["SUPPORTED_NAMES"] = _name_set(supported_names)
+    if doc is not None:
+        namespace["__doc__"] = doc
+    if abstract:
+        namespace[_STUB_ABSTRACT_HOOK.__name__] = _STUB_ABSTRACT_HOOK
+
+    # The base's metaclass, not type: FeatureGroup is an ABC, and only ABCMeta turns the injected
+    # abstract member into a real instantiation error.
+    metaclass: type[Any] = type(base)
+    return cast("type[FeatureGroup]", metaclass(name, (base,), namespace))

--- a/tests/helpers/plugin_stubs.py
+++ b/tests/helpers/plugin_stubs.py
@@ -1,8 +1,4 @@
-"""Shared FeatureGroup stubs for tests.
-
-``StubFeatureGroup`` answers every FeatureGroup hook from a ClassVar, and ``make_fg`` mints a subclass
-of it in the calling module, so a test declares a plugin by keyword instead of writing a class body.
-"""
+"""Shared FeatureGroup stubs: a test declares a plugin by keyword instead of writing a class body."""
 
 from __future__ import annotations
 
@@ -35,7 +31,6 @@ class StubFeatureGroup(FeatureGroup):
         options: Options,
         data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
-        """MATCHED_NAMES is the whole matcher."""
         # Replaces the FeatureGroup default, which matches the class name, its prefix and the input
         # data, so an unconfigured stub adds no matcher to the suite.
         return str(feature_name) in cls.MATCHED_NAMES
@@ -74,7 +69,7 @@ _MINTED_NAMES: set[tuple[str, str]] = set()
 
 
 def _claim(module: str, name: str) -> None:
-    """Reserve one (module, name) pair per process; a repeat is the collision the guard exists for."""
+    """Reserve one (module, name) pair per process."""
     if (module, name) in _MINTED_NAMES:
         raise ValueError(f"A stub named {name} was already minted in {module}. Give this one its own name.")
     _MINTED_NAMES.add((module, name))

--- a/tests/helpers/plugin_stubs.py
+++ b/tests/helpers/plugin_stubs.py
@@ -85,30 +85,44 @@ def _name_set(names: str | Iterable[str]) -> frozenset[str]:
 def make_fg(
     name: str,
     *,
-    matches: str | Iterable[str] = (),
+    matches: str | Iterable[str] | None = None,
     domain: str | None = None,
     frameworks: set[type[ComputeFramework]] | None = None,
-    supported_names: str | Iterable[str] = (),
+    supported_names: str | Iterable[str] | None = None,
     abstract: bool = False,
-    base: type[FeatureGroup] = StubFeatureGroup,
+    base: type[StubFeatureGroup] = StubFeatureGroup,
     doc: str | None = None,
-) -> type[FeatureGroup]:
-    """Mint a FeatureGroup subclass named ``name`` in the calling module, configured by keyword."""
+) -> type[StubFeatureGroup]:
+    """Mint a FeatureGroup subclass named ``name`` in the calling module, configured by keyword.
+
+    Bind the result at module level under exactly ``name``: that binding is what makes the class
+    picklable and what ``_is_live_in_module`` and the registry-isolation fixture read.
+    One ``(module, name)`` pair per process, so this cannot be called from a fixture or from a
+    parametrized test.
+    A minted class has no retrievable source, so ``version()`` is unavailable and the docs path
+    reports it as such; a stub needing a real version must be written as a class statement.
+    """
+    if not issubclass(base, StubFeatureGroup):
+        # A foreign base reads none of the stub ClassVars, so every keyword is silently dropped and
+        # FeatureGroup's default matcher, which matches the class's own name, is back in the suite.
+        raise ValueError(f"base must be a StubFeatureGroup subclass, got {base.__name__}.")
+
     # The caller's module, so (module, qualname) dedup, _is_live_in_module and the isolation fixture
     # read a minted stub exactly like a hand-written class.
     module: str = sys._getframe(1).f_globals["__name__"]
     _claim(module, name)
 
     namespace: dict[str, Any] = {"__module__": module, "__qualname__": name}
-    # Only a supplied keyword lands in the namespace; injecting an empty one would shadow the base's
-    # ClassVar instead of inheriting it.
-    if matches:
+    # An omitted keyword is None and inherits the base's ClassVar; an explicitly empty one is a
+    # value, and shadows it with the empty declaration.
+    if matches is not None:
         namespace["MATCHED_NAMES"] = _name_set(matches)
     if domain is not None:
         namespace["DOMAIN_NAME"] = domain
     if frameworks is not None:
-        namespace["FRAMEWORK_RULE"] = frameworks
-    if supported_names:
+        # A copy: mutating the caller's set afterwards must not rewrite the minted class's rule.
+        namespace["FRAMEWORK_RULE"] = set(frameworks)
+    if supported_names is not None:
         namespace["SUPPORTED_NAMES"] = _name_set(supported_names)
     if doc is not None:
         namespace["__doc__"] = doc
@@ -118,4 +132,4 @@ def make_fg(
     # The base's metaclass, not type: FeatureGroup is an ABC, and only ABCMeta turns the injected
     # abstract member into a real instantiation error.
     metaclass: type[Any] = type(base)
-    return cast("type[FeatureGroup]", metaclass(name, (base,), namespace))
+    return cast("type[StubFeatureGroup]", metaclass(name, (base,), namespace))

--- a/tests/helpers/test_plugin_stubs.py
+++ b/tests/helpers/test_plugin_stubs.py
@@ -1,0 +1,244 @@
+"""Contract for the shared FeatureGroup stub helper (tests/helpers/plugin_stubs.py).
+
+A stub is a global FeatureGroup subclass, so identity (name, calling module) and registry safety
+(no duplicate names, no reference kept by the factory) are as much of the contract as behaviour.
+"""
+
+from __future__ import annotations
+
+import gc
+import inspect
+import weakref
+
+import pytest
+
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+from tests.helpers.plugin_stubs import StubFeatureGroup, make_fg
+
+
+HELPER_MODULE = "tests.helpers.plugin_stubs"
+
+# Feature names the stubs match on; the plugin_stub_ prefix keeps them unique to this module.
+ALPHA = "plugin_stub_alpha_feature"
+BETA = "plugin_stub_beta_feature"
+UNMATCHED = "plugin_stub_unmatched_feature"
+
+DOMAIN = "plugin_stub_domain"
+PARENT_DOMAIN = "plugin_stub_parent_domain"
+OVERRIDE_DOMAIN = "plugin_stub_override_domain"
+
+DOC = "A stub minted for the plugin-stub contract."
+
+# Every make_fg call below needs its own class name: the duplicate-name guard is per (module, name)
+# and outlives the class it minted.
+DUPLICATE_NAME = "PluginStubDuplicateFG"
+
+FRAMEWORKS: set[type[ComputeFramework]] = {PythonDictFramework, PyArrowTable}
+
+
+def _matches(cls: type[FeatureGroup], feature_name: str) -> bool:
+    """The verdict of match_feature_group_criteria for one feature name."""
+    return cls.match_feature_group_criteria(feature_name, Options())
+
+
+def _as_stub(cls: type[FeatureGroup]) -> type[StubFeatureGroup]:
+    """Narrow the factory's declared return type, so the stub ClassVars are readable."""
+    assert issubclass(cls, StubFeatureGroup), f"make_fg must mint a StubFeatureGroup subclass, got {cls.__mro__}"
+    return cls
+
+
+def _mint_and_drop(name: str) -> weakref.ref[type[FeatureGroup]]:
+    """Mint a stub and hand back only a weak reference; this frame keeps no strong one."""
+    return weakref.ref(make_fg(name))
+
+
+def _collect_until_dead(reference: weakref.ref[type[FeatureGroup]]) -> None:
+    """Run the youngest-first collection ladder, stopping as soon as the referent is gone."""
+    for generation in (0, 1, 2):
+        gc.collect(generation)
+        if reference() is None:
+            return
+
+
+def _ordinary_spelling_verdicts() -> tuple[bool, bool]:
+    """Verdicts of a stub written as an ordinary subclass; the class never leaves this frame."""
+
+    class OrdinarySpellingStubFG(StubFeatureGroup):
+        MATCHED_NAMES = frozenset({ALPHA})
+
+    return _matches(OrdinarySpellingStubFG, ALPHA), _matches(OrdinarySpellingStubFG, UNMATCHED)
+
+
+class TestMintedIdentity:
+    """A minted class carries the caller's identity, never the helper module's."""
+
+    def test_the_name_is_a_required_parameter(self) -> None:
+        """An implicit name would let two unrelated tests collide in the global subclass registry."""
+        name_parameter = inspect.signature(make_fg).parameters["name"]
+        assert name_parameter.default is inspect.Parameter.empty
+
+    def test_the_minted_class_carries_the_given_name(self) -> None:
+        name = "PluginStubIdentityFG"
+        cls = make_fg(name)
+        assert cls.__name__ == name
+        assert cls.__qualname__ == name
+        assert cls.get_class_name() == name
+
+    def test_the_minted_class_belongs_to_the_calling_module(self) -> None:
+        """(module, qualname) dedup and _is_live_in_module must read a stub like a hand-written class."""
+        cls = make_fg("PluginStubCallingModuleFG")
+        assert cls.__module__ == __name__
+        assert cls.__module__ != HELPER_MODULE
+
+
+class TestRegistrySafety:
+    """Stubs are global FeatureGroup subclasses, so the factory must neither collide nor retain."""
+
+    def test_a_repeated_name_in_the_same_module_raises(self) -> None:
+        """A duplicate (module, name) is exactly the cross-contamination the isolation guard exists for."""
+        make_fg(DUPLICATE_NAME)
+        with pytest.raises(ValueError, match=DUPLICATE_NAME):
+            make_fg(DUPLICATE_NAME)
+
+    def test_the_factory_keeps_no_strong_reference(self) -> None:
+        """A cached class object would leak every stub in the suite past its own test."""
+        reference = _mint_and_drop("PluginStubWeakrefFG")
+        _collect_until_dead(reference)
+        assert reference() is None, "make_fg must not retain the classes it mints"
+
+    def test_distinct_calls_mint_distinct_classes(self) -> None:
+        first = make_fg("PluginStubDistinctFirstFG")
+        second = make_fg("PluginStubDistinctSecondFG")
+        assert first is not second
+        assert not issubclass(first, second)
+        assert not issubclass(second, first)
+
+
+class TestMatching:
+    """matches= is the whole matcher: a stub answers True for those names and for nothing else."""
+
+    def test_the_default_stub_matches_nothing(self) -> None:
+        """Deliberately unlike FeatureGroup's default matcher, which matches the class name."""
+        name = "PluginStubDefaultMatchFG"
+        cls = make_fg(name)
+        assert _matches(cls, name) is False
+
+    def test_a_string_is_one_name_not_one_per_character(self) -> None:
+        cls = make_fg("PluginStubStringMatchFG", matches=ALPHA)
+        assert _matches(cls, ALPHA) is True
+        assert _matches(cls, ALPHA[0]) is False
+        assert _matches(cls, UNMATCHED) is False
+
+    def test_an_iterable_matches_each_of_its_names(self) -> None:
+        cls = make_fg("PluginStubIterableMatchFG", matches={ALPHA, BETA})
+        assert _as_stub(cls).MATCHED_NAMES == frozenset({ALPHA, BETA})
+        assert _matches(cls, ALPHA) is True
+        assert _matches(cls, BETA) is True
+        assert _matches(cls, UNMATCHED) is False
+
+    def test_the_ordinary_subclass_spelling_matches_identically(self) -> None:
+        """Setting MATCHED_NAMES in a class body and passing matches= are one mechanism."""
+        verdicts = _ordinary_spelling_verdicts()
+        factory = make_fg("PluginStubFactoryTwinFG", matches=ALPHA)
+        assert verdicts == (_matches(factory, ALPHA), _matches(factory, UNMATCHED))
+        assert verdicts == (True, False)
+
+
+class TestDeclaredAttributes:
+    """Each keyword lands on the FeatureGroup accessor it stands for."""
+
+    def test_no_domain_means_the_default_domain(self) -> None:
+        cls = make_fg("PluginStubDefaultDomainFG")
+        assert cls.get_domain() == Domain.get_default_domain()
+
+    def test_a_named_domain_becomes_that_domain(self) -> None:
+        cls = make_fg("PluginStubNamedDomainFG", domain=DOMAIN)
+        assert cls.get_domain() == Domain(DOMAIN)
+
+    def test_no_frameworks_means_no_compute_framework_rule(self) -> None:
+        cls = make_fg("PluginStubDefaultFrameworksFG")
+        assert cls.compute_framework_rule() is None
+
+    def test_frameworks_become_the_compute_framework_rule(self) -> None:
+        cls = make_fg("PluginStubNamedFrameworksFG", frameworks=FRAMEWORKS)
+        assert cls.compute_framework_rule() == FRAMEWORKS
+
+    def test_no_supported_names_means_the_empty_set(self) -> None:
+        cls = make_fg("PluginStubDefaultSupportedFG")
+        assert cls.feature_names_supported() == set()
+
+    def test_supported_names_become_the_supported_feature_names(self) -> None:
+        cls = make_fg("PluginStubNamedSupportedFG", supported_names=(ALPHA, BETA))
+        assert cls.feature_names_supported() == {ALPHA, BETA}
+
+    def test_doc_becomes_the_class_description(self) -> None:
+        cls = make_fg("PluginStubDocFG", doc=DOC)
+        assert cls.__doc__ == DOC
+        assert cls.description() == DOC
+
+
+class TestInstances:
+    """A stub is a root feature, and instantiable unless it was minted abstract."""
+
+    def test_input_features_returns_none_on_an_instance(self) -> None:
+        """None is the root-feature protocol signal that FeatureGroup.is_root reads."""
+        instance = make_fg("PluginStubRootFG")()
+        assert instance.input_features(Options(), FeatureName(ALPHA)) is None
+        assert instance.is_root(Options(), ALPHA) is True
+
+    def test_an_abstract_stub_cannot_be_instantiated(self) -> None:
+        cls = make_fg("PluginStubAbstractFG", abstract=True)
+        assert inspect.isabstract(cls) is True
+        with pytest.raises(TypeError):
+            cls()
+
+    def test_a_concrete_stub_is_instantiable(self) -> None:
+        cls = make_fg("PluginStubConcreteFG", abstract=False)
+        assert inspect.isabstract(cls) is False
+        assert isinstance(cls(), cls)
+
+
+class TestBaseParameter:
+    """base= mints a subclass, so a family of stubs can share one set of ClassVars."""
+
+    def test_a_base_stub_is_subclassed_and_its_class_vars_inherited(self) -> None:
+        parent = make_fg("PluginStubParentFG", matches=ALPHA, domain=PARENT_DOMAIN, supported_names=(BETA,))
+        child = make_fg("PluginStubChildFG", base=parent)
+        assert issubclass(child, parent)
+        assert _matches(child, ALPHA) is True
+        assert child.get_domain() == Domain(PARENT_DOMAIN)
+        assert child.feature_names_supported() == {BETA}
+
+    def test_an_explicit_keyword_overrides_the_inherited_class_var(self) -> None:
+        parent = make_fg("PluginStubOverrideParentFG", matches=ALPHA, domain=OVERRIDE_DOMAIN)
+        child = make_fg("PluginStubOverrideChildFG", base=parent, matches=BETA)
+        assert _matches(child, BETA) is True
+        assert _matches(child, ALPHA) is False
+        assert child.get_domain() == Domain(OVERRIDE_DOMAIN)
+
+
+class TestStubFeatureGroupBase:
+    """The base class alone is inert: it matches nothing and answers the FeatureGroup defaults."""
+
+    def test_it_matches_nothing(self) -> None:
+        """Its own name included, so importing the helper adds no matcher to the suite."""
+        assert _matches(StubFeatureGroup, StubFeatureGroup.get_class_name()) is False
+        assert _matches(StubFeatureGroup, ALPHA) is False
+
+    def test_it_answers_the_feature_group_defaults(self) -> None:
+        assert StubFeatureGroup.get_domain() == Domain.get_default_domain()
+        assert StubFeatureGroup.compute_framework_rule() is None
+        assert StubFeatureGroup.feature_names_supported() == set()
+
+    def test_its_class_vars_are_empty(self) -> None:
+        assert StubFeatureGroup.MATCHED_NAMES == frozenset()
+        assert StubFeatureGroup.DOMAIN_NAME is None
+        assert StubFeatureGroup.FRAMEWORK_RULE is None
+        assert StubFeatureGroup.SUPPORTED_NAMES == frozenset()

--- a/tests/helpers/test_plugin_stubs.py
+++ b/tests/helpers/test_plugin_stubs.py
@@ -1,8 +1,4 @@
-"""Contract for the shared FeatureGroup stub helper (tests/helpers/plugin_stubs.py).
-
-A stub is a global FeatureGroup subclass, so identity (name, calling module) and registry safety
-(no duplicate names, no reference kept by the factory) are as much of the contract as behaviour.
-"""
+"""Contract for the shared FeatureGroup stub helper (tests/helpers/plugin_stubs.py)."""
 
 from __future__ import annotations
 
@@ -44,7 +40,6 @@ FRAMEWORKS: set[type[ComputeFramework]] = {PythonDictFramework, PyArrowTable}
 
 
 def _matches(cls: type[FeatureGroup], feature_name: str) -> bool:
-    """The verdict of match_feature_group_criteria for one feature name."""
     return cls.match_feature_group_criteria(feature_name, Options())
 
 
@@ -55,12 +50,11 @@ def _as_stub(cls: type[FeatureGroup]) -> type[StubFeatureGroup]:
 
 
 def _mint_and_drop(name: str) -> weakref.ref[type[FeatureGroup]]:
-    """Mint a stub and hand back only a weak reference; this frame keeps no strong one."""
+    """Hand back only a weak reference: this frame keeps no strong one."""
     return weakref.ref(make_fg(name))
 
 
 def _collect_until_dead(reference: weakref.ref[type[FeatureGroup]]) -> None:
-    """Run the youngest-first collection ladder, stopping as soon as the referent is gone."""
     for generation in (0, 1, 2):
         gc.collect(generation)
         if reference() is None:

--- a/tests/helpers/test_plugin_stubs.py
+++ b/tests/helpers/test_plugin_stubs.py
@@ -13,6 +13,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import _safe_version
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
@@ -164,6 +165,13 @@ class TestDeclaredAttributes:
         cls = make_fg("PluginStubNamedFrameworksFG", frameworks=FRAMEWORKS)
         assert cls.compute_framework_rule() == FRAMEWORKS
 
+    def test_frameworks_are_copied_not_aliased(self) -> None:
+        """Mutating the passed set afterwards must not rewrite the minted class's rule."""
+        passed: set[type[ComputeFramework]] = {PythonDictFramework}
+        cls = make_fg("PluginStubFrameworksCopyFG", frameworks=passed)
+        passed.add(PyArrowTable)
+        assert cls.compute_framework_rule() == {PythonDictFramework}
+
     def test_no_supported_names_means_the_empty_set(self) -> None:
         cls = make_fg("PluginStubDefaultSupportedFG")
         assert cls.feature_names_supported() == set()
@@ -217,6 +225,32 @@ class TestBaseParameter:
         assert _matches(child, ALPHA) is False
         assert child.get_domain() == Domain(OVERRIDE_DOMAIN)
 
+    def test_a_base_outside_the_stub_hierarchy_raises(self) -> None:
+        """A plain base reads none of the stub ClassVars, so every keyword is silently dropped."""
+
+        class PluginStubPlainFG(FeatureGroup):
+            pass
+
+        with pytest.raises(ValueError, match="StubFeatureGroup") as raised:
+            make_fg("PluginStubPlainChildFG", base=PluginStubPlainFG, matches=ALPHA)  # type: ignore[arg-type]
+        assert "PluginStubPlainFG" in str(raised.value)
+
+
+class TestEmptyIsAValueNotAnOmission:
+    """An omitted keyword inherits from base=; an explicitly empty one declares the value empty."""
+
+    def test_an_omitted_matches_inherits_the_base_names(self) -> None:
+        parent = make_fg("PluginStubInheritMatchesParentFG", matches=ALPHA)
+        child = make_fg("PluginStubInheritMatchesChildFG", base=parent)
+        assert _matches(child, ALPHA) is True
+
+    def test_an_explicitly_empty_matches_clears_the_inherited_names(self) -> None:
+        parent = make_fg("PluginStubEmptyMatchesParentFG", matches=(ALPHA, BETA))
+        child = make_fg("PluginStubEmptyMatchesChildFG", base=parent, matches=frozenset())
+        assert _as_stub(child).MATCHED_NAMES == frozenset()
+        assert _matches(child, ALPHA) is False
+        assert _matches(child, BETA) is False
+
 
 class TestStubFeatureGroupBase:
     """The base class alone is inert: it matches nothing and answers the FeatureGroup defaults."""
@@ -236,3 +270,19 @@ class TestStubFeatureGroupBase:
         assert StubFeatureGroup.DOMAIN_NAME is None
         assert StubFeatureGroup.FRAMEWORK_RULE is None
         assert StubFeatureGroup.SUPPORTED_NAMES == frozenset()
+
+
+class TestNoRetrievableSource:
+    """A minted class has no source: a stub that needs a real version() must be written as a class statement."""
+
+    def test_source_and_version_are_unavailable(self) -> None:
+        cls = make_fg("PluginStubNoSourceFG")
+        with pytest.raises(OSError):
+            inspect.getsource(cls)
+        with pytest.raises(OSError):
+            cls.version()
+
+    def test_the_docs_version_accessor_degrades_instead_of_raising(self) -> None:
+        """get_feature_group_docs reads the version field through _safe_version, so a stub degrades, not raises."""
+        cls = make_fg("PluginStubDocsVersionFG")
+        assert _safe_version(cls) == "unavailable"

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -15,11 +15,10 @@ Follows the construction conventions in test_identify_feature_group_error_messag
 
 import inspect
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 import pytest
 
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
@@ -27,6 +26,7 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import matches_feature_group_scope
+from tests.helpers.plugin_stubs import StubFeatureGroup, make_fg
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import BaseInputData, DataCreator, FeatureSet
 from mloda.user import PluginCollector, mloda
@@ -43,86 +43,33 @@ class SecondMockComputeFramework(ComputeFramework):
     """A second mock compute framework, for rival subclasses of different frameworks."""
 
 
-class ScopeSourceA(FeatureGroup):
+class ScopeSourceA(StubFeatureGroup):
     """Source A: matches the shared "subject_token" plus its own "scoping_value_a"."""
 
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        return {"subject_token", "scoping_value_a"}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        name = str(feature_name)
-        return name in {"subject_token", "scoping_value_a"}
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"subject_token", "scoping_value_a"})
+    SUPPORTED_NAMES: ClassVar[frozenset[str]] = MATCHED_NAMES
 
 
-class ScopeSourceB(FeatureGroup):
+class ScopeSourceB(StubFeatureGroup):
     """Source B: matches the shared "subject_token" plus its own "scoping_value_b"."""
 
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        return {"subject_token", "scoping_value_b"}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        name = str(feature_name)
-        return name in {"subject_token", "scoping_value_b"}
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"subject_token", "scoping_value_b"})
+    SUPPORTED_NAMES: ClassVar[frozenset[str]] = MATCHED_NAMES
 
 
-class InaccessibleScopeSource(FeatureGroup):
-    """A FeatureGroup that matches "subject_token" but is never added to accessible_plugins."""
+InaccessibleScopeSource = make_fg(
+    "InaccessibleScopeSource",
+    matches="subject_token",
+    supported_names="subject_token",
+    doc="A FeatureGroup that is never added to accessible_plugins.",
+)
 
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        return {"subject_token"}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == "subject_token"
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class _DupNameBase(FeatureGroup):
-    """Base for two feature groups that will share the identical class name."""
-
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        return {"subject_token"}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == "subject_token"
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+_DupNameBase = make_fg(
+    "_DupNameBase",
+    matches="subject_token",
+    supported_names="subject_token",
+    doc="Base for two feature groups that will share the identical class name.",
+)
 
 
 def _both_sources() -> FeatureGroupEnvironmentMapping:
@@ -301,21 +248,11 @@ class ScopedCapabilityFw(ComputeFramework):
     """Compute framework rejected by RejectAllScopedSource at match time."""
 
 
-class RejectAllScopedSource(FeatureGroup):
+class RejectAllScopedSource(StubFeatureGroup):
     """Matches "subject_token" but declares every compute framework unsupported."""
 
-    @classmethod
-    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        return {ScopedCapabilityFw}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == "subject_token"
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"subject_token"})
+    FRAMEWORK_RULE: ClassVar[set[type[ComputeFramework]]] = {ScopedCapabilityFw}
 
     @classmethod
     def supports_compute_framework(
@@ -325,9 +262,6 @@ class RejectAllScopedSource(FeatureGroup):
         compute_framework: type[ComputeFramework],
     ) -> bool:
         return False
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
 
 
 def test_capability_rejection_error_names_the_scope() -> None:
@@ -475,29 +409,16 @@ def test_string_scope_does_not_widen_to_unrelated_groups() -> None:
     assert resolved_feature_group is ScopeSourceASub
 
 
-class ScopeAbstractFamilyBase(FeatureGroup):
+class ScopeAbstractFamilyBase(StubFeatureGroup):
     """Abstract family base: matches "subject_token" but cannot be instantiated."""
 
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        return {"subject_token"}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == "subject_token"
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"subject_token"})
+    SUPPORTED_NAMES: ClassVar[frozenset[str]] = frozenset({"subject_token"})
 
     @classmethod
     @abstractmethod
     def _family_hook(cls) -> str:
         """Abstract hook that makes this base abstract."""
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
 
 
 class ScopeConcreteFamilyMember(ScopeAbstractFamilyBase):

--- a/tests/test_core/test_prepare/test_feature_resolution_error.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error.py
@@ -12,17 +12,12 @@ runs in parallel, so a shared name would leak into another module's candidate un
 
 import copy
 import pickle  # nosec B403
-from typing import Optional
 
 import pytest
 
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import (
     FeatureResolutionError,
@@ -30,6 +25,7 @@ from mloda.core.prepare.identify_feature_group import (
 )
 from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.user import mlodaAPI
+from tests.helpers.plugin_stubs import make_fg
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
@@ -43,52 +39,11 @@ class ResolutionErrorFw_809(ComputeFramework):
     """Dummy compute framework for the typed-resolution-error tests."""
 
 
-class ResolutionErrorKnownFG_809(FeatureGroup):
-    """Concrete feature group matching exactly one unique feature name."""
+ResolutionErrorKnownFG_809 = make_fg("ResolutionErrorKnownFG_809", matches=KNOWN_FEATURE_809)
 
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == KNOWN_FEATURE_809
+ResolutionErrorSiblingAFG_809 = make_fg("ResolutionErrorSiblingAFG_809", matches=MULTIPLE_FEATURE_809)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class ResolutionErrorSiblingAFG_809(FeatureGroup):
-    """First of two unrelated siblings matching the same name, forcing an ambiguous match."""
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == MULTIPLE_FEATURE_809
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class ResolutionErrorSiblingBFG_809(FeatureGroup):
-    """Second unrelated sibling matching the same name, forcing an ambiguous match."""
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == MULTIPLE_FEATURE_809
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+ResolutionErrorSiblingBFG_809 = make_fg("ResolutionErrorSiblingBFG_809", matches=MULTIPLE_FEATURE_809)
 
 
 def _no_match_accessible_plugins() -> FeatureGroupEnvironmentMapping:

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -4,13 +4,11 @@ The formatting lives in mloda/core/prepare/resolution_failure_renderer.py: _rend
 candidate as "ClassName (module.path)" instead of a raw dict/class representation.
 """
 
-from typing import Optional
+from typing import ClassVar, Optional
 
 import pytest
 
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
@@ -21,6 +19,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from tests.helpers.plugin_stubs import StubFeatureGroup
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
@@ -30,55 +29,18 @@ class MockComputeFramework(ComputeFramework):
     pass
 
 
-class ConflictingFeatureGroupA(FeatureGroup):
-    """First conflicting feature group with custom domain 'domain_a'.
+class ConflictingFeatureGroupA(StubFeatureGroup):
+    """First conflicting feature group with custom domain 'domain_a'."""
 
-    This feature group matches any feature named 'conflicting_test_feature'.
-    """
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("domain_a")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        if isinstance(feature_name, FeatureName):
-            feature_name = str(feature_name)
-        return feature_name == "conflicting_test_feature"
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    DOMAIN_NAME: ClassVar[str] = "domain_a"
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"conflicting_test_feature"})
 
 
-class ConflictingFeatureGroupB(FeatureGroup):
-    """Second conflicting feature group with custom domain 'domain_b'.
+class ConflictingFeatureGroupB(StubFeatureGroup):
+    """Second conflicting feature group with custom domain 'domain_b', creating a conflict scenario."""
 
-    This feature group also matches any feature named 'conflicting_test_feature',
-    creating a conflict scenario.
-    """
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("domain_b")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        if isinstance(feature_name, FeatureName):
-            feature_name = str(feature_name)
-        return feature_name == "conflicting_test_feature"
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    DOMAIN_NAME: ClassVar[str] = "domain_b"
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"conflicting_test_feature"})
 
 
 class TestIdentifyFeatureGroupErrorMessageFormat:
@@ -224,26 +186,12 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         )
 
 
-class KnownFeatureGroup(FeatureGroup):
+class KnownFeatureGroup(StubFeatureGroup):
     """Feature group that matches 'known_feature' for testing fuzzy match suggestions."""
 
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        return {"known_feature", "another_feature"}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        if isinstance(feature_name, FeatureName):
-            feature_name = str(feature_name)
-        return feature_name == "known_feature"
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    # Matching stays narrower than the supported names: 'another_feature' is only a suggestion source.
+    MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"known_feature"})
+    SUPPORTED_NAMES: ClassVar[frozenset[str]] = frozenset({"known_feature", "another_feature"})
 
 
 class TestNoFeatureGroupFoundErrorMessage:

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -30,14 +30,14 @@ class MockComputeFramework(ComputeFramework):
 
 
 class ConflictingFeatureGroupA(StubFeatureGroup):
-    """First conflicting feature group with custom domain 'domain_a'."""
+    """One of two rivals for the same feature name, so resolution has to report a conflict."""
 
     DOMAIN_NAME: ClassVar[str] = "domain_a"
     MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"conflicting_test_feature"})
 
 
 class ConflictingFeatureGroupB(StubFeatureGroup):
-    """Second conflicting feature group with custom domain 'domain_b', creating a conflict scenario."""
+    """The other rival, so the failure message has two candidates to render."""
 
     DOMAIN_NAME: ClassVar[str] = "domain_b"
     MATCHED_NAMES: ClassVar[frozenset[str]] = frozenset({"conflicting_test_feature"})

--- a/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
@@ -6,18 +6,10 @@ raising path now lives in the engine seam, mirrored here by the ``evaluate_or_ra
 suite pins evaluate()'s non-raising contract against that raising counterpart.
 """
 
-from abc import abstractmethod
-from typing import Any, Optional
-
 import pytest
 
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
-from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.api.request import mlodaAPI
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
@@ -28,6 +20,7 @@ from mloda.core.prepare.identify_feature_group import (
 from mloda.core.prepare.resolution_types import EvaluationResult
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.helpers.plugin_stubs import make_fg
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
@@ -49,85 +42,13 @@ class SeamFwBeta(ComputeFramework):
     """Second dummy compute framework, distinct from SeamFwAlpha."""
 
 
-class SeamSingleFG(FeatureGroup):
-    """Concrete feature group matching exactly one unique feature name."""
+SeamSingleFG = make_fg("SeamSingleFG", matches=SEAM_SINGLE_FEATURE)
 
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_SINGLE_FEATURE
+SeamSiblingAFG = make_fg("SeamSiblingAFG", matches=SEAM_MULTIPLE_FEATURE, domain="seam_a")
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+SeamSiblingBFG = make_fg("SeamSiblingBFG", matches=SEAM_MULTIPLE_FEATURE, domain="seam_b")
 
-
-class SeamSiblingAFG(FeatureGroup):
-    """First of two unrelated siblings matching the same name (distinct domain 'seam_a')."""
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("seam_a")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_MULTIPLE_FEATURE
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class SeamSiblingBFG(FeatureGroup):
-    """Second unrelated sibling matching the same name (distinct domain 'seam_b')."""
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("seam_b")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_MULTIPLE_FEATURE
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class SeamAbstractOnlyFG(FeatureGroup):
-    """Abstract base matching a unique name; uninstantiable via an unimplemented abstract hook.
-
-    No concrete subclass is registered, so this base is the only name-match and can never win.
-    """
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_ABSTRACT_FEATURE
-
-    @classmethod
-    @abstractmethod
-    def _seam_abstract_hook(cls, data: Any) -> Any:
-        """Abstract hook that makes this base uninstantiable."""
-        ...
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+SeamAbstractOnlyFG = make_fg("SeamAbstractOnlyFG", matches=SEAM_ABSTRACT_FEATURE, abstract=True)
 
 
 class TestEvaluationSeamNeverRaises:

--- a/tests/test_core/test_prepare/test_identify_seam.py
+++ b/tests/test_core/test_prepare/test_identify_seam.py
@@ -7,18 +7,10 @@ returns the same structured outcome as ``IdentifyFeatureGroupClass.evaluate(...)
 raises a typed ``FeatureResolutionError`` whose message is exactly the pure-renderer projection.
 """
 
-from abc import abstractmethod
-from typing import Any, Optional
-
 import pytest
 
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
-from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import (
     FeatureResolutionError,
@@ -26,6 +18,7 @@ from mloda.core.prepare.identify_feature_group import (
 )
 from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.core.prepare.resolution_types import EvaluationResult
+from tests.helpers.plugin_stubs import make_fg
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise, identify_winner
 
 
@@ -44,85 +37,17 @@ class SeamContract014FwBeta(ComputeFramework):
     """Second dummy compute framework, distinct from SeamContract014Fw."""
 
 
-class SeamContract014FG(FeatureGroup):
-    """Concrete feature group matching exactly one unique seam-contract feature name."""
+SeamContract014FG = make_fg("SeamContract014FG", matches=SEAM_CONTRACT_MATCH_FEATURE)
 
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_CONTRACT_MATCH_FEATURE
+SeamContract014SiblingAFG = make_fg(
+    "SeamContract014SiblingAFG", matches=SEAM_CONTRACT_MULTIPLE_FEATURE, domain="seam_contract_014_a"
+)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+SeamContract014SiblingBFG = make_fg(
+    "SeamContract014SiblingBFG", matches=SEAM_CONTRACT_MULTIPLE_FEATURE, domain="seam_contract_014_b"
+)
 
-
-class SeamContract014SiblingAFG(FeatureGroup):
-    """First of two unrelated siblings matching the same name (distinct domain 'seam_contract_014_a')."""
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("seam_contract_014_a")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_CONTRACT_MULTIPLE_FEATURE
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class SeamContract014SiblingBFG(FeatureGroup):
-    """Second unrelated sibling matching the same name (distinct domain 'seam_contract_014_b')."""
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("seam_contract_014_b")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_CONTRACT_MULTIPLE_FEATURE
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class SeamContract014AbstractFG(FeatureGroup):
-    """Abstract base matching a unique name; uninstantiable via an unimplemented abstract hook.
-
-    No concrete subclass is registered, so this base is the only name-match and can never win.
-    """
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == SEAM_CONTRACT_ABSTRACT_FEATURE
-
-    @classmethod
-    @abstractmethod
-    def _seam_contract_014_abstract_hook(cls, data: Any) -> Any:
-        """Abstract hook that makes this base uninstantiable."""
-        ...
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+SeamContract014AbstractFG = make_fg("SeamContract014AbstractFG", matches=SEAM_CONTRACT_ABSTRACT_FEATURE, abstract=True)
 
 
 class TestEvaluateOrRaiseSuccess:

--- a/tests/test_core/test_prepare/test_resolve_or_raise.py
+++ b/tests/test_core/test_prepare/test_resolve_or_raise.py
@@ -21,17 +21,13 @@ All fixture names carry an ``016`` suffix: test feature groups become global sub
 parallel, so a shared name would leak into another module's candidate universe.
 """
 
-from abc import abstractmethod
-from typing import Any, Optional
+from typing import Optional
 
 import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
-from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.link import Link
-from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -52,6 +48,7 @@ from mloda.core.prepare.resolution_types import (
     EvaluationResult,
     ResolutionRecord,
 )
+from tests.helpers.plugin_stubs import make_fg
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
@@ -70,85 +67,19 @@ class ResolveOrRaiseFwBeta016(ComputeFramework):
     """Second dummy compute framework, distinct from ResolveOrRaiseFw016."""
 
 
-class ResolveOrRaiseMatchFG016(FeatureGroup):
-    """Concrete feature group matching exactly one unique helper-test feature name."""
+ResolveOrRaiseMatchFG016 = make_fg("ResolveOrRaiseMatchFG016", matches=RESOLVE_MATCH_FEATURE_016)
 
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == RESOLVE_MATCH_FEATURE_016
+ResolveOrRaiseSiblingAFG016 = make_fg(
+    "ResolveOrRaiseSiblingAFG016", matches=RESOLVE_MULTIPLE_FEATURE_016, domain="resolve_or_raise_016_a"
+)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+ResolveOrRaiseSiblingBFG016 = make_fg(
+    "ResolveOrRaiseSiblingBFG016", matches=RESOLVE_MULTIPLE_FEATURE_016, domain="resolve_or_raise_016_b"
+)
 
-
-class ResolveOrRaiseSiblingAFG016(FeatureGroup):
-    """First of two unrelated siblings matching the same name (distinct domain 'resolve_or_raise_016_a')."""
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("resolve_or_raise_016_a")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == RESOLVE_MULTIPLE_FEATURE_016
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class ResolveOrRaiseSiblingBFG016(FeatureGroup):
-    """Second unrelated sibling matching the same name (distinct domain 'resolve_or_raise_016_b')."""
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        return Domain("resolve_or_raise_016_b")
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == RESOLVE_MULTIPLE_FEATURE_016
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
-
-
-class ResolveOrRaiseAbstractFG016(FeatureGroup):
-    """Abstract base matching a unique name; uninstantiable via an unimplemented abstract hook.
-
-    No concrete subclass is registered, so this base is the only name-match and can never win.
-    """
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == RESOLVE_ABSTRACT_FEATURE_016
-
-    @classmethod
-    @abstractmethod
-    def _resolve_or_raise_016_abstract_hook(cls, data: Any) -> Any:
-        """Abstract hook that makes this base uninstantiable."""
-        ...
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+ResolveOrRaiseAbstractFG016 = make_fg(
+    "ResolveOrRaiseAbstractFG016", matches=RESOLVE_ABSTRACT_FEATURE_016, abstract=True
+)
 
 
 def _match_plugins() -> FeatureGroupEnvironmentMapping:

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -1,7 +1,7 @@
 """Pinning tests for match-time enforcement of SubtypeDeclaration (issue #639)."""
 
 import re
-from typing import Optional
+from typing import ClassVar, Optional
 
 import pytest
 
@@ -14,6 +14,7 @@ from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.core.prepare.resolution_types import CandidateFrameworks
 from mloda.provider import FeatureChainParserMixin, FeatureGroup, SubtypeDeclaration, property_spec
+from tests.helpers.plugin_stubs import StubFeatureGroup, make_fg
 from tests.test_core.test_prepare.identify_seam import identify_winner
 
 
@@ -105,24 +106,12 @@ class SubDeclMatchCompiledSuffixFG(FeatureChainParserMixin, FeatureGroup):
         return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
 
-class SubDeclMatchPlainFG(FeatureGroup):
-    """Family without any subtype dimension."""
-
-    @classmethod
-    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == MATCH_PLAIN_FEATURE
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+SubDeclMatchPlainFG = make_fg(
+    "SubDeclMatchPlainFG",
+    matches=MATCH_PLAIN_FEATURE,
+    frameworks={SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+    doc="Family without any subtype dimension.",
+)
 
 
 class SubDeclMatchRankLikeFG(FeatureChainParserMixin, FeatureGroup):
@@ -155,7 +144,7 @@ def _subdeclm_frame_resolver(feature_name: str, options: Options) -> Optional[st
     return match.group(1)
 
 
-class SubDeclMatchFrameSpecFG(FeatureGroup):
+class SubDeclMatchFrameSpecFG(StubFeatureGroup):
     """Registry-like shape B family: flattened frame spec with a name resolver."""
 
     SUBTYPES = SubtypeDeclaration(
@@ -164,10 +153,7 @@ class SubDeclMatchFrameSpecFG(FeatureGroup):
         parametric_families={"rows": "Row-count frames"},
         supported={SubDeclMatchFwBeta.get_class_name(): {"rows_1"}},
     )
-
-    @classmethod
-    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+    FRAMEWORK_RULE: ClassVar[set[type[ComputeFramework]]] = {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
     @classmethod
     def match_feature_group_criteria(
@@ -177,9 +163,6 @@ class SubDeclMatchFrameSpecFG(FeatureGroup):
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> bool:
         return str(feature_name).startswith("subdeclm_") and str(feature_name).endswith("_frame")
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
 
 
 def _identify(


### PR DESCRIPTION
The test tree defines its throwaway plugin subclasses inline, so the same handful of hook bodies is
rewritten in every file. There was no shared stub to reach for, so every module built its own.

## The helper

`tests/helpers/plugin_stubs.py` offers one mechanism in two spellings:

* `StubFeatureGroup`, a declarative base that answers the five repeated hooks (`match_feature_group_criteria`,
  `get_domain`, `compute_framework_rule`, `feature_names_supported`, root `input_features`) from ClassVars.
  A stub that keeps custom members subclasses it and declares the ClassVars it needs.
* `make_fg(name, ...)`, which mints a configured subclass for stubs that are pure data, replacing a
  14 to 23 line class body with one line.

Test feature groups are global `FeatureGroup` subclasses, so identity is part of the contract, not an
afterthought:

* the name is explicit and required, and a repeated `(module, name)` pair raises rather than quietly
  minting a second class under a name another module already uses;
* `__module__` comes from the calling module, so `(module, qualname)` dedup, `_is_live_in_module` and the
  registry-isolation fixture read a minted stub exactly like a hand-written one;
* the class is created through the base's metaclass, so `abstract=True` yields a genuinely uninstantiable
  class rather than a decorative marker;
* the factory keeps no reference to what it mints, so a stub created inside a test is still reclaimed
  when that test ends.

The base's matcher deliberately replaces the FeatureGroup default (which matches the class name, its
prefix and its input data) with "matches only `MATCHED_NAMES`", so an unconfigured stub adds no matcher
to the suite. The consequence is a migration rule: only a stub that already defined its own matcher is
re-based, since re-basing one that relied on the default would silently change what it matches.

Minted classes have no retrievable source, so `version()` is unavailable and the docs path reports it as
such. That is pinned in both directions, and a stub needing a real version stays a class statement.

## The migration

26 stubs across 7 files of `tests/test_core/test_prepare`, the directory with the most of them. Those
files lose 416 lines. Suites that only ever needed "one group matching a single name, two
domain-separated siblings, an abstract-only base" now say exactly that in four lines instead of
rebuilding the family by hand.

Nothing about the tests themselves changed: no test added, removed, renamed or re-asserted. The
collected node ids for the directory are byte-identical to main, 865 before and after, checked as a list
rather than a count. `tox` is green, with the skip count unchanged.

Remaining stubs in that directory are bespoke: custom matchers, instrumented hook-counting bases, or
stubs that rely on the default matcher. They are left alone on purpose.
