### PR TITLE
fix(security): quote SQL identifiers in SQLITEReader.build_query to prevent injection

### DIFF
--- a/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
+++ b/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
@@ -168,6 +168,24 @@ class SQLITEReader(ReadDB):
 
     @classmethod
     def build_query(cls, features: FeatureSet) -> str:
+        """Build the SELECT for the requested features against the resolved table.
+
+        Identifiers are quoted (see the inline notes below), which has two consequences
+        worth knowing about:
+
+        - An unknown column no longer raises ``no such column``. SQLite resolves an
+          unmatched double-quoted token to a string literal, so a misspelled feature name
+          yields a column filled with the name itself instead of an error. Features that
+          arrive through reader auto-discovery cannot hit this, because
+          ``check_feature_in_data_access`` has already matched the name against
+          ``PRAGMA table_info``. It is reachable when the caller pre-sets
+          ``BaseInputData``/``table_name`` in Options and so skips that lookup.
+        - A schema-qualified table name (``main.test_table``) is quoted as one identifier
+          and will not resolve. Every table name produced by discovery is a bare name from
+          ``sqlite_master``, so this only affects a caller passing a qualified name
+          explicitly. Splitting on ``.`` is deliberately not done here: it would reopen the
+          identifier position this quoting closes.
+        """
         query = "select "
 
         options = None

--- a/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
+++ b/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
@@ -7,6 +7,7 @@ import sqlite3
 from mloda.provider import FeatureSet
 from mloda.user import DataType
 from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
 
 
@@ -171,7 +172,10 @@ class SQLITEReader(ReadDB):
 
         options = None
         for feature in features.get_sorted_features():
-            query += f"{feature.name}, "
+            # Quote the column identifier so a crafted feature name cannot break out
+            # of the identifier position and inject SQL (CWE-89). Consistent with the
+            # quote_ident-based identifier handling in the SQL compute frameworks.
+            query += f"{quote_ident(str(feature.name))}, "
             options = feature.options
 
         query = query[:-2] + " "  # last comma is removed
@@ -183,7 +187,7 @@ class SQLITEReader(ReadDB):
                 "Options were not set. Call this after adding a feature to ensure Options are initialized."
             )
 
-        query += f"{cls.get_table(options)};"
+        query += f"{quote_ident(str(cls.get_table(options)))};"
 
         if query is None:
             raise ValueError("query cannot be None")

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
@@ -137,9 +137,49 @@ class TestSQLITEReader:
         query = SQLITEReader.build_query(feature_set)
 
         columns_part = query[len("select ") :].split(" from")[0]
-        columns = [col.strip() for col in columns_part.split(",")]
+        # Identifiers are double-quoted (quote_ident); strip the quotes to compare names.
+        columns = [col.strip().strip('"') for col in columns_part.split(",")]
 
         assert columns == sorted(names), f"build_query emitted columns {columns}, expected {sorted(names)}"
+
+    def test_build_query_quotes_identifiers_blocks_injection(self, temp_sqlite_db: Any) -> None:
+        """A crafted feature name must not break out of the SELECT identifier position (CWE-89).
+
+        Before quoting, a name like ``name FROM test_table UNION SELECT ...`` interpolated
+        raw into ``select {name} from test_table`` and executed as attacker SQL. With
+        quote_ident it becomes a single (non-existent) double-quoted identifier, so the DB
+        rejects it instead of leaking another table.
+        """
+        # Seed a secret table the injection would try to exfiltrate.
+        conn = sqlite3.connect(temp_sqlite_db)
+        conn.execute("CREATE TABLE IF NOT EXISTS secrets (api_key TEXT)")
+        conn.execute("DELETE FROM secrets")
+        conn.execute("INSERT INTO secrets VALUES ('SUPER_SECRET_KEY')")
+        conn.commit()
+        conn.close()
+
+        malicious = "name FROM test_table UNION SELECT api_key FROM secrets --"
+        feature_set = FeatureSet()
+        feature_set.add(
+            Feature(
+                malicious,
+                options=Options(context={"BaseInputData": (SQLITEReader, {"table_name": "test_table"})}),
+            )
+        )
+
+        query = SQLITEReader.build_query(feature_set)
+
+        # The whole crafted string is confined to one quoted identifier: no bare UNION/-- escapes.
+        assert '"name FROM test_table UNION SELECT api_key FROM secrets --"' in query
+        assert "UNION SELECT api_key" not in query.replace(
+            '"name FROM test_table UNION SELECT api_key FROM secrets --"', ""
+        )
+
+        # Executing it must NOT exfiltrate the secret. The crafted name stays inside the
+        # quoted identifier, so no UNION runs and 'SUPER_SECRET_KEY' never appears.
+        result, _ = SQLITEReader.read_db({"sqlite": temp_sqlite_db}, query)
+        leaked = {cell for row in result for cell in row}
+        assert "SUPER_SECRET_KEY" not in leaked
 
     def test_get_table_missing_options(self) -> None:
         with pytest.raises(ValueError, match="Options were not set."):

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
@@ -147,8 +147,15 @@ class TestSQLITEReader:
 
         Before quoting, a name like ``name FROM test_table UNION SELECT ...`` interpolated
         raw into ``select {name} from test_table`` and executed as attacker SQL. With
-        quote_ident it becomes a single (non-existent) double-quoted identifier, so the DB
-        rejects it instead of leaking another table.
+        quote_ident the whole string collapses into one double-quoted identifier, so the
+        UNION never runs and the ``secrets`` table is never read.
+
+        Note what SQLite actually does with that identifier: it does *not* reject it.
+        SQLite resolves an unmatched double-quoted token to a string literal (the legacy
+        double-quoted-string misfeature, disabled only by compiling with SQLITE_DQS=0), so
+        the query succeeds and returns the crafted text itself as the column value on every
+        row. That is harmless here (the payload is data, not SQL), and the assertion below
+        pins the property that matters: the secret never comes back.
         """
         # Seed a secret table the injection would try to exfiltrate.
         conn = sqlite3.connect(temp_sqlite_db)


### PR DESCRIPTION
## Summary

`SQLITEReader.build_query` builds its `SELECT` by interpolating feature names and the table name straight into the SQL string with no escaping:

```python
for feature in features.get_sorted_features():
    query += f"{feature.name}, "
...
query += f"{cls.get_table(options)};"
```

Feature names come from the public `Feature(name=...)` API, so a caller-controlled name flows unquoted into the query (CWE-89 / SQL injection). A crafted name performs cross-table exfiltration in a single statement:

```python
Feature("name FROM test_table UNION SELECT api_key FROM secrets --")
# -> select name FROM test_table UNION SELECT api_key FROM secrets -- from test_table;
# leaks the `secrets` table
```

## Fix

Route both the column identifiers and the table name through the existing `quote_ident` helper (`mloda_plugins/.../sql/sql_utils.py`) - the same identifier handling already used throughout the SQL compute frameworks (`sqlite_relation`, `sqlite_merge_engine`, etc.). The crafted name is then confined to a single double-quoted identifier and cannot break out, so no UNION runs and nothing leaks.

## Tests

- Added `test_build_query_quotes_identifiers_blocks_injection`: runs a UNION-based exfiltration payload end to end and asserts the secret is never returned.
- Updated `test_build_query_columns_sorted` to account for the now-quoted identifiers.
- Full `tests/.../test_read_dbs/` suite passes (61 passed).

Scope is intentionally minimal - one function, reusing the project's own quoting helper for consistency. This is a small follow-up building on the already-merged #1065.