### PR TITLE
fix: record why each filter probe lost and name the nearest miss

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -27,7 +27,7 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 
 Containment covers plugin raises only: a framework-owned raise (a two-readers conflict, a forwarded value contradicting the feature name, a rejected effective-options build) still aborts the whole resolution, because it reports a misconfiguration you have to fix.
 
-Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters`, as is a typed decline the matcher records; a framework-owned raise still aborts.
+Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters` as a `match hook` near-miss, as is a typed decline the matcher records; a framework-owned raise still aborts. Every entry names the gate that dropped the filter and that gate's reason.
 
 The probe runs per feature, but a matched filter attaches to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset).
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -221,14 +221,16 @@ return, and the drop is recorded in `GlobalFilter.dropped_filters`. A typed decl
 records lands in the same ledger, at DEBUG. A framework-owned raise still aborts.
 
 `GlobalFilter.dropped_filters` maps (FeatureGroup, filter feature name) to the gate that dropped the
-filter and that gate's reason. A plain `False` is an ordinary non-match and records nothing. A matcher
-defect takes the key from a stored near-miss; otherwise the first gate a filter loses at keeps it.
+filter and that gate's reason, for the current engine setup only. A plain `False` is an ordinary
+non-match and records nothing. A matcher defect takes the key from a stored near-miss; otherwise the
+deepest gate the filter reached keeps it, and two facts at one depth leave the first one in place.
 
 The option divergence warning fires only for a filter that actually attaches, once per distinct
 message per setup. A filter that matches no FeatureGroup at all is reported once after setup
 ("matched no feature group"), with its nearest miss appended when one was recorded: the deepest gate
 that filter reached, rendered as `<FeatureGroup> (<gate label>): <reason>`, for example `(scope)` when
-a `feature_group` scope excluded it.
+a `feature_group` scope excluded it. Two filters declared on one column name share the ledger key, so
+neither report can quote a fact and both stay the bare sentence.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -220,9 +220,15 @@ value whose truthiness test raises, that filter is a non-match for that probe, l
 return, and the drop is recorded in `GlobalFilter.dropped_filters`. A typed decline the matcher
 records lands in the same ledger, at DEBUG. A framework-owned raise still aborts.
 
+`GlobalFilter.dropped_filters` maps (FeatureGroup, filter feature name) to the gate that dropped the
+filter and that gate's reason. A plain `False` is an ordinary non-match and records nothing. A matcher
+defect takes the key from a stored near-miss; otherwise the first gate a filter loses at keeps it.
+
 The option divergence warning fires only for a filter that actually attaches, once per distinct
 message per setup. A filter that matches no FeatureGroup at all is reported once after setup
-("matched no feature group").
+("matched no feature group"), with its nearest miss appended when one was recorded: the deepest gate
+that filter reached, rendered as `<FeatureGroup> (<gate label>): <reason>`, for example `(scope)` when
+a `feature_group` scope excluded it.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -9,7 +9,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import option_key_is_present
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
-from mloda.core.abstract_plugins.components.utils import safe_field
+from mloda.core.abstract_plugins.components.utils import as_str, safe_field
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options, _isolate_forwarded_value
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
@@ -38,7 +38,9 @@ _STAGE_DEPTH: dict[EliminationStage, int] = {
     "domain": 3,
     "scope": 4,
     "capability": 5,
+    "frameworks_not_enabled": 5,
     "framework_pin": 6,
+    "links": 7,
 }
 
 
@@ -58,7 +60,7 @@ class GlobalFilter:
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
         3. `dropped_filters`: maps (feature group, filter feature name) to the `Elimination` naming the gate that
-           dropped it and why; a matcher defect outranks a stored near-miss, otherwise the first gate wins.
+           dropped it and why; a matcher defect outranks a stored near-miss, otherwise the deepest gate reached wins.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
         5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once this setup.
 
@@ -77,9 +79,13 @@ class GlobalFilter:
         self._warned_drops: set[tuple[type[FeatureGroup], str]] = set()
 
     def reset_match_tracking(self) -> None:
-        """Match and divergence-warning tracking is scoped to one engine setup."""
+        """Every match report is scoped to one engine setup, so a later setup names only what it consulted.
+        Each dedupe ledger clears with the facts it guards: one outliving them would lose that report for good."""
         self.matched_filter_uuids.clear()
+        self.dropped_filters.clear()
         self._warned_divergences.clear()
+        self._warned_drops.clear()
+        self._reported_falsy_matches.clear()
 
     def rehash_stored_filters(self) -> None:
         """Reinsert stored filters whose hashes went stale, so each one is findable in its own set again."""
@@ -209,6 +215,10 @@ class GlobalFilter:
 
     def _nearest_miss(self, filter_feature_name: str) -> str | None:
         """The captured fact of the deepest gate this filter reached, as the shared near-miss bullet."""
+        # The ledger keys on the name, so a name two declared filters share makes every fact under it
+        # unattributable to either of them.
+        if sum(1 for filter in self.filters if filter.name == filter_feature_name) > 1:
+            return None
         captured = [
             (feature_group, elimination)
             for (feature_group, name), elimination in self.dropped_filters.items()
@@ -330,8 +340,15 @@ class GlobalFilter:
     def _record_near_miss(
         self, feature_group: type[FeatureGroup], filter_feature_name: str, stage: EliminationStage, reason: str
     ) -> None:
-        """Record the gate one filter lost at against one feature group; the first fact recorded keeps the key."""
-        self.dropped_filters.setdefault((feature_group, filter_feature_name), Elimination(stage=stage, reason=reason))
+        """Record the gate one filter lost at against one feature group; the deepest gate reached keeps the key,
+        matching how `_nearest_miss` reads the ledger back."""
+        key = (feature_group, filter_feature_name)
+        stored = self.dropped_filters.get(key)
+        # A stored defect stays pinned to its key, and equal depth keeps the first fact recorded.
+        if stored is None or (
+            stored.stage != "matcher_error" and _STAGE_DEPTH.get(stored.stage, 0) < _STAGE_DEPTH.get(stage, 0)
+        ):
+            self.dropped_filters[key] = Elimination(stage=stage, reason=reason)
 
     def _record_rejected_filter(
         self, feature_group: type[FeatureGroup], filter_feature_name: str, rejection: MatchRejection
@@ -423,8 +440,9 @@ class GlobalFilter:
             compared = feat.domain.name
         else:
             # A plugin-owned read the gate already made; degraded because a log line is not worth a crash.
+            # as_str inside the guard: an unvalidated name's own __str__ must not run in the f-string below.
             compared = safe_field(
-                lambda: feature_group.get_domain().name,
+                lambda: as_str(feature_group.get_domain().name),
                 "<unreadable domain>",
                 field=f"{feature_group.get_class_name()}.get_domain",
             )

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -15,16 +15,31 @@ from mloda.core.abstract_plugins.components.options import Options, _isolate_for
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.match_hook import probe_match_criteria
+from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
 from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
 from mloda.core.prepare.identify_feature_group import matches_feature_group_scope, validate_single_framework_pin
+from mloda.core.prepare.resolution_failure_renderer import _candidate_sort_key, near_miss_text
+from mloda.core.prepare.resolution_types import Elimination, EliminationStage, rejection_elimination_stage
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+# How far down the gate chain each stage sits, so the nearest miss is the drop that got furthest. A matcher
+# defect ranks lowest on purpose: a crash says nothing about how far the filter got.
+_STAGE_DEPTH: dict[EliminationStage, int] = {
+    "matcher_error": 0,
+    "input_data": 1,
+    "value_rejection": 2,
+    "domain": 3,
+    "scope": 4,
+    "capability": 5,
+    "framework_pin": 6,
+}
 
 
 def _copy_feature_leaf(value: Any) -> Any:
@@ -42,7 +57,8 @@ class GlobalFilter:
            names and the uuid to the used single filter. This is used to track which features are associated with which filters for a specific feature group.
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
-        3. `dropped_filters`: maps (feature group, filter feature name) to the reason a matcher defect or a typed decline dropped it; a defect's reason outranks a stored decline's.
+        3. `dropped_filters`: maps (feature group, filter feature name) to the `Elimination` naming the gate that
+           dropped it and why; a matcher defect outranks a stored near-miss, otherwise the first gate wins.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
         5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once this setup.
 
@@ -51,7 +67,7 @@ class GlobalFilter:
         """
         self.filters: set[SingleFilter] = set()
         self.collection: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
-        self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
+        self.dropped_filters: dict[tuple[type[FeatureGroup], str], Elimination] = {}
         self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
         self.matched_filter_uuids: set[UUID] = set()
         self._warned_divergences: set[str] = set()
@@ -140,6 +156,8 @@ class GlobalFilter:
             -   we set the compute framework of the feature to determine the one of the filter feature,
             -   we consult the capability hook over the frameworks the filter would ride (its pin, else the feature's),
             -   we do not check links, as this is done earlier already and not needed anymore.
+
+        Each gate records why it closed at its own `continue`, so the gate predicates stay pure for other callers.
         """
 
         matched_filters: set[SingleFilter] = set()
@@ -147,17 +165,27 @@ class GlobalFilter:
             # We are making a deepcopy so that, we do not change the original filter.
             _filter = deepcopy(filter)
             _filter.filter_feature.options = self.unify_options(feat.options, _filter.filter_feature.options)
+            filter_name = str(_filter.filter_feature.name)
 
+            # criteria records its own drops: only it can tell a defect from a decline from a plain non-match.
             if not self.criteria(feature_group, _filter, data_access_collection):
                 continue
             if self.domain(_filter, feat.domain, feature_group) is False:
+                self._record_near_miss(
+                    feature_group, filter_name, "domain", self._domain_reason(_filter, feat, feature_group)
+                )
                 continue
             if self.feature_group_scope(_filter, feature_group) is False:
+                self._record_near_miss(feature_group, filter_name, "scope", "outside the requested feature group scope")
                 continue
             supported = self.capability(_filter, feat, feature_group)
             if supported is not None and not supported:
+                self._record_near_miss(feature_group, filter_name, "capability", self._capability_reason(_filter, feat))
                 continue
             if self.compute_framework(_filter, feat, supported) is False:
+                self._record_near_miss(
+                    feature_group, filter_name, "framework_pin", self._framework_pin_reason(_filter, feat)
+                )
                 continue
             # we don't check links, because this is not necessary as this is covered by the feature and feature group before
 
@@ -168,10 +196,35 @@ class GlobalFilter:
         return matched_filters
 
     def warn_on_unmatched_filters(self) -> None:
-        """Warn once per filter that matched no feature group this setup."""
+        """Warn once per filter that matched no feature group this setup, naming its nearest miss."""
         for filter in sorted(self.filters, key=lambda f: f.name):
-            if filter.uuid not in self.matched_filter_uuids:
-                logger.warning(f"Filter feature '{filter.name}' matched no feature group.")
+            if filter.uuid in self.matched_filter_uuids:
+                continue
+            message = f"Filter feature '{filter.name}' matched no feature group."
+            # SingleFilter.name reads through to filter_feature.name, which is what the recorders key on.
+            nearest = self._nearest_miss(filter.name)
+            if nearest is not None:
+                message += f" Nearest miss: {nearest}"
+            logger.warning(message)
+
+    def _nearest_miss(self, filter_feature_name: str) -> str | None:
+        """The captured fact of the deepest gate this filter reached, as the shared near-miss bullet."""
+        captured = [
+            (feature_group, elimination)
+            for (feature_group, name), elimination in self.dropped_filters.items()
+            if name == filter_feature_name
+        ]
+        if not captured:
+            return None
+        feature_group, elimination = min(captured, key=self._nearest_miss_key)
+        return near_miss_text(feature_group.__name__, elimination.stage, elimination.reason)
+
+    @staticmethod
+    def _nearest_miss_key(captured: tuple[type[FeatureGroup], Elimination]) -> tuple[int, str, str]:
+        """Deepest gate first, then the renderer's own candidate order, so insertion order decides nothing."""
+        feature_group, elimination = captured
+        name, module = _candidate_sort_key(feature_group)
+        return -_STAGE_DEPTH.get(elimination.stage, 0), name, module
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
         """Add the host options the filter feature omits, never rewriting a declared value. Layered on that repair,
@@ -270,28 +323,38 @@ class GlobalFilter:
         if probe.value_rejection is None and not probe.matched and not isinstance(probe.returned, bool):
             self._report_falsy_match(feature_group, str(filter.filter_feature.name), probe.returned)
         if probe.rejection is not None:
-            self._record_rejected_filter(feature_group, str(filter.filter_feature.name), probe.rejection.reason)
+            self._record_rejected_filter(feature_group, str(filter.filter_feature.name), probe.rejection)
             return False
         return probe.matched
 
-    def _record_rejected_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
+    def _record_near_miss(
+        self, feature_group: type[FeatureGroup], filter_feature_name: str, stage: EliminationStage, reason: str
+    ) -> None:
+        """Record the gate one filter lost at against one feature group; the first fact recorded keeps the key."""
+        self.dropped_filters.setdefault((feature_group, filter_feature_name), Elimination(stage=stage, reason=reason))
+
+    def _record_rejected_filter(
+        self, feature_group: type[FeatureGroup], filter_feature_name: str, rejection: MatchRejection
+    ) -> None:
         """Record a typed decline in the same ledger at DEBUG: a deliberate rejection is a near-miss, not a defect."""
-        self.dropped_filters.setdefault((feature_group, filter_feature_name), reason)
+        self._record_near_miss(
+            feature_group, filter_feature_name, rejection_elimination_stage(rejection.stage), rejection.reason
+        )
         logger.debug(
             "%s rejected filter feature '%s': %s; dropping that filter for this feature group.",
             # A plugin-owned read past the hook call's containment, so it degrades instead of escaping the seam.
             safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
             filter_feature_name,
-            reason,
+            rejection.reason,
         )
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
-        """Record the drop: defect drops warn once per key and take the key from a stored decline."""
+        """Record the drop: defect drops warn once per key and take the key from a stored near-miss."""
         key = (feature_group, filter_feature_name)
         first = key not in self._warned_drops
         self._warned_drops.add(key)
         if first:
-            self.dropped_filters[key] = reason
+            self.dropped_filters[key] = Elimination(stage="matcher_error", reason=reason)
         logger.log(
             logging.WARNING if first else logging.DEBUG,
             "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
@@ -350,6 +413,23 @@ class GlobalFilter:
 
         return False
 
+    @staticmethod
+    def _domain_reason(filter: SingleFilter, feat: Feature, feature_group: type[FeatureGroup]) -> str:
+        """Name the filter feature's declared domain and the domain it lost against."""
+        declared = filter.filter_feature.domain
+        # Only the drop path reaches this, and the gate reaches it only for a filter that declares a domain.
+        assert declared is not None
+        if feat.domain is not None:
+            compared = feat.domain.name
+        else:
+            # A plugin-owned read the gate already made; degraded because a log line is not worth a crash.
+            compared = safe_field(
+                lambda: feature_group.get_domain().name,
+                "<unreadable domain>",
+                field=f"{feature_group.get_class_name()}.get_domain",
+            )
+        return f"the filter feature's domain '{declared.name}' does not match '{compared}'"
+
     def feature_group_scope(self, filter: SingleFilter, feature_group: type[FeatureGroup]) -> bool:
         scope = filter.filter_feature.feature_group_scope
         return scope is None or matches_feature_group_scope(feature_group, scope)
@@ -367,6 +447,14 @@ class GlobalFilter:
             for cfw in ride_frameworks
             if feature_group.supports_compute_framework(filter.filter_feature.name, filter.filter_feature.options, cfw)
         }
+
+    @staticmethod
+    def _capability_reason(filter: SingleFilter, feat: Feature) -> str:
+        """Name the rejected ride frameworks, worded exactly as the canonical seam words its own drop."""
+        # The accepted subset is empty here, so the rejected set is the ride set: no second ask of the hook.
+        ride_frameworks = filter.filter_feature.compute_frameworks or feat.compute_frameworks or set()
+        rejected_names = sorted(cfw.get_class_name() for cfw in ride_frameworks)
+        return f"supports_compute_framework rejected {rejected_names}"
 
     def compute_framework(
         self, filter: SingleFilter, feat: Feature, supported: set[type[ComputeFramework]] | None = None
@@ -386,6 +474,14 @@ class GlobalFilter:
             return True
 
         return False
+
+    @staticmethod
+    def _framework_pin_reason(filter: SingleFilter, feat: Feature) -> str:
+        """Name the filter's pinned framework and the one the feature resolved to."""
+        # The pin degenerates to one entry, validated at add_filter.
+        pinned = filter.filter_feature.get_compute_framework().get_class_name()
+        resolved = feat.get_compute_framework().get_class_name()
+        return f"pinned compute framework '{pinned}' is not the feature's resolved '{resolved}'"
 
     def add_time_and_time_travel_filters(
         self,

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -17,6 +17,7 @@ from mloda.core.prepare.resolution_types import (
     PARTIAL_RECORDS_CAP,
     RenderFacts,
     ResolutionRecord,
+    rejection_elimination_stage,
 )
 from mloda.core.prepare.resolution_failure_renderer import (
     render_resolution_failure,
@@ -25,11 +26,7 @@ from mloda.core.prepare.resolution_failure_renderer import (
 )
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.domain import Domain
-from mloda.core.abstract_plugins.components.match_rejection import (
-    INPUT_DATA_OWNED_STAGE,
-    INPUT_DATA_STAGE,
-    MatchRejection,
-)
+from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
 from mloda.core.abstract_plugins.components.match_hook import probe_match_criteria
 from mloda.core.abstract_plugins.components.utils import (
     as_str,
@@ -441,14 +438,10 @@ class IdentifyFeatureGroupClass:
                     continue
                 rejection = self._value_rejection(feature_group)
                 if rejection is not None:
-                    # The stage is a free-form hint; only the two input-data stages are engine-known and both
-                    # surface as the public "input_data" elimination stage, the rest fall back.
-                    stage: EliminationStage = (
-                        "input_data"
-                        if rejection.stage in (INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
-                        else "value_rejection"
+                    # The shared mapper owns the projection, so both seams spell the taxonomy the same way.
+                    self._record_elimination(
+                        feature_group, rejection_elimination_stage(rejection.stage), rejection.reason
                     )
-                    self._record_elimination(feature_group, stage, rejection.reason)
                 continue
 
             if not self._filter_feature_group_by_domain(feature_group, feature):

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -75,12 +75,17 @@ def _stage_label(stage: EliminationStage) -> str:
     return label
 
 
+def near_miss_text(candidate_name: str, stage: EliminationStage, reason: str) -> str:
+    """One near-miss as '<Candidate> (<stage label>): <reason>'."""
+    return f"{candidate_name} ({_stage_label(stage)}): {reason}"
+
+
 def _render_near_miss_block(result: EvaluationResult, feature: Feature) -> str | None:
     """Shared section naming each eliminated near-miss candidate, its gate label, and its reason."""
     if not result.eliminations:
         return None
     lines = "\n".join(
-        f"  - {fg.__name__} ({_stage_label(elimination.stage)}): {elimination.reason}"
+        f"  - {near_miss_text(fg.__name__, elimination.stage, elimination.reason)}"
         for fg, elimination in sorted(result.eliminations.items(), key=lambda item: _candidate_sort_key(item[0]))
     )
     return f"Feature group(s) eliminated while matching '{str(feature.name)}':\n{lines}"

--- a/mloda/core/prepare/resolution_types.py
+++ b/mloda/core/prepare/resolution_types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.abstract_plugins.components.match_rejection import INPUT_DATA_OWNED_STAGE, INPUT_DATA_STAGE
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
@@ -31,6 +32,15 @@ EliminationStage = Literal[
 # A stage belongs here when its gate's hook cannot receive the feature name, so the outcome is the same for
 # every name the candidate declares.
 NAME_INDEPENDENT_STAGES: frozenset[EliminationStage] = frozenset({"domain", "scope", "frameworks_not_enabled", "links"})
+
+
+def rejection_elimination_stage(recorded_stage: str) -> EliminationStage:
+    """The elimination stage a recorded rejection's free-form stage hint maps onto."""
+    # Only the two input-data hints are engine-known; every other hint is provider text this side never
+    # validates, so it falls back. Shared, so the two seams cannot drift into two taxonomies.
+    if recorded_stage in (INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE):
+        return "input_data"
+    return "value_rejection"
 
 
 @dataclass(frozen=True)

--- a/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
+++ b/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
@@ -204,9 +204,12 @@ def test_required_when_rejected_filter_is_reported_as_unmatched_without_divergen
         )
 
     assert observed["collection_size"] == 0, f"the filter must not attach: {observed!r}"
-    assert _warnings_naming(caplog, FDG_REQ_KEY) == []
+    # The unmatched report names the key too, in its nearest-miss suffix; only a divergence warning is forbidden.
+    divergence = [message for message in _warnings_naming(caplog, FDG_REQ_KEY) if UNMATCHED_PHRASE not in message]
+    assert divergence == [], f"a rejected filter must report no divergence, got: {divergence!r}"
     unmatched = [message for message in _warnings_naming(caplog, FDG_TARGET) if UNMATCHED_PHRASE in message]
     assert len(unmatched) == 1, f"exactly one unmatched-filter warning expected, got: {caplog.text!r}"
+    assert FDG_REQ_KEY in unmatched[0], f"the report must carry the nearest miss's own reason, got: {unmatched[0]!r}"
 
 
 def test_engine_reports_a_filter_targeting_a_name_nothing_serves(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_core/test_filter/test_filter_elimination_reasons.py
+++ b/tests/test_core/test_filter/test_filter_elimination_reasons.py
@@ -11,7 +11,7 @@ import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar, TypeVar, cast, get_args
 
 import pytest
 
@@ -24,6 +24,7 @@ from mloda.core.abstract_plugins.components.match_rejection import (
 )
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter.global_filter import _STAGE_DEPTH
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, _render_near_miss_block
@@ -45,12 +46,14 @@ GROUP_DOMAIN_CLASS_NAME = "FerGroupDomainFG"
 CAPABILITY_REJECT_CLASS_NAME = "FerCapabilityRejectFG"
 SCOPE_TIE_A_CLASS_NAME = "FerScopeTieAFG"
 SCOPE_TIE_B_CLASS_NAME = "FerScopeTieBFG"
+UNREADABLE_DOMAIN_CLASS_NAME = "FerUnreadableDomainFG"
 
 MISSING_SCOPE = "FerNoSuchScope"  # a scope string naming no accessible class
 SCOPE_REASON = "outside the requested feature group scope"
 UNMATCHED_PHRASE = "matched no feature group"
 NEAREST_MISS_PHRASE = "Nearest miss: "
 FALSY_REPORT_FRAGMENT = "falsy non-bool"
+DROP_REPORT_FRAGMENT = "dropping that filter"  # the drop report's own wording, which no unmatched warning carries
 BARE_MESSAGE = f"Filter feature '{FILTER_FEATURE}' matched no feature group."
 
 RUNTIME_MESSAGE = "fer_runtime_boom"
@@ -62,6 +65,8 @@ UNKNOWN_STAGE = "fer_unknown_stage_hint"  # a free-form hint no engine stage kno
 GROUP_DOMAIN = "fer_group_domain"  # declared by the group-domain probe
 FEATURE_DOMAIN = "fer_feature_domain"  # carried by the resolved host feature
 OTHER_DOMAIN = "fer_other_domain"  # declared by the filter feature; matches neither
+SECOND_DOMAIN = "fer_second_domain"  # a second host domain, so two domain facts differ in their reason
+UNREADABLE_DOMAIN_FALLBACK = "<unreadable domain>"  # what a guarded read of a plugin's domain name degrades to
 
 MATCHER_ERROR_STAGE: EliminationStage = "matcher_error"
 VALUE_REJECTION_STAGE: EliminationStage = "value_rejection"
@@ -69,7 +74,9 @@ INPUT_DATA_ELIMINATION_STAGE: EliminationStage = "input_data"
 DOMAIN_STAGE: EliminationStage = "domain"
 SCOPE_STAGE: EliminationStage = "scope"
 CAPABILITY_STAGE: EliminationStage = "capability"
+FRAMEWORKS_NOT_ENABLED_STAGE: EliminationStage = "frameworks_not_enabled"
 FRAMEWORK_PIN_STAGE: EliminationStage = "framework_pin"
+LINKS_STAGE: EliminationStage = "links"
 
 # The canonical seam's own wording over the one framework the filter would ride.
 CAPABILITY_REASON = f"supports_compute_framework rejected {[PythonDictFramework.__name__]}"
@@ -82,6 +89,20 @@ STAGE_HINT_TABLE: tuple[tuple[str, EliminationStage], ...] = (
     (UNKNOWN_STAGE, VALUE_REJECTION_STAGE),
 )
 STAGE_HINT_IDS = [hint for hint, _ in STAGE_HINT_TABLE]
+
+# The gate order the depth table must express, shallowest rank first; the stages of one rank share a depth.
+EXPECTED_DEPTH_ORDER: tuple[tuple[EliminationStage, ...], ...] = (
+    (MATCHER_ERROR_STAGE,),
+    (INPUT_DATA_ELIMINATION_STAGE,),
+    (VALUE_REJECTION_STAGE,),
+    (DOMAIN_STAGE,),
+    (SCOPE_STAGE,),
+    (CAPABILITY_STAGE, FRAMEWORKS_NOT_ENABLED_STAGE),
+    (FRAMEWORK_PIN_STAGE,),
+    (LINKS_STAGE,),
+)
+
+REPEAT_RUNS = 8  # runs of one scenario, so a readout that rides set iteration order shows up as a differing one
 
 T = TypeVar("T")
 
@@ -100,6 +121,11 @@ def _messages(caplog: pytest.LogCaptureFixture, level: int) -> tuple[str, ...]:
     """Formatted messages GlobalFilter logged at exactly that level."""
     records = [record for record in caplog.records if record.name == GF_LOGGER_NAME and record.levelno == level]
     return tuple(record.getMessage() for record in records)
+
+
+def _carrying(messages: Sequence[str], fragment: str) -> tuple[str, ...]:
+    """The messages carrying `fragment`."""
+    return tuple(message for message in messages if fragment in message)
 
 
 def _stage_reason(stage: str) -> str:
@@ -144,6 +170,21 @@ def _host_feature(domain: str | None = None, pin: type[ComputeFramework] | None 
 def _plain_host() -> Feature:
     """The host carrying neither a domain nor a pin."""
     return _host_feature()
+
+
+def _domain_losing_host() -> Feature:
+    """A host whose own domain sends the filter out at the domain gate."""
+    return _host_feature(domain=FEATURE_DOMAIN, pin=PythonDictFramework)
+
+
+def _pin_losing_host() -> Feature:
+    """A host sharing the filter's domain, so the filter survives to lose at the framework pin."""
+    return _host_feature(domain=OTHER_DOMAIN, pin=PythonDictFramework)
+
+
+def _losing_pair() -> tuple[Feature, Feature]:
+    """Two filters on one name, one losing at the scope gate and one at the framework pin."""
+    return _filter_feature(scope=MISSING_SCOPE), _filter_feature(pin=PandasDataFrame)
 
 
 def _make_plain_fg() -> type[FeatureGroup]:
@@ -244,6 +285,30 @@ def _make_group_domain_fg() -> type[FeatureGroup]:
             return Domain(GROUP_DOMAIN)
 
     return FerGroupDomainFG
+
+
+class _RaisingName:
+    """A plugin's own object in a Domain's name slot, whose text form raises."""
+
+    def __str__(self) -> str:
+        raise RuntimeError(RUNTIME_MESSAGE)
+
+
+def _make_unreadable_domain_fg() -> type[FeatureGroup]:
+    """A plain matcher declaring a group domain whose name no f-string can render."""
+    gc.collect()
+
+    class FerUnreadableDomainFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def get_domain(cls) -> Domain:
+            # cast, because the annotation is exactly what a plugin is free to ignore here.
+            return Domain(cast(str, _RaisingName()))
+
+    return FerUnreadableDomainFG
 
 
 def _make_capability_reject_fg() -> type[FeatureGroup]:
@@ -412,19 +477,24 @@ class _LedgerSnapshot:
     unmatched: tuple[str, ...]
 
 
-def _drive_matching(
-    makes: Sequence[_Factory],
-    caplog: pytest.LogCaptureFixture,
-    filter_feature: Feature | str = FILTER_FEATURE,
-    make_host: Callable[[], Feature] = _plain_host,
-    calls: int = 1,
-    warn_unmatched: bool = False,
-) -> _LedgerSnapshot:
-    """Match one declared filter against every probe, `calls` times each, on ONE fresh GlobalFilter."""
-    caplog.clear()
-    groups = [make() for make in makes]
+def _new_global_filter(filter_features: Sequence[Feature | str]) -> GlobalFilter:
+    """One GlobalFilter declaring an EQUAL filter per given filter feature, each on its own parameter."""
     global_filter = GlobalFilter()
-    global_filter.add_filter(filter_feature, FilterType.EQUAL, {"value": 1})
+    for index, filter_feature in enumerate(filter_features, start=1):
+        global_filter.add_filter(filter_feature, FilterType.EQUAL, {"value": index})
+    return global_filter
+
+
+def _run_setup(
+    global_filter: GlobalFilter,
+    groups: list[type[FeatureGroup]],
+    caplog: pytest.LogCaptureFixture,
+    make_hosts: Sequence[Callable[[], Feature]],
+    calls: int,
+    warn_unmatched: bool,
+) -> _LedgerSnapshot:
+    """One engine setup: match every declared filter against every probe, once per host, `calls` times each."""
+    caplog.clear()
     matched: set[SingleFilter] | None = None
     names: tuple[str, ...] = ()
     escaped: str | None = None
@@ -433,11 +503,17 @@ def _drive_matching(
             for _ in range(calls):
                 # By index: no loop local may keep a probe class alive for a failing assert's traceback.
                 for index in range(len(groups)):
-                    matched, call_escaped = _capture(
-                        partial(global_filter.identify_matched_filters, groups[index], make_host(), None)
-                    )
-                    escaped = escaped or call_escaped
-                    names = (*names, *sorted(single.name for single in matched or ()))
+                    for host_index in range(len(make_hosts)):
+                        matched, call_escaped = _capture(
+                            partial(
+                                global_filter.identify_matched_filters,
+                                groups[index],
+                                make_hosts[host_index](),
+                                None,
+                            )
+                        )
+                        escaped = escaped or call_escaped
+                        names = (*names, *sorted(single.name for single in matched or ()))
             if warn_unmatched:
                 global_filter.warn_on_unmatched_filters()
         rows, ledger_error = _capture(partial(_ledger_rows, global_filter))
@@ -454,8 +530,74 @@ def _drive_matching(
         )
     finally:
         groups.clear()
-        del groups, global_filter, matched
+        del groups, matched
         gc.collect()
+
+
+def _drive(
+    makes: Sequence[_Factory],
+    caplog: pytest.LogCaptureFixture,
+    filter_features: Sequence[Feature | str] = (FILTER_FEATURE,),
+    make_hosts: Sequence[Callable[[], Feature]] = (_plain_host,),
+    calls: int = 1,
+    warn_unmatched: bool = False,
+) -> _LedgerSnapshot:
+    """One setup on ONE fresh GlobalFilter carrying every declared filter."""
+    groups = [make() for make in makes]
+    global_filter = _new_global_filter(filter_features)
+    try:
+        return _run_setup(global_filter, groups, caplog, make_hosts, calls, warn_unmatched)
+    finally:
+        groups.clear()
+        del groups, global_filter
+        gc.collect()
+
+
+def _drive_matching(
+    makes: Sequence[_Factory],
+    caplog: pytest.LogCaptureFixture,
+    filter_feature: Feature | str = FILTER_FEATURE,
+    make_host: Callable[[], Feature] = _plain_host,
+    calls: int = 1,
+    warn_unmatched: bool = False,
+) -> _LedgerSnapshot:
+    """Match one declared filter against every probe, `calls` times each, on ONE fresh GlobalFilter."""
+    return _drive(makes, caplog, (filter_feature,), (make_host,), calls, warn_unmatched)
+
+
+def _drive_setups(
+    makes: Sequence[_Factory],
+    setups: Sequence[Sequence[int]],
+    caplog: pytest.LogCaptureFixture,
+    filter_feature: Feature | str = FILTER_FEATURE,
+    make_host: Callable[[], Feature] = _plain_host,
+) -> tuple[_LedgerSnapshot, ...]:
+    """One readout per engine setup, each consulting the probes it names by index, with a reset between them."""
+    groups = [make() for make in makes]
+    global_filter = _new_global_filter((filter_feature,))
+    snapshots: list[_LedgerSnapshot] = []
+    try:
+        for index in range(len(setups)):
+            if index:
+                global_filter.reset_match_tracking()
+            consulted = [groups[probe] for probe in setups[index]]
+            snapshots.append(_run_setup(global_filter, consulted, caplog, (make_host,), 1, True))
+        return tuple(snapshots)
+    finally:
+        groups.clear()
+        del groups, global_filter
+        gc.collect()
+
+
+def _drive_shared_name(caplog: pytest.LogCaptureFixture, filter_features: Sequence[Feature]) -> _LedgerSnapshot:
+    """Drive filters that all declare one name against a single plain probe whose host loses the pin."""
+    return _drive(
+        [_make_plain_fg],
+        caplog,
+        filter_features=filter_features,
+        make_hosts=(partial(_host_feature, pin=PythonDictFramework),),
+        warn_unmatched=True,
+    )
 
 
 @dataclass(frozen=True)
@@ -855,3 +997,184 @@ class TestTheUnmatchedWarningNamesTheNearestMiss:
 
         assert snapshot.names == (FILTER_FEATURE,), f"the filter must attach, got: {snapshot.names}"
         assert snapshot.unmatched == (), f"an attached filter is not unmatched, got: {snapshot.unmatched}"
+
+
+class TestEveryMatchReportIsScopedToOneSetup:
+    """A GlobalFilter outlives the setup that filled it, so reset_match_tracking clears every match report."""
+
+    def test_the_reset_drops_the_previous_setups_fact(self, caplog: pytest.LogCaptureFixture) -> None:
+        first, second = _drive_setups(
+            [_make_plain_fg, _make_plain_decline_fg],
+            [[0], [1]],
+            caplog,
+            filter_feature=_filter_feature(scope=MISSING_SCOPE),
+        )
+
+        assert first.rows == ((PLAIN_CLASS_NAME, FILTER_FEATURE, SCOPE_STAGE, SCOPE_REASON),), (
+            f"the first setup must capture its scope fact, got: {first.rows}"
+        )
+        assert second.rows == (), f"the reset must clear the previous setup's facts, got: {second.rows}"
+        assert second.unmatched == (BARE_MESSAGE,), (
+            f"with nothing captured this setup, the message is the bare sentence, got: {second.unmatched}"
+        )
+
+    def test_a_group_consulted_only_before_the_reset_is_never_named(self, caplog: pytest.LogCaptureFixture) -> None:
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+        first, second = _drive_setups(
+            [_make_plain_fg, _make_scope_tie_b_fg],
+            [[0], [1]],
+            caplog,
+            filter_feature=_filter_feature(scope=MISSING_SCOPE),
+        )
+
+        assert _carrying(first.unmatched, PLAIN_CLASS_NAME) == first.unmatched, (
+            f"the first setup must name the group it consulted, got: {first.unmatched}"
+        )
+        expected_bullet = near_miss_text(SCOPE_TIE_B_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)
+        assert second.unmatched == (f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{expected_bullet}",), (
+            f"only a group this setup consulted may be named, got: {second.unmatched}"
+        )
+
+    def test_a_matcher_defect_warns_once_in_each_setup(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The same probe class in both setups: the WARNING dedupe is per setup, not per process."""
+        first, second = _drive_setups([_make_matcher_error_fg], [[0], [0]], caplog)
+
+        assert len(_carrying(first.warnings, DROP_REPORT_FRAGMENT)) == 1, (
+            f"the defect must warn once in the first setup, got: {first.warnings}"
+        )
+        reported = _carrying(second.warnings, DROP_REPORT_FRAGMENT)
+        assert len(reported) == 1, f"the defect must warn again in a new setup, got: {second.warnings}"
+        assert RUNTIME_MESSAGE in reported[0], f"the report must carry the raise message: {reported[0]}"
+        assert len(second.rows) == 1, f"exactly one fact for the key, got: {second.rows}"
+        _, _, stage, reason = second.rows[0]
+        assert stage == MATCHER_ERROR_STAGE, f"the new setup must re-record the defect, got stage: {stage}"
+        assert RUNTIME_MESSAGE in reason, f"the re-recorded reason must carry the raise message: {reason}"
+
+    def test_a_falsy_non_bool_is_reported_again_in_a_new_setup(self, caplog: pytest.LogCaptureFixture) -> None:
+        first, second = _drive_setups([_make_falsy_decline_fg], [[0], [0]], caplog)
+
+        assert len(_carrying(first.warnings, FALSY_REPORT_FRAGMENT)) == 1, (
+            f"the detached filter must be reported in the first setup, got: {first.warnings}"
+        )
+        assert len(_carrying(second.warnings, FALSY_REPORT_FRAGMENT)) == 1, (
+            f"a new setup must report the detached filter again, got: {second.warnings}"
+        )
+
+
+class TestTwoFiltersOnOneNameAttributeNothing:
+    """The ledger keys on the filter feature NAME, so a shared name cannot attribute a fact to one filter."""
+
+    def test_both_warnings_are_the_bare_sentence(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One filter loses at scope and the other at the pin; neither message may quote the other's fact."""
+        snapshot = _drive_shared_name(caplog, _losing_pair())
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"neither filter may attach, got: {snapshot.names}"
+        assert snapshot.unmatched == (BARE_MESSAGE, BARE_MESSAGE), (
+            f"an unattributable fact must not be quoted, got: {snapshot.unmatched}"
+        )
+
+    def test_one_filter_on_that_name_still_names_its_nearest_miss(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The guard covers the ambiguous case only: a single filter still gets its suffix."""
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+        snapshot = _drive_shared_name(caplog, (_filter_feature(scope=MISSING_SCOPE),))
+
+        expected = f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{near_miss_text(PLAIN_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)}"
+        assert snapshot.unmatched == (expected,), f"one filter on the name keeps its suffix, got: {snapshot.unmatched}"
+
+    def test_the_pair_renders_the_same_way_on_every_run(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Which of the two facts the ledger keeps rides set iteration order; the messages must not."""
+        runs = tuple(_drive_shared_name(caplog, _losing_pair()).unmatched for _ in range(REPEAT_RUNS))
+
+        assert set(runs) == {(BARE_MESSAGE, BARE_MESSAGE)}, f"the runs diverged: {sorted(set(runs))}"
+
+
+class TestTheDeepestFactKeepsTheKey:
+    """The write policy must match the read policy: within one key, the deepest gate reached is the stored fact."""
+
+    @pytest.mark.parametrize(
+        "make_hosts",
+        [
+            pytest.param((_domain_losing_host, _pin_losing_host), id="domain_first"),
+            pytest.param((_pin_losing_host, _domain_losing_host), id="pin_first"),
+        ],
+    )
+    def test_the_deepest_fact_survives_whichever_host_ran_first(
+        self, make_hosts: tuple[Callable[[], Feature], ...], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two hosts drive one (group, filter) key; input_features is a set, so host order decides nothing."""
+        snapshot = _drive(
+            [_make_plain_fg],
+            caplog,
+            filter_features=(_filter_feature(domain=OTHER_DOMAIN, pin=PandasDataFrame),),
+            make_hosts=make_hosts,
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.names == (), f"both hosts must lose their gate, got: {snapshot.names}"
+        assert len(snapshot.rows) == 1, f"exactly one fact for the key, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == FRAMEWORK_PIN_STAGE, f"the deepest gate reached keeps the key, got stage: {stage}"
+        assert PandasDataFrame.__name__ in reason, f"the reason must name the filter's pinned framework: {reason}"
+
+    def test_two_facts_at_one_depth_keep_the_first(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Deepest-wins must not become last-wins: at equal depth the first fact recorded still owns the key."""
+        snapshot = _drive(
+            [_make_plain_fg],
+            caplog,
+            filter_features=(_filter_feature(domain=OTHER_DOMAIN),),
+            make_hosts=(partial(_host_feature, domain=FEATURE_DOMAIN), partial(_host_feature, domain=SECOND_DOMAIN)),
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert len(snapshot.rows) == 1, f"exactly one fact for the key, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == DOMAIN_STAGE, f"both hosts lose at the domain gate, got stage: {stage}"
+        assert FEATURE_DOMAIN in reason, f"the first fact at one depth keeps the key: {reason}"
+        assert SECOND_DOMAIN not in reason, f"an equally deep fact must not displace it: {reason}"
+
+
+class TestEveryEliminationStageCarriesADepth:
+    """A stage the depth table misses is silently ranked with a matcher defect, the deliberately lowest rank."""
+
+    def test_every_stage_carries_a_depth(self) -> None:
+        """dict[EliminationStage, int] does not force an entry per member, so the table is pinned complete here."""
+        unranked = sorted(set(get_args(EliminationStage)) - set(_STAGE_DEPTH))
+        assert unranked == [], f"_STAGE_DEPTH ranks no depth for {unranked}"
+
+    def test_the_expected_order_names_every_stage(self) -> None:
+        """A tenth stage fails here until someone states where it ranks."""
+        named = {stage for rank in EXPECTED_DEPTH_ORDER for stage in rank}
+        assert named == set(get_args(EliminationStage)), f"the expected order names {sorted(named)}"
+
+    def test_the_depths_rank_the_gates_in_order(self) -> None:
+        missing = [stage for rank in EXPECTED_DEPTH_ORDER for stage in rank if stage not in _STAGE_DEPTH]
+        assert missing == [], f"_STAGE_DEPTH ranks no depth for {missing}"
+
+        ranks = [sorted({_STAGE_DEPTH[stage] for stage in rank}) for rank in EXPECTED_DEPTH_ORDER]
+        for index in range(len(ranks)):
+            assert len(ranks[index]) == 1, f"{EXPECTED_DEPTH_ORDER[index]} must share one depth, got: {ranks[index]}"
+        depths = [rank[0] for rank in ranks]
+        assert depths == sorted(set(depths)), f"each rank must sit strictly deeper than the last, got: {depths}"
+
+
+class TestAnUnreadableGroupDomainDegrades:
+    """get_domain().name is plugin-owned and unvalidated, so the read that renders it must degrade in its guard."""
+
+    def test_an_unreadable_domain_name_degrades_to_the_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching(
+            [_make_unreadable_domain_fg], caplog, filter_feature=_filter_feature(domain=OTHER_DOMAIN)
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.names == (), f"a diverging domain must attach no filter, got: {snapshot.names}"
+        assert len(snapshot.rows) == 1, f"the domain fact must still be recorded, got: {snapshot.rows}"
+        name, _, stage, reason = snapshot.rows[0]
+        assert name == UNREADABLE_DOMAIN_CLASS_NAME, f"wrong key: {name}"
+        assert stage == DOMAIN_STAGE, f"the domain gate owns this drop, got stage: {stage}"
+        assert OTHER_DOMAIN in reason, f"the reason must name the filter feature's declared domain: {reason}"
+        assert UNREADABLE_DOMAIN_FALLBACK in reason, f"an unreadable domain name must degrade: {reason}"

--- a/tests/test_core/test_filter/test_filter_elimination_reasons.py
+++ b/tests/test_core/test_filter/test_filter_elimination_reasons.py
@@ -1,0 +1,857 @@
+"""Every gate GlobalFilter.identify_matched_filters closes records WHY, as a stage plus a reason, and the
+unmatched-filter warning names each filter's nearest miss from those facts. Probe classes live inside factory
+functions and are dropped before any assert runs, so a failing assert never pins a throwaway FeatureGroup and
+trips the no-leak fixture in tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, ClassVar, TypeVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_OWNED_STAGE,
+    INPUT_DATA_STAGE,
+    record_match_rejection,
+)
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, _render_near_miss_block
+from mloda.core.prepare.resolution_types import Elimination, EliminationStage, EvaluationResult
+from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, SingleFilter
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+GF_LOGGER_NAME = "mloda.core.filter.global_filter"
+
+HOST_FEATURE = "fer_host_feat"  # the resolved feature the filters are matched against
+FILTER_FEATURE = "fer_filter_feat"  # the declared filter feature every probe is asked about
+
+PLAIN_CLASS_NAME = "FerPlainFG"
+MATCHER_ERROR_CLASS_NAME = "FerMatcherErrorFG"
+STAGE_DECLINE_CLASS_NAME = "FerStageDeclineFG"
+GROUP_DOMAIN_CLASS_NAME = "FerGroupDomainFG"
+CAPABILITY_REJECT_CLASS_NAME = "FerCapabilityRejectFG"
+SCOPE_TIE_A_CLASS_NAME = "FerScopeTieAFG"
+SCOPE_TIE_B_CLASS_NAME = "FerScopeTieBFG"
+
+MISSING_SCOPE = "FerNoSuchScope"  # a scope string naming no accessible class
+SCOPE_REASON = "outside the requested feature group scope"
+UNMATCHED_PHRASE = "matched no feature group"
+NEAREST_MISS_PHRASE = "Nearest miss: "
+FALSY_REPORT_FRAGMENT = "falsy non-bool"
+BARE_MESSAGE = f"Filter feature '{FILTER_FEATURE}' matched no feature group."
+
+RUNTIME_MESSAGE = "fer_runtime_boom"
+RUNTIME_TYPE_NAME = "RuntimeError"
+DEFECT_MESSAGE = "fer_defect_after_decline"
+DECLINE_REASON = "fer_decline_reason"
+UNKNOWN_STAGE = "fer_unknown_stage_hint"  # a free-form hint no engine stage knows
+
+GROUP_DOMAIN = "fer_group_domain"  # declared by the group-domain probe
+FEATURE_DOMAIN = "fer_feature_domain"  # carried by the resolved host feature
+OTHER_DOMAIN = "fer_other_domain"  # declared by the filter feature; matches neither
+
+MATCHER_ERROR_STAGE: EliminationStage = "matcher_error"
+VALUE_REJECTION_STAGE: EliminationStage = "value_rejection"
+INPUT_DATA_ELIMINATION_STAGE: EliminationStage = "input_data"
+DOMAIN_STAGE: EliminationStage = "domain"
+SCOPE_STAGE: EliminationStage = "scope"
+CAPABILITY_STAGE: EliminationStage = "capability"
+FRAMEWORK_PIN_STAGE: EliminationStage = "framework_pin"
+
+# The canonical seam's own wording over the one framework the filter would ride.
+CAPABILITY_REASON = f"supports_compute_framework rejected {[PythonDictFramework.__name__]}"
+
+# (recorded free-form hint, the elimination stage it maps onto).
+STAGE_HINT_TABLE: tuple[tuple[str, EliminationStage], ...] = (
+    (INPUT_DATA_STAGE, INPUT_DATA_ELIMINATION_STAGE),
+    (INPUT_DATA_OWNED_STAGE, INPUT_DATA_ELIMINATION_STAGE),
+    (VALUE_REJECTION_STAGE, VALUE_REJECTION_STAGE),
+    (UNKNOWN_STAGE, VALUE_REJECTION_STAGE),
+)
+STAGE_HINT_IDS = [hint for hint, _ in STAGE_HINT_TABLE]
+
+T = TypeVar("T")
+
+_Factory = Callable[[], type[FeatureGroup]]
+
+
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (red-phase probe: an escape is the fact under test)
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _messages(caplog: pytest.LogCaptureFixture, level: int) -> tuple[str, ...]:
+    """Formatted messages GlobalFilter logged at exactly that level."""
+    records = [record for record in caplog.records if record.name == GF_LOGGER_NAME and record.levelno == level]
+    return tuple(record.getMessage() for record in records)
+
+
+def _stage_reason(stage: str) -> str:
+    """The reason text the stage-recording probe stores for one recorded hint."""
+    return f"fer_stage_reason_{stage}"
+
+
+def _fact_of(recorded: Any) -> tuple[str, str]:
+    """(stage, reason) of one recorded fact. Any, because the ledger's value type is what this suite pins."""
+    return str(recorded.stage), str(recorded.reason)
+
+
+def _ledger_rows(global_filter: GlobalFilter) -> tuple[tuple[str, str, str, str], ...]:
+    """(group class name, filter feature name, stage, reason) per recorded fact, sorted. Holds no class."""
+    rows: list[tuple[str, str, str, str]] = []
+    for key, recorded in global_filter.dropped_filters.items():
+        stage, reason = _fact_of(recorded)
+        rows.append((key[0].get_class_name(), key[1], stage, reason))
+    return tuple(sorted(rows))
+
+
+def _filter_feature(
+    domain: str | None = None,
+    scope: str | None = None,
+    pin: type[ComputeFramework] | None = None,
+) -> Feature:
+    """The module's filter feature, declared with the given domain, scope and single framework pin."""
+    feature = Feature(FILTER_FEATURE, domain=domain, feature_group=scope)
+    if pin is not None:
+        feature.compute_frameworks = {pin}
+    return feature
+
+
+def _host_feature(domain: str | None = None, pin: type[ComputeFramework] | None = None) -> Feature:
+    """The resolved feature the filters are matched against."""
+    feature = Feature(HOST_FEATURE, domain=domain)
+    if pin is not None:
+        feature.compute_frameworks = {pin}
+    return feature
+
+
+def _plain_host() -> Feature:
+    """The host carrying neither a domain nor a pin."""
+    return _host_feature()
+
+
+def _make_plain_fg() -> type[FeatureGroup]:
+    """A throwaway group matching both module names through the default criteria."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class FerPlainFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+    return FerPlainFG
+
+
+def _make_scope_tie_a_fg() -> type[FeatureGroup]:
+    """A plain matcher whose class name sorts before its twin's."""
+    gc.collect()
+
+    class FerScopeTieAFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+    return FerScopeTieAFG
+
+
+def _make_scope_tie_b_fg() -> type[FeatureGroup]:
+    """A plain matcher whose class name sorts after its twin's."""
+    gc.collect()
+
+    class FerScopeTieBFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+    return FerScopeTieBFG
+
+
+def _make_matcher_error_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook raises a plain RuntimeError for the filter feature."""
+    gc.collect()
+
+    class FerMatcherErrorFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                raise RuntimeError(RUNTIME_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerMatcherErrorFG
+
+
+def _make_stage_decline_fg(stage: str) -> type[FeatureGroup]:
+    """A throwaway group whose hook records under the caller's stage hint and declines the filter feature."""
+    gc.collect()
+
+    class FerStageDeclineFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                record_match_rejection(cls.__name__, _stage_reason(stage), stage=stage)
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerStageDeclineFG
+
+
+def _make_group_domain_fg() -> type[FeatureGroup]:
+    """A plain matcher declaring a non-default group domain."""
+    gc.collect()
+
+    class FerGroupDomainFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def get_domain(cls) -> Domain:
+            return Domain(GROUP_DOMAIN)
+
+    return FerGroupDomainFG
+
+
+def _make_capability_reject_fg() -> type[FeatureGroup]:
+    """A plain matcher whose capability hook rejects every framework."""
+    gc.collect()
+
+    class FerCapabilityRejectFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def supports_compute_framework(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            return False
+
+    return FerCapabilityRejectFG
+
+
+def _make_plain_decline_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook returns a literal False for the filter feature, recording nothing."""
+    gc.collect()
+
+    class FerPlainDeclineFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerPlainDeclineFG
+
+
+def _make_falsy_decline_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook returns None for the filter feature, recording nothing."""
+    gc.collect()
+
+    class FerFalsyDeclineFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> Any:  # Any, not bool: the falsy non-bool return is the case under test.
+            if str(feature_name) == FILTER_FEATURE:
+                return None
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerFalsyDeclineFG
+
+
+def _make_decline_then_defect_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook declines with a recorded reason once, then raises on the next ask."""
+    gc.collect()
+
+    class FerDeclineThenDefectFG(FeatureGroup):
+        declined: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                if not cls.declined:
+                    cls.declined = True
+                    record_match_rejection(cls.__name__, DECLINE_REASON)
+                    return False
+                raise RuntimeError(DEFECT_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerDeclineThenDefectFG
+
+
+def _make_defect_then_match_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook raises once, then matches the filter feature on every later ask."""
+    gc.collect()
+
+    class FerDefectThenMatchFG(FeatureGroup):
+        raised: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE and not cls.raised:
+                cls.raised = True
+                raise RuntimeError(RUNTIME_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerDefectThenMatchFG
+
+
+def _make_match_then_decline_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook matches the filter feature once, then declines with a recorded reason."""
+    gc.collect()
+
+    class FerMatchThenDeclineFG(FeatureGroup):
+        matched: ClassVar[bool] = False
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                if not cls.matched:
+                    cls.matched = True
+                    return True
+                record_match_rejection(cls.__name__, DECLINE_REASON)
+                return False
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerMatchThenDeclineFG
+
+
+@dataclass(frozen=True)
+class _LedgerSnapshot:
+    """Plain-data readout of one matching pass. Holds no class, no filter and no recorded fact object."""
+
+    escaped: str | None
+    names: tuple[str, ...]
+    fact_types: tuple[str, ...]
+    # Set when reading a stored fact raised, which is how a bare-string ledger reports itself.
+    ledger_error: str | None
+    rows: tuple[tuple[str, str, str, str], ...]
+    warnings: tuple[str, ...]
+    debugs: tuple[str, ...]
+    unmatched: tuple[str, ...]
+
+
+def _drive_matching(
+    makes: Sequence[_Factory],
+    caplog: pytest.LogCaptureFixture,
+    filter_feature: Feature | str = FILTER_FEATURE,
+    make_host: Callable[[], Feature] = _plain_host,
+    calls: int = 1,
+    warn_unmatched: bool = False,
+) -> _LedgerSnapshot:
+    """Match one declared filter against every probe, `calls` times each, on ONE fresh GlobalFilter."""
+    caplog.clear()
+    groups = [make() for make in makes]
+    global_filter = GlobalFilter()
+    global_filter.add_filter(filter_feature, FilterType.EQUAL, {"value": 1})
+    matched: set[SingleFilter] | None = None
+    names: tuple[str, ...] = ()
+    escaped: str | None = None
+    try:
+        with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
+            for _ in range(calls):
+                # By index: no loop local may keep a probe class alive for a failing assert's traceback.
+                for index in range(len(groups)):
+                    matched, call_escaped = _capture(
+                        partial(global_filter.identify_matched_filters, groups[index], make_host(), None)
+                    )
+                    escaped = escaped or call_escaped
+                    names = (*names, *sorted(single.name for single in matched or ()))
+            if warn_unmatched:
+                global_filter.warn_on_unmatched_filters()
+        rows, ledger_error = _capture(partial(_ledger_rows, global_filter))
+        warnings = _messages(caplog, logging.WARNING)
+        return _LedgerSnapshot(
+            escaped=escaped,
+            names=tuple(sorted(names)),
+            fact_types=tuple(sorted(type(fact).__name__ for fact in global_filter.dropped_filters.values())),
+            ledger_error=ledger_error,
+            rows=rows or (),
+            warnings=warnings,
+            debugs=_messages(caplog, logging.DEBUG),
+            unmatched=tuple(message for message in warnings if UNMATCHED_PHRASE in message),
+        )
+    finally:
+        groups.clear()
+        del groups, global_filter, matched
+        gc.collect()
+
+
+@dataclass(frozen=True)
+class _CanonicalSnapshot:
+    """Plain-data readout of one evaluate() pass. Holds no class and no Elimination object."""
+
+    escaped: str | None
+    identified: tuple[str, ...]
+    eliminations: tuple[tuple[str, str, str], ...]
+
+
+def _canonical_snapshot(result: EvaluationResult | None, escaped: str | None) -> _CanonicalSnapshot:
+    """Fold one evaluate() outcome to plain data."""
+    if result is None:
+        return _CanonicalSnapshot(escaped=escaped, identified=(), eliminations=())
+    return _CanonicalSnapshot(
+        escaped=escaped,
+        identified=tuple(sorted(g.get_class_name() for g in result.identified)),
+        eliminations=tuple(
+            sorted((g.get_class_name(), str(e.stage), str(e.reason)) for g, e in result.eliminations.items())
+        ),
+    )
+
+
+def _drive_canonical(make: _Factory) -> _CanonicalSnapshot:
+    """Evaluate the filter feature against the probe alone and fold the eliminations to plain tuples."""
+    fg = make()
+    plugins: FeatureGroupEnvironmentMapping = {fg: {PythonDictFramework}}
+    result = None
+    try:
+        result, escaped = _capture(partial(IdentifyFeatureGroupClass.evaluate, Feature(FILTER_FEATURE), plugins, None))
+        snapshot = _canonical_snapshot(result, escaped)
+        del result
+        result = None
+        return snapshot
+    finally:
+        del fg, plugins, result
+        gc.collect()
+
+
+def _drive_near_miss_block() -> tuple[str | None, str]:
+    """(the rendered block, the same block rebuilt from the shared bullet) over two eliminated candidates."""
+    from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+    # Built before the classes exist, so a raising helper leaves no throwaway class behind.
+    expected = "\n".join(
+        (
+            f"Feature group(s) eliminated while matching '{FILTER_FEATURE}':",
+            f"  - {near_miss_text(SCOPE_TIE_A_CLASS_NAME, VALUE_REJECTION_STAGE, DECLINE_REASON)}",
+            f"  - {near_miss_text(SCOPE_TIE_B_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)}",
+        )
+    )
+    fg_a = _make_scope_tie_a_fg()
+    fg_b = _make_scope_tie_b_fg()
+    result = None
+    try:
+        # B first: the block owns the ordering, so insertion order must not decide it.
+        eliminations = {
+            fg_b: Elimination(stage=SCOPE_STAGE, reason=SCOPE_REASON),
+            fg_a: Elimination(stage=VALUE_REJECTION_STAGE, reason=DECLINE_REASON),
+        }
+        result = EvaluationResult(identified={}, eliminations=eliminations)
+        rendered = _render_near_miss_block(result, Feature(FILTER_FEATURE))
+        del eliminations, result
+        result = None
+        return rendered, expected
+    finally:
+        del fg_a, fg_b, result
+        gc.collect()
+
+
+class TestTheSharedStageMapper:
+    """One mapper projects a recorded free-form stage hint onto its elimination stage for both seams."""
+
+    @pytest.mark.parametrize(("hint", "expected"), STAGE_HINT_TABLE, ids=STAGE_HINT_IDS)
+    def test_the_mapper_table(self, hint: str, expected: EliminationStage) -> None:
+        from mloda.core.prepare.resolution_types import rejection_elimination_stage
+
+        assert rejection_elimination_stage(hint) == expected, f"'{hint}' must map onto '{expected}'"
+
+    @pytest.mark.parametrize(("hint", "expected"), STAGE_HINT_TABLE, ids=STAGE_HINT_IDS)
+    def test_the_canonical_seam_records_the_stage_the_mapper_names(self, hint: str, expected: EliminationStage) -> None:
+        from mloda.core.prepare.resolution_types import rejection_elimination_stage
+
+        snapshot = _drive_canonical(partial(_make_stage_decline_fg, hint))
+
+        assert snapshot.escaped is None, f"nothing may cross evaluate: {snapshot.escaped}"
+        assert snapshot.eliminations == ((STAGE_DECLINE_CLASS_NAME, expected, _stage_reason(hint)),), (
+            f"exactly one elimination at '{expected}', got: {snapshot.eliminations}"
+        )
+        assert rejection_elimination_stage(hint) == expected, "the canonical seam must map through the shared mapper"
+
+
+class TestTheSharedNearMissBullet:
+    """One helper renders a near-miss bullet; the canonical block must stay byte-identical to it."""
+
+    def test_the_bullet_names_the_candidate_its_stage_label_and_its_reason(self) -> None:
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+        rendered = near_miss_text(PLAIN_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)
+
+        assert rendered == f"{PLAIN_CLASS_NAME} ({_STAGE_LABELS[SCOPE_STAGE]}): {SCOPE_REASON}", (
+            f"the bullet must read '<Candidate> (<stage label>): <reason>', got: {rendered}"
+        )
+
+    def test_the_near_miss_block_is_the_shared_bullet_per_candidate(self) -> None:
+        """The block's output must not move: it is the shared bullet, indented, one candidate per line."""
+        rendered, expected = _drive_near_miss_block()
+
+        assert rendered == expected, f"the block must render the shared bullet, got: {rendered!r} vs {expected!r}"
+
+
+class TestEachGateRecordsItsOwnFact:
+    """One fact per (feature group, filter feature): the gate that closed and why it closed."""
+
+    def test_the_ledger_stores_elimination_facts(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A bare reason string cannot say which gate closed, so the ledger holds the stage-plus-reason fact."""
+        snapshot = _drive_matching([_make_matcher_error_fg], caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.fact_types == (Elimination.__name__,), (
+            f"the ledger must store {Elimination.__name__} facts, got: {snapshot.fact_types}"
+        )
+        assert snapshot.ledger_error is None, f"a stored fact must carry a stage and a reason: {snapshot.ledger_error}"
+
+    def test_a_matcher_defect_records_matcher_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching([_make_matcher_error_fg], caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert len(snapshot.rows) == 1, f"exactly one fact, got: {snapshot.rows}"
+        name, filter_name, stage, reason = snapshot.rows[0]
+        assert (name, filter_name) == (MATCHER_ERROR_CLASS_NAME, FILTER_FEATURE), f"wrong key: {name}, {filter_name}"
+        assert stage == MATCHER_ERROR_STAGE, f"a contained raise is a matcher defect, got stage: {stage}"
+        assert RUNTIME_TYPE_NAME in reason, f"the reason must name the exception type: {reason}"
+        assert RUNTIME_MESSAGE in reason, f"the reason must carry the raise message: {reason}"
+
+    @pytest.mark.parametrize(("hint", "expected"), STAGE_HINT_TABLE, ids=STAGE_HINT_IDS)
+    def test_a_typed_decline_records_its_mapped_stage(
+        self, hint: str, expected: EliminationStage, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The recorded hint decides the stage through the shared mapper; the reason text is unchanged."""
+        snapshot = _drive_matching([partial(_make_stage_decline_fg, hint)], caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.rows == ((STAGE_DECLINE_CLASS_NAME, FILTER_FEATURE, expected, _stage_reason(hint)),), (
+            f"a decline recorded under '{hint}' must land at '{expected}', got: {snapshot.rows}"
+        )
+        assert snapshot.warnings == (), f"a typed decline is a verdict, not a defect, got: {snapshot.warnings}"
+
+    @pytest.mark.parametrize(
+        ("make", "host_domain", "compared"),
+        [
+            pytest.param(_make_group_domain_fg, None, GROUP_DOMAIN, id="against_the_group_domain"),
+            pytest.param(_make_plain_fg, FEATURE_DOMAIN, FEATURE_DOMAIN, id="against_the_feature_domain"),
+        ],
+    )
+    def test_the_domain_gate_names_both_domains(
+        self, make: _Factory, host_domain: str | None, compared: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        snapshot = _drive_matching(
+            [make],
+            caplog,
+            filter_feature=_filter_feature(domain=OTHER_DOMAIN),
+            make_host=partial(_host_feature, domain=host_domain),
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.names == (), f"a diverging domain must attach no filter, got: {snapshot.names}"
+        assert len(snapshot.rows) == 1, f"exactly one fact, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == DOMAIN_STAGE, f"the domain gate owns this drop, got stage: {stage}"
+        assert OTHER_DOMAIN in reason, f"the reason must name the filter feature's declared domain: {reason}"
+        assert compared in reason, f"the reason must name the domain it was compared against: {reason}"
+
+    def test_the_scope_gate_records_the_canonical_seams_own_string(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Byte-identical to the string the canonical seam records at its own scope gate."""
+        snapshot = _drive_matching([_make_plain_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE))
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.rows == ((PLAIN_CLASS_NAME, FILTER_FEATURE, SCOPE_STAGE, SCOPE_REASON),), (
+            f"exactly one scope fact carrying the shared string, got: {snapshot.rows}"
+        )
+
+    def test_the_capability_gate_mirrors_the_canonical_seams_wording(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The rejected frameworks are the ones the filter would ride, named as the canonical seam names them."""
+        snapshot = _drive_matching(
+            [_make_capability_reject_fg], caplog, make_host=partial(_host_feature, pin=PythonDictFramework)
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.names == (), f"a hook rejecting every framework must attach no filter, got: {snapshot.names}"
+        assert snapshot.rows == (
+            (CAPABILITY_REJECT_CLASS_NAME, FILTER_FEATURE, CAPABILITY_STAGE, CAPABILITY_REASON),
+        ), f"exactly one capability fact carrying the shared wording, got: {snapshot.rows}"
+
+    def test_the_framework_pin_gate_names_the_pin_and_the_resolved_framework(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        snapshot = _drive_matching(
+            [_make_plain_fg],
+            caplog,
+            filter_feature=_filter_feature(pin=PandasDataFrame),
+            make_host=partial(_host_feature, pin=PythonDictFramework),
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.names == (), f"a diverging pin must attach no filter, got: {snapshot.names}"
+        assert len(snapshot.rows) == 1, f"exactly one fact, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == FRAMEWORK_PIN_STAGE, f"the pin gate owns this drop, got stage: {stage}"
+        assert PandasDataFrame.__name__ in reason, f"the reason must name the filter's pinned framework: {reason}"
+        assert PythonDictFramework.__name__ in reason, f"the reason must name the feature's own framework: {reason}"
+
+
+class TestAPlainNonMatchIsNotAFact:
+    """Only a near-miss is a fact: saying no is the matcher's judgment and records nothing."""
+
+    def test_a_literal_false_records_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching([_make_plain_decline_fg], caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.rows == (), f"a plain non-match is not a near-miss, got: {snapshot.rows}"
+        assert snapshot.warnings == (), f"saying no correctly must not warn, got: {snapshot.warnings}"
+
+    def test_a_falsy_non_bool_records_nothing_but_is_still_reported(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching([_make_falsy_decline_fg], caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.rows == (), f"a falsy non-bool is a non-match, never a fact, got: {snapshot.rows}"
+        assert len(snapshot.warnings) == 1, f"the detached filter must still be reported, got: {snapshot.warnings}"
+        assert FALSY_REPORT_FRAGMENT in snapshot.warnings[0], (
+            f"the report must call the return a falsy non-bool: {snapshot.warnings[0]}"
+        )
+
+
+class TestPrecedenceAmongFacts:
+    """A defect outranks a stored decline; every other stage is first-one-wins and never displaces a defect."""
+
+    def test_a_defect_outranks_a_stored_decline(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching([_make_decline_then_defect_fg], caplog, calls=2)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert len(snapshot.rows) == 1, f"exactly one fact for the key, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == MATCHER_ERROR_STAGE, f"the defect must take the key from the decline, got stage: {stage}"
+        assert DEFECT_MESSAGE in reason, f"the reason must carry the defect message: {reason}"
+        assert DECLINE_REASON not in reason, f"the defect outranks the recorded decline: {reason}"
+        assert len(snapshot.warnings) == 1, f"the defect must warn exactly once, got: {snapshot.warnings}"
+
+    def test_a_later_gate_never_displaces_a_stored_defect(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The second pass clears criteria and loses at scope, which must not overwrite the recorded defect."""
+        snapshot = _drive_matching(
+            [_make_defect_then_match_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE), calls=2
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.names == (), f"the scope still detaches the filter, got: {snapshot.names}"
+        assert len(snapshot.rows) == 1, f"exactly one fact for the key, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == MATCHER_ERROR_STAGE, f"a later gate must not displace the defect, got stage: {stage}"
+        assert RUNTIME_MESSAGE in reason, f"the defect's reason must survive the later gate: {reason}"
+
+    def test_the_first_near_miss_wins_among_non_defects(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Scope loses the first pass, a typed decline the second: the first fact recorded keeps the key."""
+        snapshot = _drive_matching(
+            [_make_match_then_decline_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE), calls=2
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert len(snapshot.rows) == 1, f"exactly one fact for the key, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == SCOPE_STAGE, f"the first near-miss keeps the key, got stage: {stage}"
+        assert reason == SCOPE_REASON, f"the later decline must not rewrite the reason: {reason}"
+
+
+class TestCriteriaRunsBeforeTheScopeGate:
+    """Gate order is observable in the recorded stage: criteria decides before the scope gate is asked."""
+
+    def test_a_raising_matcher_records_matcher_error_even_when_the_scope_would_exclude_it_too(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        snapshot = _drive_matching(
+            [_make_matcher_error_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE)
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert len(snapshot.rows) == 1, f"exactly one fact, got: {snapshot.rows}"
+        assert snapshot.rows[0][2] == MATCHER_ERROR_STAGE, (
+            f"criteria runs before the scope gate, got stage: {snapshot.rows[0][2]}"
+        )
+
+    def test_a_probe_that_clears_criteria_records_scope_without_hook_noise(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        snapshot = _drive_matching([_make_plain_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE))
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert snapshot.rows == ((PLAIN_CLASS_NAME, FILTER_FEATURE, SCOPE_STAGE, SCOPE_REASON),), (
+            f"a cleared criteria gate must leave the scope fact alone in the ledger, got: {snapshot.rows}"
+        )
+        assert snapshot.warnings == (), f"a scope drop is no defect and must not warn, got: {snapshot.warnings}"
+
+
+class TestTheUnmatchedWarningNamesTheNearestMiss:
+    """warn_on_unmatched_filters projects the captured facts: the deepest gate a filter reached."""
+
+    def test_without_a_captured_fact_the_message_is_the_bare_sentence(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching([_make_plain_decline_fg], caplog, warn_unmatched=True)
+
+        assert snapshot.rows == (), f"a plain non-match captures nothing, got: {snapshot.rows}"
+        assert snapshot.unmatched == (BARE_MESSAGE,), f"the message must stay unchanged, got: {snapshot.unmatched}"
+
+    def test_a_captured_fact_appends_the_shared_near_miss_bullet(self, caplog: pytest.LogCaptureFixture) -> None:
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+        snapshot = _drive_matching(
+            [_make_plain_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE), warn_unmatched=True
+        )
+
+        expected = f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{near_miss_text(PLAIN_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)}"
+        assert snapshot.unmatched == (expected,), f"the suffix must be the shared bullet, got: {snapshot.unmatched}"
+
+    def test_the_label_comes_from_the_live_stage_table(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Never a second spelling of the label: the renderer's own table owns it."""
+        snapshot = _drive_matching(
+            [_make_plain_fg], caplog, filter_feature=_filter_feature(scope=MISSING_SCOPE), warn_unmatched=True
+        )
+
+        assert len(snapshot.unmatched) == 1, f"exactly one unmatched warning, got: {snapshot.unmatched}"
+        assert f"({_STAGE_LABELS[SCOPE_STAGE]}):" in snapshot.unmatched[0], (
+            f"the label must come from the live table, got: {snapshot.unmatched[0]}"
+        )
+
+    def test_the_deepest_gate_wins_between_two_groups(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One group loses at criteria, the other survives to the pin gate: the pin is the nearer miss."""
+        snapshot = _drive_matching(
+            [partial(_make_stage_decline_fg, VALUE_REJECTION_STAGE), _make_plain_fg],
+            caplog,
+            filter_feature=_filter_feature(pin=PandasDataFrame),
+            make_host=partial(_host_feature, pin=PythonDictFramework),
+            warn_unmatched=True,
+        )
+
+        assert len(snapshot.unmatched) == 1, f"exactly one unmatched warning, got: {snapshot.unmatched}"
+        message = snapshot.unmatched[0]
+        assert message.startswith(
+            f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{PLAIN_CLASS_NAME} ({_STAGE_LABELS[FRAMEWORK_PIN_STAGE]}):"
+        ), f"the deepest gate must own the nearest miss, got: {message}"
+        assert STAGE_DECLINE_CLASS_NAME not in message, f"the shallower miss must not be named: {message}"
+
+    def test_a_defect_loses_to_a_declining_sibling(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A crash says nothing about how far the filter got, so a real decline is the nearer miss."""
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+        snapshot = _drive_matching(
+            [_make_matcher_error_fg, partial(_make_stage_decline_fg, VALUE_REJECTION_STAGE)],
+            caplog,
+            warn_unmatched=True,
+        )
+
+        expected_bullet = near_miss_text(
+            STAGE_DECLINE_CLASS_NAME, VALUE_REJECTION_STAGE, _stage_reason(VALUE_REJECTION_STAGE)
+        )
+        assert snapshot.unmatched == (f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{expected_bullet}",), (
+            f"the decline must outrank the defect, got: {snapshot.unmatched}"
+        )
+
+    def test_an_equal_stage_ties_break_by_class_name(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Two groups losing at the same gate: the pick is the renderer's own candidate order, not insertion order."""
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
+        snapshot = _drive_matching(
+            [_make_scope_tie_b_fg, _make_scope_tie_a_fg],
+            caplog,
+            filter_feature=_filter_feature(scope=MISSING_SCOPE),
+            warn_unmatched=True,
+        )
+
+        expected_bullet = near_miss_text(SCOPE_TIE_A_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)
+        assert snapshot.unmatched == (f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{expected_bullet}",), (
+            f"the tie must break by class name, got: {snapshot.unmatched}"
+        )
+
+    def test_a_filter_that_matched_warns_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        snapshot = _drive_matching([_make_plain_fg], caplog, warn_unmatched=True)
+
+        assert snapshot.names == (FILTER_FEATURE,), f"the filter must attach, got: {snapshot.names}"
+        assert snapshot.unmatched == (), f"an attached filter is not unmatched, got: {snapshot.unmatched}"

--- a/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
+++ b/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
@@ -10,7 +10,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import ClassVar, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 import pytest
 
@@ -87,6 +87,16 @@ def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
 def _single(filter_feature: Feature | str = FILTER_FEATURE) -> SingleFilter:
     """A minimal EQUAL filter on the module's filter feature, or on a caller-built Feature."""
     return SingleFilter(filter_feature, FilterType.EQUAL, {"value": 1})
+
+
+def _drop_row(feature_group: type[FeatureGroup], recorded: Any) -> tuple[str, str, str]:
+    """(class name, stage, reason) of one recorded drop. Any: the ledger's value type is pinned in a sibling suite."""
+    return feature_group.get_class_name(), str(recorded.stage), str(recorded.reason)
+
+
+def _drop_rows(global_filter: GlobalFilter) -> tuple[tuple[str, str, str], ...]:
+    """Every recorded drop as plain text, folded exactly as the canonical eliminations are."""
+    return tuple(sorted(_drop_row(key[0], recorded) for key, recorded in global_filter.dropped_filters.items()))
 
 
 def _make_plain_matcher_fg() -> type[FeatureGroup]:
@@ -362,6 +372,9 @@ class _MatchingSnapshot:
     scopes: tuple[str, ...] = ()
     # None means the driver never read the stored scope; a genuinely unscoped read folds to the text "None".
     stored_scope: str | None = None
+    # (class name, stage, reason) per recorded drop, and the read's own failure when a drop carries no stage.
+    drops: tuple[tuple[str, str, str], ...] = ()
+    drops_error: str | None = None
 
 
 def _scope_as_text(scope: str | type[FeatureGroup] | None) -> str:
@@ -398,7 +411,15 @@ def _drive_scoped_matching(make: _ScopeFactory, pick_scope: _ScopePick, probe_in
             names = tuple(sorted(single.name for single in matched))
             scopes = tuple(sorted(_scope_as_text(single.filter_feature.feature_group_scope) for single in matched))
         stored = _scope_as_text(next(iter(global_filter.filters)).filter_feature.feature_group_scope)
-        return _MatchingSnapshot(escaped=escaped, names=names, scopes=scopes, stored_scope=stored)
+        drops, drops_error = _capture(partial(_drop_rows, global_filter))
+        return _MatchingSnapshot(
+            escaped=escaped,
+            names=names,
+            scopes=scopes,
+            stored_scope=stored,
+            drops=drops or (),
+            drops_error=drops_error,
+        )
     finally:
         del made, classes, scope, global_filter, matched
         gc.collect()
@@ -474,10 +495,13 @@ def _drive_matching_counted(make: _CounterFactory, pin_host: bool, pin_filter: b
     matched = None
     try:
         matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, host, None))
+        drops, drops_error = _capture(partial(_drop_rows, global_filter))
         return _MatchingSnapshot(
             escaped=escaped,
             names=() if matched is None else tuple(sorted(single.name for single in matched)),
             calls=read_calls(),
+            drops=drops or (),
+            drops_error=drops_error,
         )
     finally:
         del fg, read_calls, global_filter, matched
@@ -863,6 +887,19 @@ class TestScopeGate:
             f"exactly one scope elimination, got: {snapshot.eliminations}"
         )
 
+    def test_the_filter_seam_records_the_stage_the_canonical_seam_eliminates_at(self) -> None:
+        """Same candidate, same gate, same words: one shared fact rather than two seams describing a scope drop."""
+        filter_side = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(MISSING_SCOPE_728))
+        canonical = _drive_canonical(_make_plain_matcher_fg, scope=MISSING_SCOPE_728)
+
+        assert filter_side.drops_error is None, f"a recorded drop must carry a stage: {filter_side.drops_error}"
+        assert filter_side.drops == ((PLAIN_CLASS_NAME, "scope", SCOPE_REASON),), (
+            f"the filter seam must record the scope drop, got: {filter_side.drops}"
+        )
+        assert filter_side.drops == canonical.eliminations, (
+            f"both seams must name one stage and one reason, got: {filter_side.drops} vs {canonical.eliminations}"
+        )
+
 
 class TestFrameworkPinCardinality:
     """Both seams validate the pin cardinality before matching via one shared validator; one pin gates on equality."""
@@ -1029,6 +1066,21 @@ class TestCapabilityHook:
         assert stage == "capability", f"the empty supported split owns the reason, got stage: {stage}"
         assert CAPABILITY_REASON_PART in reason, f"the reason must name the rejecting hook: {reason}"
         assert snapshot.calls >= 1, "evaluate must have consulted the hook"
+
+    def test_the_filter_seam_records_the_stage_the_canonical_seam_eliminates_at(self) -> None:
+        """The ride set and the candidate's accessible set are the same one framework here, so the words match too."""
+        filter_side = _drive_matching_counted(_make_capability_reject_fg, pin_host=True)
+        canonical = _drive_canonical_counted(_make_capability_reject_fg, with_links=False)
+
+        assert filter_side.drops_error is None, f"a recorded drop must carry a stage: {filter_side.drops_error}"
+        assert len(filter_side.drops) == 1, f"exactly one recorded drop, got: {filter_side.drops}"
+        name, stage, reason = filter_side.drops[0]
+        assert name == CAPABILITY_CLASS_NAME, f"the drop must name the candidate, got: {name}"
+        assert stage == "capability", f"the empty accepted subset owns the drop, got stage: {stage}"
+        assert CAPABILITY_REASON_PART in reason, f"the reason must name the rejecting hook: {reason}"
+        assert filter_side.drops == canonical.eliminations, (
+            f"both seams must name one stage and one reason, got: {filter_side.drops} vs {canonical.eliminations}"
+        )
 
 
 class TestDomainDefaulting:

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -229,6 +229,11 @@ def _ledger(global_filter: GlobalFilter) -> Optional[dict[Any, Any]]:
     return cast(Optional[dict[Any, Any]], getattr(global_filter, "dropped_filters", None))
 
 
+def _reason_of(recorded: Any) -> Any:
+    """Reason of one recorded drop, degrading to the record itself when it carries none."""
+    return getattr(recorded, "reason", recorded)
+
+
 def _messages(caplog: pytest.LogCaptureFixture, level: int) -> tuple[str, ...]:
     """Formatted messages GlobalFilter logged at exactly that level."""
     records = [record for record in caplog.records if record.name == GF_LOGGER_NAME and record.levelno == level]
@@ -291,8 +296,8 @@ def _drive_criteria(
             has_ledger=ledger is not None,
             keyed_by_group_and_filter=ledger is not None and (fg, filter_feature_name) in ledger,
             entries=tuple((str(key[0].get_class_name()), str(key[1])) for key, _ in items),
-            reasons=tuple(str(reason) for _, reason in items),
-            reason_types=tuple(type(reason).__name__ for _, reason in items),
+            reasons=tuple(str(_reason_of(recorded)) for _, recorded in items),
+            reason_types=tuple(type(_reason_of(recorded)).__name__ for _, recorded in items),
             warnings=_messages(caplog, logging.WARNING),
             debugs=_messages(caplog, logging.DEBUG),
         )

--- a/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
+++ b/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
@@ -101,6 +101,12 @@ def _stage_reason(stage: str) -> str:
     return f"rtx_stage_reason_728_{stage}"
 
 
+def _reason_text(recorded: Any) -> str:
+    """Reason text of one recorded drop, or a marker naming what the ledger stored instead of a fact."""
+    reason = getattr(recorded, "reason", None)
+    return str(reason) if reason is not None else f"<no reason on {type(recorded).__name__}>"
+
+
 def _window_not_observed() -> bool:
     """Reader for probes that never record: their tests assert nothing about the window."""
     return False
@@ -501,7 +507,7 @@ def _drive_criteria(make: _RtxFactory, caplog: pytest.LogCaptureFixture, calls: 
             is_true=value is True,
             escaped=escaped,
             entries=tuple((str(key[0].get_class_name()), str(key[1])) for key, _ in items),
-            reasons=tuple(str(reason) for _, reason in items),
+            reasons=tuple(_reason_text(recorded) for _, recorded in items),
             warnings=_messages(caplog, logging.WARNING),
             debugs=_messages(caplog, logging.DEBUG),
             window_active=read_window(),

--- a/tests/test_core/test_filter/test_filter_matcher_truthiness.py
+++ b/tests/test_core/test_filter/test_filter_matcher_truthiness.py
@@ -130,6 +130,12 @@ def _dropped_entries(global_filter: GlobalFilter) -> tuple[tuple[str, str], ...]
     return tuple(sorted((key[0].get_class_name(), key[1]) for key in global_filter.dropped_filters))
 
 
+def _reason_text(recorded: Any) -> str:
+    """Reason text of one recorded drop, or a marker naming what the ledger stored instead of a fact."""
+    reason = getattr(recorded, "reason", None)
+    return str(reason) if reason is not None else f"<no reason on {type(recorded).__name__}>"
+
+
 def _make_non_bool_matcher_fg(returned: Any) -> type[FeatureGroup]:
     """A throwaway group whose hook returns the caller's value for FILTER_FEATURE and matches HOST_FEATURE."""
     # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
@@ -207,7 +213,7 @@ def _drive_criteria(returned: Any, caplog: pytest.LogCaptureFixture, calls: int 
             shown=_shown(value),
             escaped=escaped,
             entries=_dropped_entries(global_filter),
-            reasons=tuple(global_filter.dropped_filters.values()),
+            reasons=tuple(_reason_text(recorded) for recorded in global_filter.dropped_filters.values()),
             warnings=_messages(caplog, logging.WARNING),
             debugs=_messages(caplog, logging.DEBUG),
         )

--- a/tests/test_core/test_prepare/test_resolution_module_split.py
+++ b/tests/test_core/test_prepare/test_resolution_module_split.py
@@ -43,6 +43,7 @@ RENDERER_NAMES = (
     "_supported_feature_names",
     "_prefix_name",
     "_STAGE_LABELS",
+    "near_miss_text",
     "_render_near_miss_block",
     "_render_multiple",
     "_render_abstract_only",

--- a/tests/test_documentation/test_near_miss_labels_in_docs.py
+++ b/tests/test_documentation/test_near_miss_labels_in_docs.py
@@ -139,6 +139,7 @@ PROSE_LABEL_PAGES: tuple[tuple[str, EliminationStage], ...] = (
     ("in_depth/data-access-patterns.md", "input_data"),
     ("in_depth/feature-chain-parser.md", "matcher_error"),
     ("in_depth/feature-group-matching.md", "matcher_error"),
+    ("in_depth/filter_data.md", "scope"),
 )
 
 


### PR DESCRIPTION
## Summary

`GlobalFilter` had almost no failure surface. Its only signals were a warn-once log saying a filter "matched no feature group" with no reason, and a `dropped_filters` ledger holding bare reason strings for contained matcher raises and typed declines. The domain, scope, capability and compute framework pin gates dropped filters silently.

The canonical resolver already captures the first gate each candidate failed as an `Elimination` (stage plus reason) during its single decision pass, and renders failures purely from those captured facts. This reuses that machinery for filter probes.

## Changes

- `dropped_filters` now maps to `Elimination`, and every gate records the stage it closed at plus a reason. The scope and capability reasons are byte-identical to the canonical seam's, pinned by a cross-seam test rather than a restated literal.
- `warn_on_unmatched_filters` names each unmatched filter's nearest miss, the deepest gate it reached, rendered through the resolution renderer's own stage labels. No provider hook runs on the render path.
- The free-form rejection stage hint maps to its elimination stage in one shared place, so the two seams cannot drift into separate taxonomies, and both render a near-miss through one helper.
- Precedence is unchanged where it was already settled: a matcher defect warns once and takes the key from a stored near-miss, a plain `False` and a falsy non-bool stay ordinary non-matches and record nothing.

Recording sits at each `continue` in `identify_matched_filters`, mirroring the canonical filter loop, so the gate predicates stay pure for their other callers.

### Correctness work the rendering exposed

Making the ledger user-visible surfaced three ways it could not back what the message claimed:

- The ledger outlived the setup that filled it, so a reused `GlobalFilter` could name a feature group a later setup never consulted. Every match report now clears in `reset_match_tracking`, alongside the divergence warnings already scoped that way.
- The ledger keys on the filter feature name, so two filters declared over one column share an entry and only one of the two warnings could be right, with set iteration deciding which. The nearest miss is withheld when a name is shared, so no message is wrong.
- The write policy kept the first gate while the read policy claimed the deepest, and host order is set order. The deepest gate reached now keeps the key.

Also: the stage depth table covers every elimination stage rather than silently ranking the two it missed alongside a matcher defect, and the plugin-owned domain name is read through `as_str` inside its guard.

## Compatibility

`GlobalFilter.dropped_filters` is exported via `mloda.user` and named in the docs. Its values change from `str` to `Elimination`; read `.reason` for the previous string. Its lifetime also narrows to the current engine setup.

## Tests

New suite covering every gate's recorded stage and reason, the precedence rules, the criteria-before-scope gate order, and the nearest-miss selection including determinism and tie-breaks. The canonical-map parity suite gains pins that the filter seam records the stage the canonical seam eliminates at. A doc guard pins the stage label the filter page now quotes.

`tox` green locally: 8835 passed, 170 skipped, ruff format, ruff check, license allowlist, `mypy --strict`, bandit.

Part of #728.