### PR TITLE
test: declare the renderer's plugin stubs through the shared factory

### DIFF
--- a/tests/helpers/plugin_stubs.py
+++ b/tests/helpers/plugin_stubs.py
@@ -11,6 +11,7 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -54,6 +55,118 @@ class StubFeatureGroup(FeatureGroup):
         return None
 
 
+class StubHookError(RuntimeError):
+    """The single error an armed stub hook raises."""
+
+
+class HookCounter:
+    """The tally a consuming test module owns: hook calls by class, plus candidate-framework pairs."""
+
+    def __init__(self) -> None:
+        self.calls: dict[str, int] = {}
+        self.pairs: dict[tuple[str, str], int] = {}
+
+    def record(self, class_name: str, hook: str) -> None:
+        key = f"{class_name}.{hook}"
+        self.calls[key] = self.calls.get(key, 0) + 1
+
+    def record_pair(self, class_name: str, framework_name: str) -> None:
+        """A hook-name tally cannot see one pair being asked twice, which is what this one is for."""
+        pair = (class_name, framework_name)
+        self.pairs[pair] = self.pairs.get(pair, 0) + 1
+
+    def clear(self) -> None:
+        # In place, never rebound: a caller aliases counter.calls at import and asserts on that alias
+        # for the rest of its module.
+        self.calls.clear()
+        self.pairs.clear()
+
+
+class CountingStubFeatureGroup(StubFeatureGroup):
+    """A stub that tallies every provider-overridable hook it answers, and may raise from a named one."""
+
+    COUNTER: ClassVar[HookCounter | None] = None
+    SUPPORTED_FRAMEWORKS: ClassVar[frozenset[str] | None] = None
+    INDEX_COLUMNS: ClassVar[list[Index] | None] = None
+    SUPPORTS_INDEX_RESULT: ClassVar[bool | None] = None
+    RAISING_HOOKS: ClassVar[frozenset[str]] = frozenset()
+    ARMED: ClassVar[bool] = True
+
+    @classmethod
+    def _enter_hook(cls, hook: str, compute_framework: type[ComputeFramework] | None = None) -> None:
+        """Tally the call, then raise if the hook is armed: a caller asserts on the count of the hook that raised."""
+        # Read off the ClassVar at call time, so a child counts into whatever its base currently
+        # declares. An unset counter counts nowhere and still answers: this is a globally visible
+        # FeatureGroup subclass, so other tests' registry sweeps call these hooks.
+        counter = cls.COUNTER
+        if counter is not None:
+            counter.record(cls.get_class_name(), hook)
+            if compute_framework is not None:
+                counter.record_pair(cls.get_class_name(), compute_framework.get_class_name())
+        if cls.ARMED and hook in cls.RAISING_HOOKS:
+            raise StubHookError(f"{cls.get_class_name()}.{hook} is armed to raise.")
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        cls._enter_hook("match_feature_group_criteria")
+        return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        cls._enter_hook("get_domain")
+        return super().get_domain()
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        cls._enter_hook("compute_framework_rule")
+        return super().compute_framework_rule()
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        cls._enter_hook("supports_compute_framework", compute_framework)
+        if cls.SUPPORTED_FRAMEWORKS is None:
+            return super().supports_compute_framework(feature_name, options, compute_framework)
+        return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        cls._enter_hook("index_columns")
+        if cls.INDEX_COLUMNS is None:
+            return super().index_columns()
+        return cls.INDEX_COLUMNS
+
+    @classmethod
+    def supports_index(cls, index: Index) -> bool | None:
+        cls._enter_hook("supports_index")
+        if cls.SUPPORTS_INDEX_RESULT is not None:
+            return cls.SUPPORTS_INDEX_RESULT
+        # The FeatureGroup answer, spelled out rather than delegated: super() reads it off
+        # index_columns(), whose call the caller would then see counted a second time.
+        if cls.INDEX_COLUMNS is None:
+            return None
+        return any(index.is_a_part_of(column) for column in cls.INDEX_COLUMNS)
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        cls._enter_hook("feature_names_supported")
+        return super().feature_names_supported()
+
+    @classmethod
+    def prefix(cls) -> str:
+        cls._enter_hook("prefix")
+        return super().prefix()
+
+
 def _stub_abstract_hook(self: FeatureGroup) -> None:
     """Unimplemented member that makes an ``abstract=True`` stub abstract to ABCMeta."""
 
@@ -89,6 +202,11 @@ def make_fg(
     domain: str | None = None,
     frameworks: set[type[ComputeFramework]] | None = None,
     supported_names: str | Iterable[str] | None = None,
+    counter: HookCounter | None = None,
+    supported_frameworks: str | Iterable[str] | None = None,
+    index_columns: list[Index] | None = None,
+    supports_index: bool | None = None,
+    raising_hooks: str | Iterable[str] | None = None,
     abstract: bool = False,
     base: type[StubFeatureGroup] = StubFeatureGroup,
     doc: str | None = None,
@@ -107,6 +225,22 @@ def make_fg(
         # FeatureGroup's default matcher, which matches the class's own name, is back in the suite.
         raise ValueError(f"base must be a StubFeatureGroup subclass, got {base.__name__}.")
 
+    counting_keywords = {
+        keyword: value
+        for keyword, value in (
+            ("counter", counter),
+            ("supported_frameworks", supported_frameworks),
+            ("index_columns", index_columns),
+            ("supports_index", supports_index),
+            ("raising_hooks", raising_hooks),
+        )
+        if value is not None
+    }
+    if counting_keywords and not issubclass(base, CountingStubFeatureGroup):
+        # Only a counting base reads these ClassVars, so on any other base the keyword is dropped and
+        # the stub answers as if it had never been passed.
+        raise ValueError(f"{', '.join(counting_keywords)} needs a CountingStubFeatureGroup base, got {base.__name__}.")
+
     # The caller's module, so (module, qualname) dedup, _is_live_in_module and the isolation fixture
     # read a minted stub exactly like a hand-written class.
     module: str = sys._getframe(1).f_globals["__name__"]
@@ -124,6 +258,17 @@ def make_fg(
         namespace["FRAMEWORK_RULE"] = set(frameworks)
     if supported_names is not None:
         namespace["SUPPORTED_NAMES"] = _name_set(supported_names)
+    if counter is not None:
+        namespace["COUNTER"] = counter
+    if supported_frameworks is not None:
+        namespace["SUPPORTED_FRAMEWORKS"] = _name_set(supported_frameworks)
+    if index_columns is not None:
+        # A copy, for the same reason as frameworks above.
+        namespace["INDEX_COLUMNS"] = list(index_columns)
+    if supports_index is not None:
+        namespace["SUPPORTS_INDEX_RESULT"] = supports_index
+    if raising_hooks is not None:
+        namespace["RAISING_HOOKS"] = _name_set(raising_hooks)
     if doc is not None:
         namespace["__doc__"] = doc
     if abstract:
@@ -133,3 +278,29 @@ def make_fg(
     # abstract member into a real instantiation error.
     metaclass: type[Any] = type(base)
     return cast("type[StubFeatureGroup]", metaclass(name, (base,), namespace))
+
+
+def make_raising_fg(
+    name: str,
+    hook: str,
+    *,
+    doc: str | None = None,
+    base: type[FeatureGroup] = FeatureGroup,
+) -> type[FeatureGroup]:
+    """Mint a transient double in the calling module whose ``hook`` classmethod raises for any arguments.
+
+    No ``(module, name)`` claim and nothing retained: the caller reaps its class within the test
+    instead of binding it at module level, so the same name can be minted again.
+    """
+
+    def raise_from_hook(cls: type[FeatureGroup], *args: Any, **kwargs: Any) -> Any:
+        # A plain RuntimeError, not StubHookError: this double stands in for an arbitrary broken plugin.
+        raise RuntimeError(f"{name}.{hook} is a deliberately broken stub.")
+
+    module: str = sys._getframe(1).f_globals["__name__"]
+    namespace: dict[str, Any] = {"__module__": module, "__qualname__": name, hook: classmethod(raise_from_hook)}
+    if doc is not None:
+        namespace["__doc__"] = doc
+
+    metaclass: type[Any] = type(base)
+    return cast("type[FeatureGroup]", metaclass(name, (base,), namespace))

--- a/tests/helpers/plugin_stubs.py
+++ b/tests/helpers/plugin_stubs.py
@@ -94,7 +94,7 @@ class CountingStubFeatureGroup(StubFeatureGroup):
 
     @classmethod
     def _enter_hook(cls, hook: str, compute_framework: type[ComputeFramework] | None = None) -> None:
-        """Tally the call, then raise if the hook is armed: a caller asserts on the count of the hook that raised."""
+        """Count before raising: a caller asserts on the count of the very hook that raised."""
         # Read off the ClassVar at call time, so a child counts into whatever its base currently
         # declares. An unset counter counts nowhere and still answers: this is a globally visible
         # FeatureGroup subclass, so other tests' registry sweeps call these hooks.
@@ -237,8 +237,8 @@ def make_fg(
         if value is not None
     }
     if counting_keywords and not issubclass(base, CountingStubFeatureGroup):
-        # Only a counting base reads these ClassVars, so on any other base the keyword is dropped and
-        # the stub answers as if it had never been passed.
+        # Only a counting base reads these ClassVars, so on any other base the keyword would be
+        # silently dropped.
         raise ValueError(f"{', '.join(counting_keywords)} needs a CountingStubFeatureGroup base, got {base.__name__}.")
 
     # The caller's module, so (module, qualname) dedup, _is_live_in_module and the isolation fixture
@@ -289,7 +289,7 @@ def make_raising_fg(
 ) -> type[FeatureGroup]:
     """Mint a transient double in the calling module whose ``hook`` classmethod raises for any arguments.
 
-    No ``(module, name)`` claim and nothing retained: the caller reaps its class within the test
+    Claims no ``(module, name)`` and retains nothing: the caller reaps its class inside the test
     instead of binding it at module level, so the same name can be minted again.
     """
 

--- a/tests/helpers/plugin_stubs.py
+++ b/tests/helpers/plugin_stubs.py
@@ -150,8 +150,8 @@ class CountingStubFeatureGroup(StubFeatureGroup):
         cls._enter_hook("supports_index")
         if cls.SUPPORTS_INDEX_RESULT is not None:
             return cls.SUPPORTS_INDEX_RESULT
-        # The FeatureGroup answer, spelled out rather than delegated: super() reads it off
-        # index_columns(), whose call the caller would then see counted a second time.
+        # Reads the ClassVar, not index_columns(), which is what super() would call: delegating would
+        # count that hook a second time and would make an armed index_columns reachable through here.
         if cls.INDEX_COLUMNS is None:
             return None
         return any(index.is_a_part_of(column) for column in cls.INDEX_COLUMNS)

--- a/tests/helpers/test_plugin_stubs.py
+++ b/tests/helpers/test_plugin_stubs.py
@@ -541,7 +541,7 @@ class TestCountedCapabilityHook:
         assert cls.supports_compute_framework(ALPHA, Options(), PyArrowTable) is False
 
     def test_it_records_both_the_hook_call_and_the_pair(self) -> None:
-        """A hook-name tally cannot see one pair being asked twice, which is what the pair tally is for."""
+        """The hook-name tally alone cannot see one pair being asked twice."""
         counter = HookCounter()
         name = "PluginStubPairCountFG"
         cls = make_fg(name, base=CountingStubFeatureGroup, counter=counter)
@@ -797,7 +797,7 @@ class TestTransientRaisingDouble:
             cls.supports_index(INDEX)
 
     def test_the_same_name_can_be_minted_twice(self) -> None:
-        """No (module, name) claim: the caller reaps its class per test instead of binding it at module level."""
+        """No (module, name) claim, because the caller reaps its class per test."""
         name = "PluginStubTransientTwiceFG"
         first = make_raising_fg(name, COUNTED_HOOK)
         second = make_raising_fg(name, COUNTED_HOOK)

--- a/tests/helpers/test_plugin_stubs.py
+++ b/tests/helpers/test_plugin_stubs.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import gc
 import inspect
 import weakref
+from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -17,7 +20,14 @@ from mloda.core.api.plugin_docs import _safe_version
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
-from tests.helpers.plugin_stubs import StubFeatureGroup, make_fg
+from tests.helpers.plugin_stubs import (
+    CountingStubFeatureGroup,
+    HookCounter,
+    StubFeatureGroup,
+    StubHookError,
+    make_fg,
+    make_raising_fg,
+)
 
 
 HELPER_MODULE = "tests.helpers.plugin_stubs"
@@ -38,6 +48,30 @@ DOC = "A stub minted for the plugin-stub contract."
 DUPLICATE_NAME = "PluginStubDuplicateFG"
 
 FRAMEWORKS: set[type[ComputeFramework]] = {PythonDictFramework, PyArrowTable}
+
+FRAMEWORK_NAME = PythonDictFramework.get_class_name()
+OTHER_FRAMEWORK_NAME = PyArrowTable.get_class_name()
+
+INDEX = Index(("plugin_stub_index_column",))
+
+# Every provider-overridable hook a counting stub tallies, in the order _call_every_counted_hook calls them.
+COUNTED_HOOKS = (
+    "match_feature_group_criteria",
+    "get_domain",
+    "compute_framework_rule",
+    "supports_compute_framework",
+    "index_columns",
+    "supports_index",
+    "feature_names_supported",
+    "prefix",
+)
+
+# The make_fg keywords only a CountingStubFeatureGroup base reads.
+COUNTING_KEYWORDS = ("counter", "supported_frameworks", "index_columns", "supports_index", "raising_hooks")
+
+COUNTED_CLASS = "PluginStubTalliedClassName"
+COUNTED_HOOK = "get_domain"
+OTHER_HOOK = "prefix"
 
 
 def _matches(cls: type[FeatureGroup], feature_name: str) -> bool:
@@ -69,6 +103,60 @@ def _ordinary_spelling_verdicts() -> tuple[bool, bool]:
         MATCHED_NAMES = frozenset({ALPHA})
 
     return _matches(OrdinarySpellingStubFG, ALPHA), _matches(OrdinarySpellingStubFG, UNMATCHED)
+
+
+def _as_counting(cls: type[FeatureGroup]) -> type[CountingStubFeatureGroup]:
+    """Narrow the factory's declared return type, so the counting ClassVars are readable."""
+    assert issubclass(cls, CountingStubFeatureGroup), f"expected a counting stub, got {cls.__mro__}"
+    return cls
+
+
+def _call_every_counted_hook(cls: type[FeatureGroup]) -> None:
+    """Call each counted hook exactly once, in COUNTED_HOOKS order."""
+    cls.match_feature_group_criteria(ALPHA, Options())
+    cls.get_domain()
+    cls.compute_framework_rule()
+    cls.supports_compute_framework(ALPHA, Options(), PythonDictFramework)
+    cls.index_columns()
+    cls.supports_index(INDEX)
+    cls.feature_names_supported()
+    cls.prefix()
+
+
+def _counting_keyword_value(keyword: str) -> Any:
+    """One representative value per counting-only make_fg keyword, built on demand."""
+    values: dict[str, Any] = {
+        "counter": HookCounter(),
+        "supported_frameworks": FRAMEWORK_NAME,
+        "index_columns": [INDEX],
+        "supports_index": True,
+        "raising_hooks": COUNTED_HOOK,
+    }
+    return values[keyword]
+
+
+def _mint_raising_and_drop(name: str) -> weakref.ref[type[FeatureGroup]]:
+    """Hand back only a weak reference: this frame keeps no strong one."""
+    return weakref.ref(make_raising_fg(name, COUNTED_HOOK))
+
+
+ARMED_STUBS: list[type[CountingStubFeatureGroup]] = []
+
+
+def _armed(cls: type[FeatureGroup]) -> type[CountingStubFeatureGroup]:
+    """Track a stub with an armed hook, so the fixture can disarm it after the test."""
+    stub = _as_counting(cls)
+    ARMED_STUBS.append(stub)
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def disarm_stubs_after_each_test() -> Iterator[None]:
+    """An armed stub that outlives its test stays globally visible, so disarm every one a test built."""
+    yield
+    for stub in ARMED_STUBS:
+        stub.ARMED = False
+    ARMED_STUBS.clear()
 
 
 class TestMintedIdentity:
@@ -286,3 +374,450 @@ class TestNoRetrievableSource:
         """get_feature_group_docs reads the version field through _safe_version, so a stub degrades, not raises."""
         cls = make_fg("PluginStubDocsVersionFG")
         assert _safe_version(cls) == "unavailable"
+
+
+class TestStubHookError:
+    """The single error an armed stub hook raises."""
+
+    def test_it_is_a_runtime_error(self) -> None:
+        """Callers catch it the way they would catch a real plugin's failure."""
+        assert issubclass(StubHookError, RuntimeError)
+
+
+class TestHookCounter:
+    """The tally the consuming test module owns."""
+
+    def test_a_fresh_counter_is_empty(self) -> None:
+        counter = HookCounter()
+        assert counter.calls == {}
+        assert counter.pairs == {}
+
+    def test_record_counts_one_call_per_class_and_hook(self) -> None:
+        counter = HookCounter()
+        counter.record(COUNTED_CLASS, COUNTED_HOOK)
+        counter.record(COUNTED_CLASS, COUNTED_HOOK)
+        counter.record(COUNTED_CLASS, OTHER_HOOK)
+        assert counter.calls == {f"{COUNTED_CLASS}.{COUNTED_HOOK}": 2, f"{COUNTED_CLASS}.{OTHER_HOOK}": 1}
+        assert counter.pairs == {}
+
+    def test_record_pair_counts_one_call_per_candidate_and_framework(self) -> None:
+        counter = HookCounter()
+        counter.record_pair(COUNTED_CLASS, FRAMEWORK_NAME)
+        counter.record_pair(COUNTED_CLASS, FRAMEWORK_NAME)
+        counter.record_pair(COUNTED_CLASS, OTHER_FRAMEWORK_NAME)
+        assert counter.pairs == {(COUNTED_CLASS, FRAMEWORK_NAME): 2, (COUNTED_CLASS, OTHER_FRAMEWORK_NAME): 1}
+        assert counter.calls == {}
+
+    def test_clear_empties_both_tallies(self) -> None:
+        counter = HookCounter()
+        counter.record(COUNTED_CLASS, COUNTED_HOOK)
+        counter.record_pair(COUNTED_CLASS, FRAMEWORK_NAME)
+        counter.clear()
+        assert counter.calls == {}
+        assert counter.pairs == {}
+
+    def test_clear_empties_the_dicts_in_place(self) -> None:
+        """A caller binds counter.calls once at import, so a rebinding clear would leave it reading a stale dict."""
+        counter = HookCounter()
+        calls = counter.calls
+        pairs = counter.pairs
+        counter.record(COUNTED_CLASS, COUNTED_HOOK)
+        counter.record_pair(COUNTED_CLASS, FRAMEWORK_NAME)
+        counter.clear()
+        assert calls is counter.calls
+        assert pairs is counter.pairs
+        assert calls == {}
+        assert pairs == {}
+
+    def test_two_counters_do_not_share_state(self) -> None:
+        first = HookCounter()
+        second = HookCounter()
+        first.record(COUNTED_CLASS, COUNTED_HOOK)
+        first.record_pair(COUNTED_CLASS, FRAMEWORK_NAME)
+        assert second.calls == {}
+        assert second.pairs == {}
+
+
+class TestCountingStubBase:
+    """The counting base alone is inert: it matches nothing, counts nowhere and answers the defaults."""
+
+    def test_it_is_a_stub_feature_group(self) -> None:
+        assert issubclass(CountingStubFeatureGroup, StubFeatureGroup)
+
+    def test_it_matches_nothing(self) -> None:
+        """Its own name included, so importing the helper adds no matcher to the suite."""
+        counting = CountingStubFeatureGroup
+        assert _matches(counting, counting.get_class_name()) is False
+        assert _matches(counting, ALPHA) is False
+
+    def test_its_class_vars_are_the_inert_defaults(self) -> None:
+        counting = CountingStubFeatureGroup
+        assert counting.COUNTER is None
+        assert counting.SUPPORTED_FRAMEWORKS is None
+        assert counting.INDEX_COLUMNS is None
+        assert counting.SUPPORTS_INDEX_RESULT is None
+        assert counting.RAISING_HOOKS == frozenset()
+        assert counting.ARMED is True
+
+    def test_an_unset_counter_counts_nowhere_and_still_answers(self) -> None:
+        """Other tests' registry sweeps call these hooks on this globally visible class, so it must never raise."""
+        counting = CountingStubFeatureGroup
+        _call_every_counted_hook(counting)
+        assert counting.get_domain() == Domain.get_default_domain()
+        assert counting.compute_framework_rule() is None
+        assert counting.feature_names_supported() == set()
+        assert counting.index_columns() is None
+        assert counting.supports_index(INDEX) is None
+        assert counting.supports_compute_framework(ALPHA, Options(), PythonDictFramework) is True
+        assert counting.prefix() == f"{counting.get_class_name()}_"
+
+
+class TestCountedHookCalls:
+    """A counting stub tallies every hook it answers, keyed by its own class name."""
+
+    def test_every_counted_hook_lands_under_its_class_and_name(self) -> None:
+        counter = HookCounter()
+        name = "PluginStubCountedHooksFG"
+        cls = make_fg(name, base=CountingStubFeatureGroup, counter=counter)
+        _call_every_counted_hook(cls)
+        assert counter.calls == {f"{name}.{hook}": 1 for hook in COUNTED_HOOKS}
+
+    def test_a_repeated_call_increments_the_same_key(self) -> None:
+        counter = HookCounter()
+        name = "PluginStubCountedRepeatFG"
+        cls = make_fg(name, base=CountingStubFeatureGroup, counter=counter)
+        cls.get_domain()
+        cls.get_domain()
+        assert counter.calls == {f"{name}.get_domain": 2}
+
+    def test_the_answers_are_the_stub_defaults(self) -> None:
+        """Counting changes what is observed, never what is answered."""
+        counter = HookCounter()
+        name = "PluginStubCountedDefaultsFG"
+        cls = make_fg(name, base=CountingStubFeatureGroup, counter=counter, matches=ALPHA)
+        assert _matches(cls, ALPHA) is True
+        assert _matches(cls, UNMATCHED) is False
+        assert cls.get_domain() == Domain.get_default_domain()
+        assert cls.compute_framework_rule() is None
+        assert cls.feature_names_supported() == set()
+        assert cls.index_columns() is None
+        assert cls.supports_index(INDEX) is None
+        assert cls.prefix() == f"{name}_"
+
+    def test_the_existing_keywords_still_declare_their_answers(self) -> None:
+        counter = HookCounter()
+        name = "PluginStubCountedDeclaredFG"
+        cls = make_fg(
+            name,
+            base=CountingStubFeatureGroup,
+            counter=counter,
+            domain=DOMAIN,
+            frameworks=FRAMEWORKS,
+            supported_names=BETA,
+        )
+        assert cls.get_domain() == Domain(DOMAIN)
+        assert cls.compute_framework_rule() == FRAMEWORKS
+        assert cls.feature_names_supported() == {BETA}
+        assert counter.calls == {
+            f"{name}.{hook}": 1 for hook in ("get_domain", "compute_framework_rule", "feature_names_supported")
+        }
+
+
+class TestCountedCapabilityHook:
+    """supports_compute_framework answers the declared framework names and records the pair it was asked about."""
+
+    def test_no_declared_frameworks_supports_every_framework(self) -> None:
+        cls = make_fg("PluginStubOpenFrameworksFG", base=CountingStubFeatureGroup)
+        assert cls.supports_compute_framework(ALPHA, Options(), PythonDictFramework) is True
+        assert cls.supports_compute_framework(ALPHA, Options(), PyArrowTable) is True
+
+    def test_declared_frameworks_gate_by_framework_class_name(self) -> None:
+        cls = make_fg(
+            "PluginStubGatedFrameworksFG",
+            base=CountingStubFeatureGroup,
+            supported_frameworks=FRAMEWORK_NAME,
+        )
+        assert cls.supports_compute_framework(ALPHA, Options(), PythonDictFramework) is True
+        assert cls.supports_compute_framework(ALPHA, Options(), PyArrowTable) is False
+
+    def test_it_records_both_the_hook_call_and_the_pair(self) -> None:
+        """A hook-name tally cannot see one pair being asked twice, which is what the pair tally is for."""
+        counter = HookCounter()
+        name = "PluginStubPairCountFG"
+        cls = make_fg(name, base=CountingStubFeatureGroup, counter=counter)
+        cls.supports_compute_framework(ALPHA, Options(), PythonDictFramework)
+        cls.supports_compute_framework(ALPHA, Options(), PythonDictFramework)
+        cls.supports_compute_framework(ALPHA, Options(), PyArrowTable)
+        assert counter.calls == {f"{name}.supports_compute_framework": 3}
+        assert counter.pairs == {(name, FRAMEWORK_NAME): 2, (name, OTHER_FRAMEWORK_NAME): 1}
+
+
+class TestArmedHooks:
+    """A hook named in RAISING_HOOKS raises while ARMED, and answers once disarmed."""
+
+    def test_an_armed_hook_raises_a_stub_hook_error_naming_the_hook(self) -> None:
+        cls = _armed(make_fg("PluginStubArmedDomainFG", base=CountingStubFeatureGroup, raising_hooks=COUNTED_HOOK))
+        with pytest.raises(StubHookError, match=COUNTED_HOOK):
+            cls.get_domain()
+
+    def test_the_call_is_counted_before_it_raises(self) -> None:
+        """Callers assert on the call count of the very hook that raised."""
+        counter = HookCounter()
+        name = "PluginStubArmedCountedFG"
+        cls = _armed(make_fg(name, base=CountingStubFeatureGroup, counter=counter, raising_hooks=COUNTED_HOOK))
+        with pytest.raises(StubHookError):
+            cls.get_domain()
+        assert counter.calls == {f"{name}.{COUNTED_HOOK}": 1}
+
+    def test_a_hook_that_is_not_listed_is_unaffected(self) -> None:
+        counter = HookCounter()
+        name = "PluginStubArmedOtherHookFG"
+        cls = _armed(make_fg(name, base=CountingStubFeatureGroup, counter=counter, raising_hooks=COUNTED_HOOK))
+        assert cls.prefix() == f"{name}_"
+        assert counter.calls == {f"{name}.{OTHER_HOOK}": 1}
+
+    def test_every_listed_hook_raises(self) -> None:
+        cls = _armed(
+            make_fg(
+                "PluginStubArmedPairFG",
+                base=CountingStubFeatureGroup,
+                raising_hooks=(COUNTED_HOOK, OTHER_HOOK),
+            )
+        )
+        with pytest.raises(StubHookError, match=COUNTED_HOOK):
+            cls.get_domain()
+        with pytest.raises(StubHookError, match=OTHER_HOOK):
+            cls.prefix()
+
+    def test_a_disarmed_hook_answers_normally(self) -> None:
+        """Disarming is what makes a stub that outlives its own test inert."""
+        counter = HookCounter()
+        name = "PluginStubDisarmedFG"
+        cls = _armed(
+            make_fg(
+                name,
+                base=CountingStubFeatureGroup,
+                counter=counter,
+                supported_names=BETA,
+                raising_hooks="feature_names_supported",
+            )
+        )
+        with pytest.raises(StubHookError):
+            cls.feature_names_supported()
+        cls.ARMED = False
+        assert cls.feature_names_supported() == {BETA}
+        assert counter.calls == {f"{name}.feature_names_supported": 2}
+
+
+class TestCounterReadAtCallTime:
+    """A stub reads COUNTER off the ClassVar when the hook runs, not when the class is minted."""
+
+    def test_a_child_counts_into_the_counter_declared_on_its_base(self) -> None:
+        counter = HookCounter()
+        parent = make_fg("PluginStubInheritedCounterParentFG", base=CountingStubFeatureGroup, counter=counter)
+        child_name = "PluginStubInheritedCounterChildFG"
+        child = make_fg(child_name, base=parent)
+        child.get_domain()
+        assert counter.calls == {f"{child_name}.get_domain": 1}
+
+    def test_reassigning_the_bases_counter_redirects_its_children(self) -> None:
+        first = HookCounter()
+        second = HookCounter()
+        parent = _as_counting(
+            make_fg("PluginStubRedirectCounterParentFG", base=CountingStubFeatureGroup, counter=first)
+        )
+        child_name = "PluginStubRedirectCounterChildFG"
+        child = make_fg(child_name, base=parent)
+        child.get_domain()
+        parent.COUNTER = second
+        child.get_domain()
+        assert first.calls == {f"{child_name}.get_domain": 1}
+        assert second.calls == {f"{child_name}.get_domain": 1}
+
+
+class TestCountingKeywords:
+    """Each counting keyword lands on its ClassVar, and only a counting base may receive one."""
+
+    def test_counter_lands_on_the_counter_class_var(self) -> None:
+        counter = HookCounter()
+        cls = _as_counting(make_fg("PluginStubCounterKeywordFG", base=CountingStubFeatureGroup, counter=counter))
+        assert cls.COUNTER is counter
+
+    def test_a_supported_frameworks_string_is_one_name_not_one_per_character(self) -> None:
+        cls = _as_counting(
+            make_fg(
+                "PluginStubFrameworkStringFG",
+                base=CountingStubFeatureGroup,
+                supported_frameworks=FRAMEWORK_NAME,
+            )
+        )
+        assert cls.SUPPORTED_FRAMEWORKS == frozenset({FRAMEWORK_NAME})
+
+    def test_supported_frameworks_accepts_an_iterable(self) -> None:
+        cls = _as_counting(
+            make_fg(
+                "PluginStubFrameworkIterableFG",
+                base=CountingStubFeatureGroup,
+                supported_frameworks=(FRAMEWORK_NAME, OTHER_FRAMEWORK_NAME),
+            )
+        )
+        assert cls.SUPPORTED_FRAMEWORKS == frozenset({FRAMEWORK_NAME, OTHER_FRAMEWORK_NAME})
+
+    def test_index_columns_lands_on_the_index_columns_hook(self) -> None:
+        cls = make_fg("PluginStubIndexColumnsFG", base=CountingStubFeatureGroup, index_columns=[INDEX])
+        assert _as_counting(cls).INDEX_COLUMNS == [INDEX]
+        assert cls.index_columns() == [INDEX]
+
+    def test_supports_index_lands_on_the_supports_index_hook(self) -> None:
+        cls = make_fg("PluginStubSupportsIndexFG", base=CountingStubFeatureGroup, supports_index=True)
+        assert _as_counting(cls).SUPPORTS_INDEX_RESULT is True
+        assert cls.supports_index(INDEX) is True
+
+    def test_a_raising_hooks_string_is_one_name_not_one_per_character(self) -> None:
+        cls = _armed(
+            make_fg(
+                "PluginStubRaisingHooksStringFG",
+                base=CountingStubFeatureGroup,
+                raising_hooks=COUNTED_HOOK,
+            )
+        )
+        assert cls.RAISING_HOOKS == frozenset({COUNTED_HOOK})
+
+    def test_raising_hooks_accepts_an_iterable(self) -> None:
+        cls = _armed(
+            make_fg(
+                "PluginStubRaisingHooksIterableFG",
+                base=CountingStubFeatureGroup,
+                raising_hooks=(COUNTED_HOOK, OTHER_HOOK),
+            )
+        )
+        assert cls.RAISING_HOOKS == frozenset({COUNTED_HOOK, OTHER_HOOK})
+
+    def test_a_counting_base_without_any_counting_keyword_still_mints(self) -> None:
+        name = "PluginStubPlainCountingBaseFG"
+        cls = _as_counting(make_fg(name, base=CountingStubFeatureGroup))
+        assert cls.COUNTER is None
+        assert _matches(cls, name) is False
+        assert cls.prefix() == f"{name}_"
+
+    @pytest.mark.parametrize("keyword", COUNTING_KEYWORDS)
+    def test_a_non_counting_base_raises_for_every_counting_keyword(self, keyword: str) -> None:
+        """A plain stub base reads none of the counting ClassVars, so the keyword would be silently dropped."""
+        name = f"PluginStubNonCountingBase{keyword.title().replace('_', '')}FG"
+        with pytest.raises(ValueError, match="CountingStubFeatureGroup") as raised:
+            make_fg(name, base=StubFeatureGroup, **{keyword: _counting_keyword_value(keyword)})
+        assert keyword in str(raised.value)
+
+
+class TestCountingKeywordsInherit:
+    """An omitted counting keyword inherits from base=; an explicitly empty one declares the value empty."""
+
+    def test_every_omitted_counting_keyword_inherits_the_base_declaration(self) -> None:
+        counter = HookCounter()
+        parent = _armed(
+            make_fg(
+                "PluginStubInheritCountingParentFG",
+                base=CountingStubFeatureGroup,
+                counter=counter,
+                supported_frameworks=FRAMEWORK_NAME,
+                index_columns=[INDEX],
+                supports_index=True,
+                raising_hooks=COUNTED_HOOK,
+            )
+        )
+        child = _armed(make_fg("PluginStubInheritCountingChildFG", base=parent))
+        assert child.COUNTER is counter
+        assert child.SUPPORTED_FRAMEWORKS == frozenset({FRAMEWORK_NAME})
+        assert child.INDEX_COLUMNS == [INDEX]
+        assert child.SUPPORTS_INDEX_RESULT is True
+        assert child.RAISING_HOOKS == frozenset({COUNTED_HOOK})
+
+    def test_an_explicitly_empty_supported_frameworks_supports_no_framework(self) -> None:
+        parent = make_fg(
+            "PluginStubEmptyFrameworksParentFG",
+            base=CountingStubFeatureGroup,
+            supported_frameworks=FRAMEWORK_NAME,
+        )
+        child = _as_counting(make_fg("PluginStubEmptyFrameworksChildFG", base=parent, supported_frameworks=frozenset()))
+        assert child.SUPPORTED_FRAMEWORKS == frozenset()
+        assert child.supports_compute_framework(ALPHA, Options(), PythonDictFramework) is False
+
+    def test_an_explicitly_empty_raising_hooks_disarms_the_inherited_hook(self) -> None:
+        parent = _armed(
+            make_fg(
+                "PluginStubEmptyRaisingParentFG",
+                base=CountingStubFeatureGroup,
+                raising_hooks=COUNTED_HOOK,
+            )
+        )
+        child = make_fg("PluginStubEmptyRaisingChildFG", base=parent, raising_hooks=frozenset())
+        assert child.get_domain() == Domain.get_default_domain()
+        with pytest.raises(StubHookError):
+            parent.get_domain()
+
+    def test_an_explicitly_false_supports_index_shadows_the_inherited_true(self) -> None:
+        parent = make_fg("PluginStubFalseSupportsIndexParentFG", base=CountingStubFeatureGroup, supports_index=True)
+        child = make_fg("PluginStubFalseSupportsIndexChildFG", base=parent, supports_index=False)
+        assert child.supports_index(INDEX) is False
+        assert parent.supports_index(INDEX) is True
+
+
+class TestTransientRaisingDouble:
+    """make_raising_fg stands in for a broken plugin the caller reaps: it claims no name and leaves nothing behind."""
+
+    def test_it_mints_a_subclass_of_the_given_base_under_the_given_name(self) -> None:
+        name = "PluginStubTransientNameFG"
+        cls = make_raising_fg(name, COUNTED_HOOK)
+        assert issubclass(cls, FeatureGroup)
+        assert cls.__name__ == name
+        assert cls.get_class_name() == name
+
+    def test_a_stub_base_is_honoured(self) -> None:
+        """A caller that needs an inert double passes a stub base, which matches nothing."""
+        name = "PluginStubTransientStubBaseFG"
+        cls = make_raising_fg(name, COUNTED_HOOK, base=StubFeatureGroup)
+        assert issubclass(cls, StubFeatureGroup)
+        assert _matches(cls, name) is False
+
+    def test_the_minted_class_belongs_to_the_calling_module(self) -> None:
+        cls = make_raising_fg("PluginStubTransientModuleFG", COUNTED_HOOK)
+        assert cls.__module__ == __name__
+        assert cls.__module__ != HELPER_MODULE
+
+    def test_the_named_hook_raises_a_plain_runtime_error(self) -> None:
+        """Plain RuntimeError, not StubHookError: it stands in for an arbitrary broken plugin."""
+        cls = make_raising_fg("PluginStubTransientRaiseFG", COUNTED_HOOK)
+        with pytest.raises(RuntimeError) as raised:
+            cls.get_domain()
+        assert not isinstance(raised.value, StubHookError)
+
+    def test_the_hook_raises_whatever_arguments_it_is_called_with(self) -> None:
+        cls = make_raising_fg("PluginStubTransientArgsFG", "supports_index")
+        with pytest.raises(RuntimeError):
+            cls.supports_index(INDEX)
+
+    def test_the_same_name_can_be_minted_twice(self) -> None:
+        """No (module, name) claim: the caller reaps its class per test instead of binding it at module level."""
+        name = "PluginStubTransientTwiceFG"
+        first = make_raising_fg(name, COUNTED_HOOK)
+        second = make_raising_fg(name, COUNTED_HOOK)
+        assert first is not second
+        assert first.get_class_name() == name
+        assert second.get_class_name() == name
+
+    def test_the_helper_keeps_no_strong_reference(self) -> None:
+        reference = _mint_raising_and_drop("PluginStubTransientWeakrefFG")
+        _collect_until_dead(reference)
+        assert reference() is None, "make_raising_fg must not retain the classes it mints"
+
+    def test_doc_becomes_the_class_description(self) -> None:
+        cls = make_raising_fg("PluginStubTransientDocFG", COUNTED_HOOK, doc=DOC)
+        assert cls.__doc__ == DOC
+        assert cls.description() == DOC
+
+    def test_an_omitted_doc_leaves_the_docstring_unset(self) -> None:
+        """A None __doc__ is what makes the docstring-less degrade path reachable for callers."""
+        name = "PluginStubTransientNoDocFG"
+        cls = make_raising_fg(name, COUNTED_HOOK)
+        assert cls.__doc__ is None
+        assert cls.description() == name

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -1,6 +1,7 @@
 import gc
 import inspect
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -18,6 +19,7 @@ from mloda.core.api.plugin_docs import (
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.user import PluginLoader
+from tests.helpers.plugin_stubs import make_raising_fg
 
 # Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
 pytestmark = pytest.mark.timeout(30)
@@ -241,6 +243,80 @@ class TestGetFeatureGroupDocs:
         assert len(upper_filtered) == expected
 
 
+@dataclass(frozen=True)
+class DegradedFieldCase:
+    """One broken hook, the docs field it degrades and the base-class fallback that field lands on."""
+
+    hook: str
+    class_name: str
+    field: str
+    expected: str | list[str] | set[str]
+    doc: str | None = None
+
+    @property
+    def case_id(self) -> str:
+        """Names the hook; a hook read twice is told apart by the docstring the double carries."""
+        return self.hook if self.doc is not None else f"{self.hook}_without_docstring"
+
+
+DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
+    DegradedFieldCase(
+        hook="get_class_name",
+        class_name="_DocsGetClassNameBoomFG",
+        field="name",
+        expected="_DocsGetClassNameBoomFG",
+        doc="Test double whose get_class_name() raises.",
+    ),
+    DegradedFieldCase(
+        # The fallback is base-class-derived, not "": an empty description would hide the broken
+        # plugin from every search= query, which is the masking risk the degradation avoids.
+        hook="description",
+        class_name="_DocsDescriptionBoomFG",
+        field="description",
+        expected="Test double whose description() raises.",
+        doc="Test double whose description() raises.",
+    ),
+    DegradedFieldCase(
+        # No docstring to fall back on, so the fallback walks one step further, to the class name.
+        hook="description",
+        class_name="_DocsDescriptionNoDocstringFG",
+        field="description",
+        expected="_DocsDescriptionNoDocstringFG",
+    ),
+    DegradedFieldCase(
+        hook="compute_framework_definition",
+        class_name="_DocsFrameworkBoomFG",
+        field="compute_frameworks",
+        expected=[],
+        doc="Test double whose compute_framework_definition() raises.",
+    ),
+    DegradedFieldCase(
+        # The realistic break: the definition hook is @final, so a real plugin breaks framework
+        # discovery by raising from the overridable rule hook that final method calls.
+        hook="compute_framework_rule",
+        class_name="_DocsFrameworkRuleBoomFG",
+        field="compute_frameworks",
+        expected=[],
+        doc="Test double whose compute_framework_rule() raises.",
+    ),
+    DegradedFieldCase(
+        hook="feature_names_supported",
+        class_name="_DocsFeatureNamesBoomFG",
+        field="supported_feature_names",
+        expected=set(),
+        doc="Test double whose feature_names_supported() raises.",
+    ),
+    DegradedFieldCase(
+        # The base-class convention "<__name__>_".
+        hook="prefix",
+        class_name="_DocsPrefixBoomFG",
+        field="prefix",
+        expected="_DocsPrefixBoomFG_",
+        doc="Test double whose prefix() raises.",
+    ),
+]
+
+
 class TestGetFeatureGroupDocsDegradedFieldReads:
     """A FeatureGroup with one broken introspection hook degrades that field, it does not sink the catalog.
 
@@ -250,108 +326,29 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
     frameworks. Degraded entries stay in the catalog and are filtered on their
     degraded values.
 
-    Isolation: every test double is defined inside its test function and reaped in
-    a ``finally`` block (``del`` plus ``gc.collect()``), because plugin docs walk the
-    live ``__subclasses__()`` registry and a leaked class would corrupt sibling
-    tests' catalog calls. This mirrors ``test_get_compute_framework_docs_degrades_when_is_available_raises``.
+    Isolation: every test double is minted inside its test function, under a name of
+    its own, and reaped in a ``finally`` block (``del`` plus ``gc.collect()``), because
+    plugin docs walk the live ``__subclasses__()`` registry and a leaked class would
+    corrupt sibling tests' catalog calls. Only the test-local name holds the double, so
+    no fixture may own it. This mirrors
+    ``test_get_compute_framework_docs_degrades_when_is_available_raises``.
     """
 
-    def test_get_class_name_raising_degrades_to_dunder_name(self) -> None:
-        """A broken get_class_name() falls back to the class __name__."""
+    @pytest.mark.parametrize("case", DEGRADED_FIELD_CASES, ids=[case.case_id for case in DEGRADED_FIELD_CASES])
+    def test_raising_hook_degrades_its_field_to_the_base_class_fallback(self, case: DegradedFieldCase) -> None:
+        """One broken hook degrades one documented field, the class stays in the catalog."""
+        # The hook is a string here, so a misspelled one would mint a healthy double whose
+        # undegraded field can still match the fallback.
+        assert hasattr(FeatureGroup, case.hook), f"{case.hook} is not a FeatureGroup hook"
 
-        class _DocsGetClassNameBoomFG(FeatureGroup):
-            """Test double whose get_class_name() raises."""
-
-            @classmethod  # type: ignore[misc]
-            def get_class_name(cls) -> str:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg(case.class_name, case.hook, doc=case.doc)
         try:
             by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsGetClassNameBoomFG" in by_name, "Degraded class must still be documented under its __name__"
-            assert by_name["_DocsGetClassNameBoomFG"].name == "_DocsGetClassNameBoomFG"
+            assert case.class_name in by_name, f"{case.hook} raising must not drop the class from the catalog"
+            degraded: str | list[str] | set[str] = getattr(by_name[case.class_name], case.field)
+            assert degraded == case.expected
         finally:
-            del _DocsGetClassNameBoomFG
-            gc.collect()
-
-    def test_description_raising_degrades_to_class_docstring(self) -> None:
-        """A broken description() falls back to the class docstring, as compute frameworks already do.
-
-        The fallback is base-class-derived, not "": an empty description would hide the
-        broken plugin from every ``search=`` query, which is exactly the masking risk the
-        degradation is meant to avoid.
-        """
-
-        class _DocsDescriptionBoomFG(FeatureGroup):
-            """Test double whose description() raises."""
-
-            @classmethod
-            def description(cls) -> str:
-                raise RuntimeError("boom")
-
-        try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsDescriptionBoomFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsDescriptionBoomFG"].description == "Test double whose description() raises."
-        finally:
-            del _DocsDescriptionBoomFG
-            gc.collect()
-
-    def test_description_raising_without_docstring_degrades_to_class_name(self) -> None:
-        """With no docstring to fall back on, a broken description() degrades to the class name."""
-
-        class _DocsDescriptionNoDocstringFG(FeatureGroup):
-            @classmethod
-            def description(cls) -> str:
-                raise RuntimeError("boom")
-
-        try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsDescriptionNoDocstringFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsDescriptionNoDocstringFG"].description == "_DocsDescriptionNoDocstringFG"
-        finally:
-            del _DocsDescriptionNoDocstringFG
-            gc.collect()
-
-    def test_compute_framework_definition_raising_degrades_to_empty_list(self) -> None:
-        """A broken compute_framework_definition() falls back to an empty framework list."""
-
-        class _DocsFrameworkBoomFG(FeatureGroup):
-            """Test double whose compute_framework_definition() raises."""
-
-            @classmethod  # type: ignore[misc]
-            def compute_framework_definition(cls) -> set[type[ComputeFramework]]:
-                raise RuntimeError("boom")
-
-        try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsFrameworkBoomFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsFrameworkBoomFG"].compute_frameworks == []
-        finally:
-            del _DocsFrameworkBoomFG
-            gc.collect()
-
-    def test_compute_framework_rule_raising_degrades_to_empty_list(self) -> None:
-        """The realistic break: compute_framework_definition() is @final, but the rule hook it calls is not.
-
-        A plugin cannot override the final definition hook, so the way a real plugin breaks
-        framework discovery is by raising from the overridable compute_framework_rule().
-        That exception surfaces through the final method and must degrade the same way.
-        """
-
-        class _DocsFrameworkRuleBoomFG(FeatureGroup):
-            """Test double whose compute_framework_rule() raises."""
-
-            @classmethod
-            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-                raise RuntimeError("boom")
-
-        try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsFrameworkRuleBoomFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsFrameworkRuleBoomFG"].compute_frameworks == []
-        finally:
-            del _DocsFrameworkRuleBoomFG
+            del double
             gc.collect()
 
     def test_degraded_compute_framework_rule_excluded_by_compute_framework_filter(self) -> None:
@@ -380,42 +377,6 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             assert "_DocsFrameworkRuleFilterBoomFG" not in {fg.name for fg in filtered}
         finally:
             del _DocsFrameworkRuleFilterBoomFG
-            gc.collect()
-
-    def test_feature_names_supported_raising_degrades_to_empty_set(self) -> None:
-        """A broken feature_names_supported() falls back to an empty set."""
-
-        class _DocsFeatureNamesBoomFG(FeatureGroup):
-            """Test double whose feature_names_supported() raises."""
-
-            @classmethod
-            def feature_names_supported(cls) -> set[str]:
-                raise RuntimeError("boom")
-
-        try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsFeatureNamesBoomFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsFeatureNamesBoomFG"].supported_feature_names == set()
-        finally:
-            del _DocsFeatureNamesBoomFG
-            gc.collect()
-
-    def test_prefix_raising_degrades_to_class_name_prefix(self) -> None:
-        """A broken prefix() falls back to the base-class convention "<__name__>_"."""
-
-        class _DocsPrefixBoomFG(FeatureGroup):
-            """Test double whose prefix() raises."""
-
-            @classmethod
-            def prefix(cls) -> str:
-                raise RuntimeError("boom")
-
-        try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsPrefixBoomFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsPrefixBoomFG"].prefix == "_DocsPrefixBoomFG_"
-        finally:
-            del _DocsPrefixBoomFG
             gc.collect()
 
     def test_broken_feature_group_does_not_sink_the_catalog(self) -> None:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -243,11 +243,14 @@ class TestGetFeatureGroupDocs:
         assert len(upper_filtered) == expected
 
 
-@dataclass(frozen=True)
+# Not frozen: a row's expected value is the very list or set the docs field returns, and the __hash__
+# frozen generates would raise on those.
+@dataclass
 class DegradedFieldCase:
-    """One broken hook, the docs field it degrades and the base-class fallback that field lands on."""
+    """One broken hook, the labelled read it degrades, the docs field that read feeds and its fallback."""
 
     hook: str
+    read: str
     class_name: str
     field: str
     expected: str | list[str] | set[str]
@@ -262,6 +265,7 @@ class DegradedFieldCase:
 DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
     DegradedFieldCase(
         hook="get_class_name",
+        read="get_class_name",
         class_name="_DocsGetClassNameBoomFG",
         field="name",
         expected="_DocsGetClassNameBoomFG",
@@ -271,6 +275,7 @@ DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
         # The fallback is base-class-derived, not "": an empty description would hide the broken
         # plugin from every search= query, which is the masking risk the degradation avoids.
         hook="description",
+        read="description",
         class_name="_DocsDescriptionBoomFG",
         field="description",
         expected="Test double whose description() raises.",
@@ -279,12 +284,14 @@ DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
     DegradedFieldCase(
         # No docstring to fall back on, so the fallback walks one step further, to the class name.
         hook="description",
+        read="description",
         class_name="_DocsDescriptionNoDocstringFG",
         field="description",
         expected="_DocsDescriptionNoDocstringFG",
     ),
     DegradedFieldCase(
         hook="compute_framework_definition",
+        read="compute_framework_definition",
         class_name="_DocsFrameworkBoomFG",
         field="compute_frameworks",
         expected=[],
@@ -292,8 +299,10 @@ DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
     ),
     DegradedFieldCase(
         # The realistic break: the definition hook is @final, so a real plugin breaks framework
-        # discovery by raising from the overridable rule hook that final method calls.
+        # discovery by raising from the overridable rule hook that final method calls. The raise
+        # therefore surfaces at that final method, which is where the read is labelled.
         hook="compute_framework_rule",
+        read="compute_framework_definition",
         class_name="_DocsFrameworkRuleBoomFG",
         field="compute_frameworks",
         expected=[],
@@ -301,6 +310,7 @@ DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
     ),
     DegradedFieldCase(
         hook="feature_names_supported",
+        read="feature_names_supported",
         class_name="_DocsFeatureNamesBoomFG",
         field="supported_feature_names",
         expected=set(),
@@ -309,6 +319,7 @@ DEGRADED_FIELD_CASES: list[DegradedFieldCase] = [
     DegradedFieldCase(
         # The base-class convention "<__name__>_".
         hook="prefix",
+        read="prefix",
         class_name="_DocsPrefixBoomFG",
         field="prefix",
         expected="_DocsPrefixBoomFG_",
@@ -334,18 +345,32 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
     """
 
     @pytest.mark.parametrize("case", DEGRADED_FIELD_CASES, ids=[case.case_id for case in DEGRADED_FIELD_CASES])
-    def test_raising_hook_degrades_its_field_to_the_base_class_fallback(self, case: DegradedFieldCase) -> None:
+    def test_raising_hook_degrades_its_field_to_the_base_class_fallback(
+        self, case: DegradedFieldCase, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """One broken hook degrades one documented field, the class stays in the catalog."""
-        # The hook is a string here, so a misspelled one would mint a healthy double whose
-        # undegraded field can still match the fallback.
+        # The hook is a string here, so a misspelled one would mint a double that breaks nothing.
         assert hasattr(FeatureGroup, case.hook), f"{case.hook} is not a FeatureGroup hook"
 
         double = make_raising_fg(case.class_name, case.hook, doc=case.doc)
         try:
-            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+                by_name = {fg.name: fg for fg in get_feature_group_docs()}
             assert case.class_name in by_name, f"{case.hook} raising must not drop the class from the catalog"
             degraded: str | list[str] | set[str] = getattr(by_name[case.class_name], case.field)
             assert degraded == case.expected
+
+            # The value alone is vacuous: for most rows the fallback is also the healthy answer, so only
+            # the warning the guarded read emits proves THIS hook is the one that degraded.
+            expected_warning = f"Degraded field '{case.class_name}.{case.read}'"
+            messages = [
+                record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
+            ]
+            assert any(expected_warning in message for message in messages), (
+                f"Expected a WARNING naming {expected_warning}, got {messages}"
+            )
         finally:
             del double
             gc.collect()
@@ -360,13 +385,11 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
                 break
         assert canonical_name is not None, "Need a feature group with at least one compute framework"
 
-        class _DocsFrameworkRuleFilterBoomFG(FeatureGroup):
-            """Test double whose compute_framework_rule() raises."""
-
-            @classmethod
-            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg(
+            "_DocsFrameworkRuleFilterBoomFG",
+            "compute_framework_rule",
+            doc="Test double whose compute_framework_rule() raises.",
+        )
         try:
             unfiltered = {fg.name for fg in get_feature_group_docs()}
             assert "_DocsFrameworkRuleFilterBoomFG" in unfiltered, "Degraded class must still be documented"
@@ -375,7 +398,7 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             assert len(filtered) > 0, "Healthy feature groups must still match the framework filter"
             assert "_DocsFrameworkRuleFilterBoomFG" not in {fg.name for fg in filtered}
         finally:
-            del _DocsFrameworkRuleFilterBoomFG
+            del double
             gc.collect()
 
     def test_broken_feature_group_does_not_sink_the_catalog(self) -> None:
@@ -383,36 +406,25 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
         baseline = {fg.name for fg in get_feature_group_docs()}
         assert len(baseline) > 0, "Need a populated baseline catalog"
 
-        class _DocsSinkBoomFG(FeatureGroup):
-            """Test double whose description() raises."""
-
-            @classmethod
-            def description(cls) -> str:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg("_DocsSinkBoomFG", "description", doc="Test double whose description() raises.")
         try:
             degraded = {fg.name for fg in get_feature_group_docs()}
             assert baseline.issubset(degraded), "A broken plugin must not drop healthy feature groups"
             assert "_DocsSinkBoomFG" in degraded
         finally:
-            del _DocsSinkBoomFG
+            del double
             gc.collect()
 
     def test_degraded_name_still_findable_by_name_filter(self) -> None:
         """A class whose get_class_name() raises is findable via name=<its real __name__>."""
-
-        class _DocsNameFilterBoomFG(FeatureGroup):
-            """Test double whose get_class_name() raises."""
-
-            @classmethod  # type: ignore[misc]
-            def get_class_name(cls) -> str:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg(
+            "_DocsNameFilterBoomFG", "get_class_name", doc="Test double whose get_class_name() raises."
+        )
         try:
             filtered = get_feature_group_docs(name="_DocsNameFilterBoomFG")
             assert [fg.name for fg in filtered] == ["_DocsNameFilterBoomFG"]
         finally:
-            del _DocsNameFilterBoomFG
+            del double
             gc.collect()
 
     def test_degraded_description_still_findable_by_search_filter(self) -> None:
@@ -421,34 +433,24 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
         Degrading to the docstring keeps a broken plugin discoverable; degrading to ""
         would make it invisible to every search query.
         """
-
-        class _DocsSearchBoomFG(FeatureGroup):
-            """Test double whose description() raises, keyword lodestarquux."""
-
-            @classmethod
-            def description(cls) -> str:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg(
+            "_DocsSearchBoomFG", "description", doc="Test double whose description() raises, keyword lodestarquux."
+        )
         try:
             searched = {fg.name for fg in get_feature_group_docs(search="lodestarquux")}
             assert "_DocsSearchBoomFG" in searched, "A degraded description must stay searchable via the docstring"
         finally:
-            del _DocsSearchBoomFG
+            del double
             gc.collect()
 
     def test_degraded_description_without_docstring_findable_by_class_name_search(self) -> None:
         """With no docstring, the degraded description is the class name and search= finds it there."""
-
-        class _DocsSearchNoDocstringBoomFG(FeatureGroup):
-            @classmethod
-            def description(cls) -> str:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg("_DocsSearchNoDocstringBoomFG", "description")
         try:
             searched = {fg.name for fg in get_feature_group_docs(search="_DocsSearchNoDocstringBoomFG")}
             assert "_DocsSearchNoDocstringBoomFG" in searched
         finally:
-            del _DocsSearchNoDocstringBoomFG
+            del double
             gc.collect()
 
     def test_degraded_compute_frameworks_excluded_by_compute_framework_filter(self) -> None:
@@ -465,13 +467,11 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
                 break
         assert canonical_name is not None, "Need a feature group with at least one compute framework"
 
-        class _DocsFrameworkFilterBoomFG(FeatureGroup):
-            """Test double whose compute_framework_definition() raises."""
-
-            @classmethod  # type: ignore[misc]
-            def compute_framework_definition(cls) -> set[type[ComputeFramework]]:
-                raise RuntimeError("boom")
-
+        double = make_raising_fg(
+            "_DocsFrameworkFilterBoomFG",
+            "compute_framework_definition",
+            doc="Test double whose compute_framework_definition() raises.",
+        )
         try:
             unfiltered = {fg.name for fg in get_feature_group_docs()}
             assert "_DocsFrameworkFilterBoomFG" in unfiltered, "Degraded class must still be documented"
@@ -480,7 +480,7 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             assert len(filtered) > 0, "Healthy feature groups must still match the framework filter"
             assert "_DocsFrameworkFilterBoomFG" not in {fg.name for fg in filtered}
         finally:
-            del _DocsFrameworkFilterBoomFG
+            del double
             gc.collect()
 
 

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -326,12 +326,11 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
     frameworks. Degraded entries stay in the catalog and are filtered on their
     degraded values.
 
-    Isolation: every test double is minted inside its test function, under a name of
-    its own, and reaped in a ``finally`` block (``del`` plus ``gc.collect()``), because
-    plugin docs walk the live ``__subclasses__()`` registry and a leaked class would
-    corrupt sibling tests' catalog calls. Only the test-local name holds the double, so
-    no fixture may own it. This mirrors
-    ``test_get_compute_framework_docs_degrades_when_is_available_raises``.
+    Isolation: every test double is minted inside its test function and reaped in a
+    ``finally`` block (``del`` plus ``gc.collect()``), because plugin docs walk the live
+    ``__subclasses__()`` registry and a leaked class would corrupt sibling tests' catalog
+    calls. No fixture may own the double, since only the test-local name holds it. This
+    mirrors ``test_get_compute_framework_docs_degrades_when_is_available_raises``.
     """
 
     @pytest.mark.parametrize("case", DEGRADED_FIELD_CASES, ids=[case.case_id for case in DEGRADED_FIELD_CASES])

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -5,7 +5,8 @@ during its single first pass: per-candidate compute-framework capability
 (``EvaluationResult.candidate_frameworks``) plus the remaining facts (``EvaluationResult.facts``).
 ``render_resolution_failure(result, feature)`` is then a PURE projection of that result: it reads
 only the result and the ``Feature``, never re-runs matching and never calls a provider-overridable
-hook. The feature groups below count every such hook, so a renderer that calls one is caught.
+hook. The feature groups below count every such hook through the shared counting stub base, so a
+renderer that calls one is caught.
 
 All names are suffixed ``_791`` because test feature groups become global subclasses.
 """
@@ -16,7 +17,7 @@ from abc import abstractmethod
 from ast import literal_eval
 from collections.abc import Callable, Iterator
 from difflib import get_close_matches
-from typing import Any, ClassVar, Optional, cast, get_args
+from typing import Any, Optional, cast, get_args
 
 import pytest
 
@@ -46,6 +47,7 @@ from mloda.core.prepare.resolution_types import (
     EvaluationResult,
     RenderFacts,
 )
+from tests.helpers.plugin_stubs import CountingStubFeatureGroup, HookCounter, StubFeatureGroup, make_fg
 
 
 SUCCESS_FEATURE_791 = "renderer_success_791"
@@ -212,24 +214,15 @@ TROUBLESHOOTING_LINE = (
 
 SUGGESTION_PREFIX = "Did you mean one of: "
 
+HOOK_COUNTER_791 = HookCounter()
+
 # Call counters for every provider-overridable hook, keyed "<ClassName>.<hook>". Reset per test.
-HOOK_CALLS: dict[str, int] = {}
+# A live alias, never rebound: HookCounter.clear() empties its dicts in place.
+HOOK_CALLS: dict[str, int] = HOOK_COUNTER_791.calls
 
 # supports_compute_framework calls keyed by the (candidate, framework) PAIR it was asked about.
 # HOOK_CALLS only knows the hook name, so it cannot see a pair being asked twice. Reset per test.
-PAIR_CALLS: dict[tuple[str, str], int] = {}
-
-
-def _record(class_name: str, hook: str) -> None:
-    """Count one call of a provider-overridable hook."""
-    key = f"{class_name}.{hook}"
-    HOOK_CALLS[key] = HOOK_CALLS.get(key, 0) + 1
-
-
-def _record_pair(class_name: str, framework_name: str) -> None:
-    """Count one capability-hook call for a single (candidate, framework) pair."""
-    key = (class_name, framework_name)
-    PAIR_CALLS[key] = PAIR_CALLS.get(key, 0) + 1
+PAIR_CALLS: dict[tuple[str, str], int] = HOOK_COUNTER_791.pairs
 
 
 def _malformed(value: Any) -> Any:
@@ -253,120 +246,59 @@ class RendererFwThree791(ComputeFramework):
     """Third dummy compute framework, used only to pin a feature away from every candidate."""
 
 
-class CountingFeatureGroup791(FeatureGroup):
+# The two framework rules the stubs below pick from; make_fg copies the set it is given, so sharing is safe.
+ONE_FRAMEWORK_791: set[type[ComputeFramework]] = {RendererFwOne791}
+TWO_FRAMEWORKS_791: set[type[ComputeFramework]] = {RendererFwOne791, RendererFwTwo791}
+
+
+class CountingFeatureGroup791(CountingStubFeatureGroup):
     """Feature group base that counts every provider-overridable hook the renderer must not call."""
 
-    MATCHES: ClassVar[frozenset[str]] = frozenset()
-    DOMAIN_NAME: ClassVar[Optional[str]] = None
-    FRAMEWORK_RULE: ClassVar[Optional[set[type[ComputeFramework]]]] = None
-    SUPPORTED_FRAMEWORKS: ClassVar[Optional[frozenset[str]]] = None
-    SUPPORTED_NAMES: ClassVar[frozenset[str]] = frozenset()
-    # Both default to what the hooks returned before they were declarative: the links gate passes unconditionally.
-    INDEX_COLUMNS: ClassVar[Optional[list[Index]]] = None
-    SUPPORTS_INDEX_RESULT: ClassVar[Optional[bool]] = None
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        _record(cls.get_class_name(), "match_feature_group_criteria")
-        return str(feature_name) in cls.MATCHES
-
-    @classmethod
-    def get_domain(cls) -> Domain:
-        _record(cls.get_class_name(), "get_domain")
-        if cls.DOMAIN_NAME is None:
-            return Domain.get_default_domain()
-        return Domain(cls.DOMAIN_NAME)
-
-    @classmethod
-    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        _record(cls.get_class_name(), "compute_framework_rule")
-        return cls.FRAMEWORK_RULE
-
-    @classmethod
-    def supports_compute_framework(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        compute_framework: type[ComputeFramework],
-    ) -> bool:
-        _record(cls.get_class_name(), "supports_compute_framework")
-        _record_pair(cls.get_class_name(), compute_framework.get_class_name())
-        if cls.SUPPORTED_FRAMEWORKS is None:
-            return True
-        return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
-
-    @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
-        _record(cls.get_class_name(), "index_columns")
-        return cls.INDEX_COLUMNS
-
-    @classmethod
-    def supports_index(cls, index: Index) -> Optional[bool]:
-        _record(cls.get_class_name(), "supports_index")
-        return cls.SUPPORTS_INDEX_RESULT
-
-    @classmethod
-    def feature_names_supported(cls) -> set[str]:
-        _record(cls.get_class_name(), "feature_names_supported")
-        return set(cls.SUPPORTED_NAMES)
-
-    @classmethod
-    def prefix(cls) -> str:
-        _record(cls.get_class_name(), "prefix")
-        return f"{cls.get_class_name()}_"
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    COUNTER = HOOK_COUNTER_791
 
 
-class RendererSuccessFG791(CountingFeatureGroup791):
-    """Sole winner of the success scenario."""
-
-    MATCHES = frozenset({SUCCESS_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class RendererMultipleAFG791(CountingFeatureGroup791):
-    """First of two unrelated siblings matching the same name, in domain 'renderer_domain_a_791'."""
-
-    MATCHES = frozenset({MULTIPLE_FEATURE_791})
-    DOMAIN_NAME = "renderer_domain_a_791"
-    FRAMEWORK_RULE = {RendererFwOne791}
+def _counting_fg(name: str, **kwargs: Any) -> type[StubFeatureGroup]:
+    """Mint a counting stub of this module; make_fg reads the calling module through this frame."""
+    kwargs.setdefault("base", CountingFeatureGroup791)
+    return make_fg(name, **kwargs)
 
 
-class RendererMultipleBFG791(CountingFeatureGroup791):
-    """Second sibling matching the same name, in domain 'renderer_domain_b_791'."""
+RendererSuccessFG791 = _counting_fg("RendererSuccessFG791", matches=SUCCESS_FEATURE_791, frameworks=ONE_FRAMEWORK_791)
 
-    MATCHES = frozenset({MULTIPLE_FEATURE_791})
-    DOMAIN_NAME = "renderer_domain_b_791"
-    FRAMEWORK_RULE = {RendererFwOne791}
+RendererMultipleAFG791 = _counting_fg(
+    "RendererMultipleAFG791",
+    matches=MULTIPLE_FEATURE_791,
+    domain="renderer_domain_a_791",
+    frameworks=ONE_FRAMEWORK_791,
+)
 
+RendererMultipleBFG791 = _counting_fg(
+    "RendererMultipleBFG791",
+    matches=MULTIPLE_FEATURE_791,
+    domain="renderer_domain_b_791",
+    frameworks=ONE_FRAMEWORK_791,
+)
 
-class RendererCapabilityAFG791(CountingFeatureGroup791):
-    """Mirrored capability candidate: supports RendererFwOne791, rejects RendererFwTwo791."""
+# Mirrored capability candidates: each supports exactly the framework the other rejects.
+RendererCapabilityAFG791 = _counting_fg(
+    "RendererCapabilityAFG791",
+    matches=CAPABILITY_FEATURE_791,
+    frameworks=TWO_FRAMEWORKS_791,
+    supported_frameworks="RendererFwOne791",
+)
 
-    MATCHES = frozenset({CAPABILITY_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwOne791"})
-
-
-class RendererCapabilityBFG791(CountingFeatureGroup791):
-    """Mirrored capability candidate: supports RendererFwTwo791, rejects RendererFwOne791."""
-
-    MATCHES = frozenset({CAPABILITY_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
+RendererCapabilityBFG791 = _counting_fg(
+    "RendererCapabilityBFG791",
+    matches=CAPABILITY_FEATURE_791,
+    frameworks=TWO_FRAMEWORKS_791,
+    supported_frameworks="RendererFwTwo791",
+)
 
 
 class RendererAbstractBaseFG791(CountingFeatureGroup791):
     """Abstract base that matches the name but can never be instantiated."""
 
-    MATCHES = frozenset({ABSTRACT_FEATURE_791})
+    MATCHED_NAMES = frozenset({ABSTRACT_FEATURE_791})
     FRAMEWORK_RULE = {RendererFwOne791}
 
     @classmethod
@@ -378,7 +310,7 @@ class RendererAbstractBaseFG791(CountingFeatureGroup791):
 class RendererConcreteSubFG791(RendererAbstractBaseFG791):
     """Concrete implementation of the abstract base, declaring two compute frameworks."""
 
-    MATCHES = frozenset({ABSTRACT_FEATURE_791})
+    MATCHED_NAMES = frozenset({ABSTRACT_FEATURE_791})
     FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
 
     @classmethod
@@ -386,18 +318,19 @@ class RendererConcreteSubFG791(RendererAbstractBaseFG791):
         return "concrete"
 
 
-class RendererKnownNamesFG791(CountingFeatureGroup791):
-    """Name catalog for the 'Did you mean' suggestion."""
-
-    MATCHES = frozenset({KNOWN_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({KNOWN_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
+# Name catalog for the 'Did you mean' suggestion.
+RendererKnownNamesFG791 = _counting_fg(
+    "RendererKnownNamesFG791",
+    matches=KNOWN_FEATURE_791,
+    supported_names=KNOWN_FEATURE_791,
+    frameworks=ONE_FRAMEWORK_791,
+)
 
 
 class RendererBareOnlyFG791(CountingFeatureGroup791):
     """Matches its bare name only: any group option makes it reject the feature."""
 
-    MATCHES = frozenset({FORWARDING_FEATURE_791})
+    MATCHED_NAMES = frozenset({FORWARDING_FEATURE_791})
     FRAMEWORK_RULE = {RendererFwOne791}
 
     @classmethod
@@ -431,17 +364,17 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
         options: Options,
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> bool:
-        _record(cls.get_class_name(), "match_feature_group_criteria")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "match_feature_group_criteria")
         return super().match_feature_group_criteria(feature_name, options, data_access_collection)
 
     @classmethod
     def get_domain(cls) -> Domain:
-        _record(cls.get_class_name(), "get_domain")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "get_domain")
         return super().get_domain()
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        _record(cls.get_class_name(), "compute_framework_rule")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "compute_framework_rule")
         return {RendererFwOne791}
 
     @classmethod
@@ -451,32 +384,32 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
         options: Options,
         compute_framework: type[ComputeFramework],
     ) -> bool:
-        _record(cls.get_class_name(), "supports_compute_framework")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "supports_compute_framework")
         return super().supports_compute_framework(feature_name, options, compute_framework)
 
     @classmethod
     def index_columns(cls) -> Optional[list[Index]]:
-        _record(cls.get_class_name(), "index_columns")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "index_columns")
         return None
 
     @classmethod
     def supports_index(cls, index: Index) -> Optional[bool]:
-        _record(cls.get_class_name(), "supports_index")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "supports_index")
         return None
 
     @classmethod
     def feature_names_supported(cls) -> set[str]:
-        _record(cls.get_class_name(), "feature_names_supported")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "feature_names_supported")
         return set()
 
     @classmethod
     def prefix(cls) -> str:
-        _record(cls.get_class_name(), "prefix")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "prefix")
         return f"{cls.get_class_name()}_"
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-        _record(cls.get_class_name(), "_strict_validation_rejection_reason")
+        HOOK_COUNTER_791.record(cls.get_class_name(), "_strict_validation_rejection_reason")
         return super()._strict_validation_rejection_reason(feature_name, options)
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -503,124 +436,101 @@ class RendererMissingOptionFG791(FeatureChainParserMixin, FeatureGroup):
 MISSING_OPTION_REASON_791 = "required option(s) some_key_791m are absent after declared defaults and name bindings"
 
 
-class RendererNarrowEnabledFG791(CountingFeatureGroup791):
-    """Declares two available frameworks; the run enables only the one this candidate rejects."""
+# Declares two available frameworks; the run enables only the one this candidate rejects.
+RendererNarrowEnabledFG791 = _counting_fg(
+    "RendererNarrowEnabledFG791",
+    matches=NARROW_ENABLED_FEATURE_791,
+    frameworks=TWO_FRAMEWORKS_791,
+    supported_frameworks="RendererFwTwo791",
+)
 
-    MATCHES = frozenset({NARROW_ENABLED_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
+# Declares two available frameworks; the run enables neither of them.
+RendererNoneEnabledFG791 = _counting_fg(
+    "RendererNoneEnabledFG791",
+    matches=NONE_ENABLED_FEATURE_791,
+    frameworks=TWO_FRAMEWORKS_791,
+    supported_frameworks="RendererFwTwo791",
+)
 
+# Declares the requested name itself, then loses every framework the run could have enabled.
+RendererStrandedFG791 = _counting_fg(
+    "RendererStrandedFG791",
+    matches=STRANDED_FEATURE_791,
+    supported_names=STRANDED_FEATURE_791,
+    frameworks=TWO_FRAMEWORKS_791,
+)
 
-class RendererNoneEnabledFG791(CountingFeatureGroup791):
-    """Declares two available frameworks; the run enables neither of them."""
+# Eliminated candidate declaring the requested name, so the name catalog carries the exact echo.
+RendererCutoffAFG791 = _counting_fg(
+    "RendererCutoffAFG791",
+    matches=CUTOFF_FEATURE_791,
+    supported_names=CUTOFF_FEATURE_791,
+    frameworks=TWO_FRAMEWORKS_791,
+)
 
-    MATCHES = frozenset({NONE_ENABLED_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
+# Second eliminated candidate, contributing two more droppable hints: its class name and its prefix.
+RendererCutoffBFG791 = _counting_fg("RendererCutoffBFG791", matches=CUTOFF_FEATURE_791, frameworks=TWO_FRAMEWORKS_791)
 
+# Healthy catalog group, named far enough from the request that only its supported name can be suggested.
+SpareNameCatalogFG791 = _counting_fg(
+    "SpareNameCatalogFG791",
+    matches=CUTOFF_CATALOG_NAME_791,
+    supported_names=CUTOFF_CATALOG_NAME_791,
+    frameworks=ONE_FRAMEWORK_791,
+)
 
-class RendererStrandedFG791(CountingFeatureGroup791):
-    """Declares the requested name itself, then loses every framework the run could have enabled."""
+# Catalog candidate declaring the shared name; the four siblings below declare exactly the same one.
+RendererDuplicateNameFG791 = _counting_fg(
+    "RendererDuplicateNameFG791", supported_names=DUPLICATE_CATALOG_NAME_791, frameworks=ONE_FRAMEWORK_791
+)
 
-    MATCHES = frozenset({STRANDED_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({STRANDED_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+RendererDuplicateSiblingAFG791 = _counting_fg("RendererDuplicateSiblingAFG791", base=RendererDuplicateNameFG791)
+RendererDuplicateSiblingBFG791 = _counting_fg("RendererDuplicateSiblingBFG791", base=RendererDuplicateNameFG791)
+RendererDuplicateSiblingCFG791 = _counting_fg("RendererDuplicateSiblingCFG791", base=RendererDuplicateNameFG791)
+# The fifth copy of the shared name, enough to fill every suggestion slot.
+RendererDuplicateSiblingDFG791 = _counting_fg("RendererDuplicateSiblingDFG791", base=RendererDuplicateNameFG791)
 
+# Catalog candidate holding the one genuinely different close name the copies push out.
+RendererDuplicateSpareFG791 = _counting_fg(
+    "RendererDuplicateSpareFG791", supported_names=DUPLICATE_SPARE_NAME_791, frameworks=ONE_FRAMEWORK_791
+)
 
-class RendererCutoffAFG791(CountingFeatureGroup791):
-    """Eliminated candidate declaring the requested name, so the name catalog carries the exact echo."""
+# Declares the requested name but matches nothing, so nothing records it as an elimination.
+RendererDeclaredUnmatchedFG791 = _counting_fg(
+    "RendererDeclaredUnmatchedFG791", supported_names=DECLARED_UNMATCHED_FEATURE_791, frameworks=ONE_FRAMEWORK_791
+)
 
-    MATCHES = frozenset({CUTOFF_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({CUTOFF_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+# Catalog candidate declaring more close names than the message may ever list.
+RendererWideCatalogFG791 = _counting_fg(
+    "RendererWideCatalogFG791", supported_names=WIDE_CATALOG_NAMES_791, frameworks=ONE_FRAMEWORK_791
+)
 
+# The reported repro: declares the requested name AND a sibling, then loses every framework.
+RendererDeadSiblingFG791 = _counting_fg(
+    "RendererDeadSiblingFG791",
+    matches=DEAD_SIBLING_FEATURE_791,
+    supported_names=(DEAD_SIBLING_FEATURE_791, DEAD_SIBLING_SPARE_791),
+    frameworks=TWO_FRAMEWORKS_791,
+)
 
-class RendererCutoffBFG791(CountingFeatureGroup791):
-    """Second eliminated candidate, contributing two more droppable hints: its class name and its prefix."""
+# Dead contributor of two names: one it shares with the live group below, one only it declares.
+RendererSharedDeadFG791 = _counting_fg(
+    "RendererSharedDeadFG791",
+    matches=SHARED_TYPO_FEATURE_791,
+    supported_names=(SHARED_LIVE_NAME_791, SHARED_DEAD_NAME_791),
+    frameworks=TWO_FRAMEWORKS_791,
+)
 
-    MATCHES = frozenset({CUTOFF_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-
-
-class SpareNameCatalogFG791(CountingFeatureGroup791):
-    """Healthy catalog group, named far enough from the request that only its supported name can be suggested."""
-
-    MATCHES = frozenset({CUTOFF_CATALOG_NAME_791})
-    SUPPORTED_NAMES = frozenset({CUTOFF_CATALOG_NAME_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class RendererDuplicateNameFG791(CountingFeatureGroup791):
-    """Catalog candidate declaring the shared name; the four siblings below declare exactly the same one."""
-
-    SUPPORTED_NAMES = frozenset({DUPLICATE_CATALOG_NAME_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class RendererDuplicateSiblingAFG791(RendererDuplicateNameFG791):
-    """Second contributor of the shared name."""
-
-
-class RendererDuplicateSiblingBFG791(RendererDuplicateNameFG791):
-    """Third contributor of the shared name."""
-
-
-class RendererDuplicateSiblingCFG791(RendererDuplicateNameFG791):
-    """Fourth contributor of the shared name."""
-
-
-class RendererDuplicateSiblingDFG791(RendererDuplicateNameFG791):
-    """Fifth contributor of the shared name, enough copies to fill every suggestion slot."""
-
-
-class RendererDuplicateSpareFG791(CountingFeatureGroup791):
-    """Catalog candidate holding the one genuinely different close name the copies push out."""
-
-    SUPPORTED_NAMES = frozenset({DUPLICATE_SPARE_NAME_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class RendererDeclaredUnmatchedFG791(CountingFeatureGroup791):
-    """Declares the requested name but matches nothing, so nothing records it as an elimination."""
-
-    SUPPORTED_NAMES = frozenset({DECLARED_UNMATCHED_FEATURE_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class RendererWideCatalogFG791(CountingFeatureGroup791):
-    """Catalog candidate declaring more close names than the message may ever list."""
-
-    SUPPORTED_NAMES = WIDE_CATALOG_NAMES_791
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class RendererDeadSiblingFG791(CountingFeatureGroup791):
-    """The reported repro: declares the requested name AND a sibling, then loses every framework."""
-
-    MATCHES = frozenset({DEAD_SIBLING_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({DEAD_SIBLING_FEATURE_791, DEAD_SIBLING_SPARE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-
-
-class RendererSharedDeadFG791(CountingFeatureGroup791):
-    """Dead contributor of two names: one it shares with the live group below, one only it declares."""
-
-    MATCHES = frozenset({SHARED_TYPO_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({SHARED_LIVE_NAME_791, SHARED_DEAD_NAME_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-
-
-class RendererSharedLiveFG791(CountingFeatureGroup791):
-    """Live contributor of the shared name: it matches nothing here, so nothing ever eliminates it."""
-
-    SUPPORTED_NAMES = frozenset({SHARED_LIVE_NAME_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
+# Live contributor of the shared name: it matches nothing here, so nothing ever eliminates it.
+RendererSharedLiveFG791 = _counting_fg(
+    "RendererSharedLiveFG791", supported_names=SHARED_LIVE_NAME_791, frameworks=ONE_FRAMEWORK_791
+)
 
 
 class RendererValueStageFG791(CountingFeatureGroup791):
     """Eliminated at value_rejection, a name-DEPENDENT stage: it declined THIS name's value."""
 
-    MATCHES = frozenset({VALUE_STAGE_FEATURE_791})
+    MATCHED_NAMES = frozenset({VALUE_STAGE_FEATURE_791})
     SUPPORTED_NAMES = frozenset({VALUE_STAGE_SPARE_791})
     FRAMEWORK_RULE = {RendererFwOne791}
 
@@ -637,31 +547,28 @@ class RendererValueStageFG791(CountingFeatureGroup791):
         raise PropertyValueRejection(VALUE_STAGE_REJECTION_REASON_791)
 
 
-class RendererCapabilityStageFG791(CountingFeatureGroup791):
-    """Eliminated at capability: the per-feature hook rejected the one framework the run enabled."""
+# Eliminated at capability: the per-feature hook rejected the one framework the run enabled.
+RendererCapabilityStageFG791 = _counting_fg(
+    "RendererCapabilityStageFG791",
+    matches=CAPABILITY_STAGE_FEATURE_791,
+    supported_names=CAPABILITY_STAGE_SPARE_791,
+    frameworks=ONE_FRAMEWORK_791,
+    supported_frameworks="RendererFwThree791",
+)
 
-    MATCHES = frozenset({CAPABILITY_STAGE_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({CAPABILITY_STAGE_SPARE_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwThree791"})
+# Declares and matches BOTH names, then loses every framework: whichever one is requested, it is eliminated.
+RendererDisabledPairFG791 = _counting_fg(
+    "RendererDisabledPairFG791",
+    matches=(DISABLED_PAIR_FEATURE_791, DISABLED_PAIR_SPARE_791),
+    supported_names=(DISABLED_PAIR_FEATURE_791, DISABLED_PAIR_SPARE_791),
+    frameworks=TWO_FRAMEWORKS_791,
+)
 
-
-class RendererDisabledPairFG791(CountingFeatureGroup791):
-    """Declares and matches BOTH names, then loses every framework: whichever one is requested, it is eliminated."""
-
-    MATCHES = frozenset({DISABLED_PAIR_FEATURE_791, DISABLED_PAIR_SPARE_791})
-    SUPPORTED_NAMES = frozenset({DISABLED_PAIR_FEATURE_791, DISABLED_PAIR_SPARE_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-
-
-class SpareNoFrameworkFG791(CountingFeatureGroup791):
-    """Declares the spare name and matches nothing, so nothing records the empty framework set that kills it.
-
-    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
-    """
-
-    SUPPORTED_NAMES = frozenset({DISABLED_PAIR_SPARE_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
+# Declares the spare name and matches nothing, so nothing records the empty framework set that kills it.
+# Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+SpareNoFrameworkFG791 = _counting_fg(
+    "SpareNoFrameworkFG791", supported_names=DISABLED_PAIR_SPARE_791, frameworks=ONE_FRAMEWORK_791
+)
 
 
 class RendererLivePrefixFG791(CountingFeatureGroup791):
@@ -676,28 +583,26 @@ class RendererLivePrefixFG791(CountingFeatureGroup791):
         options: Options,
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> bool:
-        _record(cls.get_class_name(), "match_feature_group_criteria")
+        cls._enter_hook("match_feature_group_criteria")
         return cls.feature_name_contains_class_name_as_prefix(str(feature_name))
 
 
-class RendererDeadPrefixFG791(CountingFeatureGroup791):
-    """Dead declarer of two names: one the live prefix above covers, one only its own dead prefix covers."""
+# Dead declarer of two names: one the live prefix above covers, one only its own dead prefix covers.
+RendererDeadPrefixFG791 = _counting_fg(
+    "RendererDeadPrefixFG791",
+    matches=LIVE_PREFIX_FEATURE_791,
+    supported_names=(LIVE_PREFIX_COVERED_791, DEAD_PREFIX_UNCOVERED_791),
+    frameworks=TWO_FRAMEWORKS_791,
+)
 
-    MATCHES = frozenset({LIVE_PREFIX_FEATURE_791})
-    SUPPORTED_NAMES = frozenset({LIVE_PREFIX_COVERED_791, DEAD_PREFIX_UNCOVERED_791})
-    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-
-
-class CrossDomainDeclarerFG791(CountingFeatureGroup791):
-    """Declares and matches the sibling name only, from a domain no request here asks for.
-
-    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
-    """
-
-    MATCHES = frozenset({DOMAIN_GATE_SIBLING_791})
-    SUPPORTED_NAMES = frozenset({DOMAIN_GATE_SIBLING_791})
-    DOMAIN_NAME = OTHER_DOMAIN_791
-    FRAMEWORK_RULE = {RendererFwOne791}
+# Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+CrossDomainDeclarerFG791 = _counting_fg(
+    "CrossDomainDeclarerFG791",
+    matches=DOMAIN_GATE_SIBLING_791,
+    supported_names=DOMAIN_GATE_SIBLING_791,
+    domain=OTHER_DOMAIN_791,
+    frameworks=ONE_FRAMEWORK_791,
+)
 
 
 class RendererCrossDomainNameFG791(CountingFeatureGroup791):
@@ -716,42 +621,39 @@ class RendererCrossDomainNameFG791(CountingFeatureGroup791):
         options: Options,
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> bool:
-        _record(cls.get_class_name(), "match_feature_group_criteria")
+        cls._enter_hook("match_feature_group_criteria")
         # The two class-identity rules of the default matcher, and the two names the catalog captures for it.
         name = str(feature_name)
         return cls.feature_name_equal_to_class_name(name) or cls.feature_name_contains_class_name_as_prefix(name)
 
 
-class RendererLiveNameDeclarerFG791(CountingFeatureGroup791):
-    """Live declarer of the wrong-domain group's two class-identity names, in the requested domain."""
+# Live declarer of the wrong-domain group's two class-identity names, in the requested domain.
+RendererLiveNameDeclarerFG791 = _counting_fg(
+    "RendererLiveNameDeclarerFG791",
+    supported_names=(DEAD_CLASS_NAME_791, DEAD_CLASS_PREFIX_791),
+    domain=REQUESTED_DOMAIN_791,
+    frameworks=ONE_FRAMEWORK_791,
+)
 
-    SUPPORTED_NAMES = frozenset({DEAD_CLASS_NAME_791, DEAD_CLASS_PREFIX_791})
-    DOMAIN_NAME = REQUESTED_DOMAIN_791
-    FRAMEWORK_RULE = {RendererFwOne791}
+# Declares and matches the sibling name only, from outside the scope every request here asks for.
+# Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+OutsideScopeDeclarerFG791 = _counting_fg(
+    "OutsideScopeDeclarerFG791",
+    matches=SCOPE_GATE_SIBLING_791,
+    supported_names=SCOPE_GATE_SIBLING_791,
+    frameworks=ONE_FRAMEWORK_791,
+)
 
-
-class OutsideScopeDeclarerFG791(CountingFeatureGroup791):
-    """Declares and matches the sibling name only, from outside the scope every request here asks for.
-
-    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
-    """
-
-    MATCHES = frozenset({SCOPE_GATE_SIBLING_791})
-    SUPPORTED_NAMES = frozenset({SCOPE_GATE_SIBLING_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-
-class LinksGateDeclarerFG791(CountingFeatureGroup791):
-    """Declares and matches the sibling name only, with an index column no link of the runs below reaches.
-
-    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
-    """
-
-    MATCHES = frozenset({LINKS_GATE_SIBLING_791})
-    SUPPORTED_NAMES = frozenset({LINKS_GATE_SIBLING_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
-    INDEX_COLUMNS = [Index(("renderer_links_index_791",))]
-    SUPPORTS_INDEX_RESULT = False
+# Its index column is one that no link of the runs below reaches.
+# Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+LinksGateDeclarerFG791 = _counting_fg(
+    "LinksGateDeclarerFG791",
+    matches=LINKS_GATE_SIBLING_791,
+    supported_names=LINKS_GATE_SIBLING_791,
+    frameworks=ONE_FRAMEWORK_791,
+    index_columns=[Index(("renderer_links_index_791",))],
+    supports_index=False,
+)
 
 
 # The one link every linked run below carries; no group here supports either of its two indexes.
@@ -761,38 +663,31 @@ LINKS_GATE_LINK_791 = Link.inner(
 )
 
 
-class SpareAbstractBaseFG791(CountingFeatureGroup791):
-    """Abstract base declaring and matching one name, in the requested domain: it can never be identified.
+# Abstract, so it can never be identified.
+# Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+SpareAbstractBaseFG791 = _counting_fg(
+    "SpareAbstractBaseFG791",
+    matches=ABSTRACT_DECLARER_NAME_791,
+    supported_names=ABSTRACT_DECLARER_NAME_791,
+    domain=REQUESTED_DOMAIN_791,
+    frameworks=ONE_FRAMEWORK_791,
+    abstract=True,
+)
 
-    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
-    """
-
-    MATCHES = frozenset({ABSTRACT_DECLARER_NAME_791})
-    SUPPORTED_NAMES = frozenset({ABSTRACT_DECLARER_NAME_791})
-    DOMAIN_NAME = REQUESTED_DOMAIN_791
-    FRAMEWORK_RULE = {RendererFwOne791}
-
-    @classmethod
-    @abstractmethod
-    def _renderer_spare_abstract_hook_791(cls) -> str:
-        """Abstract hook that keeps this base uninstantiable."""
-
-
-class SpareDeadTwinFG791(CountingFeatureGroup791):
-    """Concrete declarer of the same name, left without a single enabled framework by every run below.
-
-    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
-    """
-
-    MATCHES = frozenset({ABSTRACT_DECLARER_NAME_791})
-    SUPPORTED_NAMES = frozenset({ABSTRACT_DECLARER_NAME_791})
-    FRAMEWORK_RULE = {RendererFwOne791}
+# Concrete declarer of the same name, left without a single enabled framework by every run below.
+# Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+SpareDeadTwinFG791 = _counting_fg(
+    "SpareDeadTwinFG791",
+    matches=ABSTRACT_DECLARER_NAME_791,
+    supported_names=ABSTRACT_DECLARER_NAME_791,
+    frameworks=ONE_FRAMEWORK_791,
+)
 
 
 class ValueRejectingCrossDomainFG791(CountingFeatureGroup791):
     """Declines THIS name's value at the matcher AND sits in another domain: name-dependent record, name-blind gate."""
 
-    MATCHES = frozenset({VALUE_DOMAIN_FEATURE_791})
+    MATCHED_NAMES = frozenset({VALUE_DOMAIN_FEATURE_791})
     SUPPORTED_NAMES = frozenset({VALUE_DOMAIN_SPARE_791})
     DOMAIN_NAME = OTHER_DOMAIN_791
     FRAMEWORK_RULE = {RendererFwOne791}
@@ -813,7 +708,7 @@ class ValueRejectingCrossDomainFG791(CountingFeatureGroup791):
 class ValueRejectingUnlinkedFG791(CountingFeatureGroup791):
     """Declines THIS name's value at the matcher AND matches no link: name-dependent record, name-blind gate."""
 
-    MATCHES = frozenset({VALUE_LINKS_FEATURE_791})
+    MATCHED_NAMES = frozenset({VALUE_LINKS_FEATURE_791})
     SUPPORTED_NAMES = frozenset({VALUE_LINKS_SPARE_791})
     FRAMEWORK_RULE = {RendererFwOne791}
     INDEX_COLUMNS = [Index(("renderer_value_links_index_791",))]
@@ -832,50 +727,15 @@ class ValueRejectingUnlinkedFG791(CountingFeatureGroup791):
         raise PropertyValueRejection(VALUE_LINKS_REJECTION_REASON_791)
 
 
-class RendererDomainBoom791(RuntimeError):
-    """Raised by a provider's get_domain() hook."""
+# A group built per test still outlives it: pytest keeps a failing test's traceback, and that traceback keeps
+# the builder's frame, and so the class, alive and globally visible in FeatureGroup.__subclasses__(). A group
+# whose declaration hook raised forever would then take down every later test in the worker that enumerates the
+# plugin universe, because PreFilterPlugins fails closed on a raising compute_framework_definition(). Disarming
+# is what makes a leaked class inert.
+RAISING_GROUPS_BUILT: list[type[CountingFeatureGroup791]] = []
 
 
-class RendererIndexBoom791(RuntimeError):
-    """Raised by a provider's index_columns() or supports_index() hook."""
-
-
-class RendererPrefixBoom791(RuntimeError):
-    """Raised by a provider's prefix() hook."""
-
-
-class RendererNamesBoom791(RuntimeError):
-    """Raised by a provider's feature_names_supported() hook."""
-
-
-class RendererRejectionBoom791(RuntimeError):
-    """Raised by a provider's _strict_validation_rejection_reason() hook."""
-
-
-class RendererFrameworkRuleBoom791(RuntimeError):
-    """Raised by a provider's compute_framework_rule() hook."""
-
-
-class RaisingHookGroup791(CountingFeatureGroup791):
-    """Base for the groups whose fact-capture hook raises or returns a malformed value.
-
-    Its subclasses are ALWAYS built inside a function.
-
-    ``ARMED`` is what makes that safe. A group built per test still outlives it: pytest keeps a failing
-    test's traceback, and that traceback keeps the builder's frame (and so the class) alive and globally
-    visible in ``FeatureGroup.__subclasses__()``. A group whose declaration hook raised forever would then
-    take down every later test in the worker that enumerates the plugin universe -- ``PreFilterPlugins``
-    fails closed on a raising ``compute_framework_definition()``. The autouse fixture disarms every group
-    it built, so a leaked class is inert.
-    """
-
-    ARMED: ClassVar[bool] = True
-
-
-RAISING_GROUPS_BUILT: list[type[RaisingHookGroup791]] = []
-
-
-def _armed(group: type[RaisingHookGroup791]) -> type[RaisingHookGroup791]:
+def _armed(group: type[CountingFeatureGroup791]) -> type[CountingFeatureGroup791]:
     """Track a freshly built raising group so the autouse fixture can disarm it after the test."""
     RAISING_GROUPS_BUILT.append(group)
     return group
@@ -884,23 +744,17 @@ def _armed(group: type[RaisingHookGroup791]) -> type[RaisingHookGroup791]:
 def _build_raising_domain_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
     """Build a (raising get_domain, healthy get_domain) pair that both match the same feature name."""
 
-    class RendererRaisingDomainFG791(RaisingHookGroup791):
+    class RendererRaisingDomainFG791(CountingFeatureGroup791):
         """Candidate whose get_domain() hook raises."""
 
-        MATCHES = frozenset({RAISING_DOMAIN_FEATURE_791})
+        MATCHED_NAMES = frozenset({RAISING_DOMAIN_FEATURE_791})
         FRAMEWORK_RULE = {RendererFwOne791}
-
-        @classmethod
-        def get_domain(cls) -> Domain:
-            _record(cls.get_class_name(), "get_domain")
-            if cls.ARMED:
-                raise RendererDomainBoom791("get_domain exploded 791")
-            return Domain.get_default_domain()
+        RAISING_HOOKS = frozenset({"get_domain"})
 
     class RendererHealthyDomainFG791(CountingFeatureGroup791):
         """Candidate whose get_domain() hook works, standing next to the raising one."""
 
-        MATCHES = frozenset({RAISING_DOMAIN_FEATURE_791})
+        MATCHED_NAMES = frozenset({RAISING_DOMAIN_FEATURE_791})
         DOMAIN_NAME = HEALTHY_DOMAIN_791
         FRAMEWORK_RULE = {RendererFwOne791}
 
@@ -913,18 +767,12 @@ def _build_unreadable_domain_group() -> type[CountingFeatureGroup791]:
     Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
     """
 
-    class UnreadableDomainFG791(RaisingHookGroup791):
+    class UnreadableDomainFG791(CountingFeatureGroup791):
         """Declarer whose domain can never be read, matching nothing."""
 
         SUPPORTED_NAMES = frozenset({DEGRADED_DOMAIN_SPARE_791})
         FRAMEWORK_RULE = {RendererFwOne791}
-
-        @classmethod
-        def get_domain(cls) -> Domain:
-            _record(cls.get_class_name(), "get_domain")
-            if cls.ARMED:
-                raise RendererDomainBoom791("get_domain exploded 791")
-            return Domain.get_default_domain()
+        RAISING_HOOKS = frozenset({"get_domain"})
 
     return _armed(UnreadableDomainFG791)
 
@@ -935,16 +783,17 @@ def _build_malformed_domain_group() -> type[CountingFeatureGroup791]:
     Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
     """
 
-    class BadDomainReturnFG791(RaisingHookGroup791):
+    class BadDomainReturnFG791(CountingFeatureGroup791):
         """Declarer whose domain read is well-formed as a call and malformed as a value."""
 
-        MATCHES = frozenset({MALFORMED_DOMAIN_SPARE_791})
+        MATCHED_NAMES = frozenset({MALFORMED_DOMAIN_SPARE_791})
         SUPPORTED_NAMES = frozenset({MALFORMED_DOMAIN_SPARE_791})
         FRAMEWORK_RULE = {RendererFwOne791}
 
         @classmethod
         def get_domain(cls) -> Domain:
-            _record(cls.get_class_name(), "get_domain")
+            # A malformed RETURN, which RAISING_HOOKS cannot express: an armed hook only ever raises.
+            cls._enter_hook("get_domain")
             if cls.ARMED:
                 bad_domain: Domain = _malformed(MALFORMED_DOMAIN_VALUE_791)
                 return bad_domain
@@ -959,18 +808,12 @@ def _build_unreadable_index_group() -> type[CountingFeatureGroup791]:
     Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
     """
 
-    class UnreadableIndexFG791(RaisingHookGroup791):
+    class UnreadableIndexFG791(CountingFeatureGroup791):
         """Declarer whose index columns can never be read, matching nothing."""
 
         SUPPORTED_NAMES = frozenset({DEGRADED_LINKS_SPARE_791})
         FRAMEWORK_RULE = {RendererFwOne791}
-
-        @classmethod
-        def index_columns(cls) -> Optional[list[Index]]:
-            _record(cls.get_class_name(), "index_columns")
-            if cls.ARMED:
-                raise RendererIndexBoom791("index_columns exploded 791")
-            return None
+        RAISING_HOOKS = frozenset({"index_columns"})
 
     return _armed(UnreadableIndexFG791)
 
@@ -978,19 +821,13 @@ def _build_unreadable_index_group() -> type[CountingFeatureGroup791]:
 def _build_unreadable_supports_index_group() -> type[CountingFeatureGroup791]:
     """Build the same declarer one hook later: its index columns read, but supports_index() raises."""
 
-    class UnreadableSupportsIndexFG791(RaisingHookGroup791):
+    class UnreadableSupportsIndexFG791(CountingFeatureGroup791):
         """Declarer whose index support can never be decided, matching nothing."""
 
         SUPPORTED_NAMES = frozenset({DEGRADED_LINKS_SPARE_791})
         FRAMEWORK_RULE = {RendererFwOne791}
         INDEX_COLUMNS = [Index(("renderer_degraded_links_index_791",))]
-
-        @classmethod
-        def supports_index(cls, index: Index) -> Optional[bool]:
-            _record(cls.get_class_name(), "supports_index")
-            if cls.ARMED:
-                raise RendererIndexBoom791("supports_index exploded 791")
-            return None
+        RAISING_HOOKS = frozenset({"supports_index"})
 
     return _armed(UnreadableSupportsIndexFG791)
 
@@ -998,17 +835,11 @@ def _build_unreadable_supports_index_group() -> type[CountingFeatureGroup791]:
 def _build_raising_prefix_group() -> type[CountingFeatureGroup791]:
     """Build a catalog group whose prefix() hook raises."""
 
-    class RendererRaisingPrefixFG791(RaisingHookGroup791):
+    class RendererRaisingPrefixFG791(CountingFeatureGroup791):
         """Catalog candidate whose prefix() hook raises."""
 
         FRAMEWORK_RULE = {RendererFwOne791}
-
-        @classmethod
-        def prefix(cls) -> str:
-            _record(cls.get_class_name(), "prefix")
-            if cls.ARMED:
-                raise RendererPrefixBoom791("prefix exploded 791")
-            return f"{cls.get_class_name()}_"
+        RAISING_HOOKS = frozenset({"prefix"})
 
     return _armed(RendererRaisingPrefixFG791)
 
@@ -1016,18 +847,12 @@ def _build_raising_prefix_group() -> type[CountingFeatureGroup791]:
 def _build_raising_names_group() -> type[CountingFeatureGroup791]:
     """Build a catalog group whose feature_names_supported() hook raises."""
 
-    class RendererRaisingNamesFG791(RaisingHookGroup791):
+    class RendererRaisingNamesFG791(CountingFeatureGroup791):
         """Catalog candidate whose feature_names_supported() hook raises."""
 
         FRAMEWORK_RULE = {RendererFwOne791}
         SUPPORTED_NAMES = frozenset({BOOM_SUPPORTED_NAME_791})
-
-        @classmethod
-        def feature_names_supported(cls) -> set[str]:
-            _record(cls.get_class_name(), "feature_names_supported")
-            if cls.ARMED:
-                raise RendererNamesBoom791("feature_names_supported exploded 791")
-            return set()
+        RAISING_HOOKS = frozenset({"feature_names_supported"})
 
     return _armed(RendererRaisingNamesFG791)
 
@@ -1035,19 +860,13 @@ def _build_raising_names_group() -> type[CountingFeatureGroup791]:
 def _build_raising_dead_names_group() -> type[CountingFeatureGroup791]:
     """Build a group that is eliminated with no framework left AND whose feature_names_supported() raises."""
 
-    class RendererRaisingDeadNamesFG791(RaisingHookGroup791):
+    class RendererRaisingDeadNamesFG791(CountingFeatureGroup791):
         """Dead candidate whose declared names can never be read."""
 
-        MATCHES = frozenset({RAISING_DEAD_NAMES_FEATURE_791})
+        MATCHED_NAMES = frozenset({RAISING_DEAD_NAMES_FEATURE_791})
         SUPPORTED_NAMES = frozenset({RAISING_DEAD_NAMES_SPARE_791})
         FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
-
-        @classmethod
-        def feature_names_supported(cls) -> set[str]:
-            _record(cls.get_class_name(), "feature_names_supported")
-            if cls.ARMED:
-                raise RendererNamesBoom791("feature_names_supported exploded 791")
-            return set(cls.SUPPORTED_NAMES)
+        RAISING_HOOKS = frozenset({"feature_names_supported"})
 
     return _armed(RendererRaisingDeadNamesFG791)
 
@@ -1055,16 +874,17 @@ def _build_raising_dead_names_group() -> type[CountingFeatureGroup791]:
 def _build_raising_rejection_group() -> type[CountingFeatureGroup791]:
     """Build a group whose _strict_validation_rejection_reason() hook raises."""
 
-    class RendererRaisingRejectionFG791(RaisingHookGroup791):
+    class RendererRaisingRejectionFG791(CountingFeatureGroup791):
         """Candidate whose value-rejection diagnostic hook raises."""
 
         FRAMEWORK_RULE = {RendererFwOne791}
+        RAISING_HOOKS = frozenset({"_strict_validation_rejection_reason"})
 
         @classmethod
         def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-            _record(cls.get_class_name(), "_strict_validation_rejection_reason")
-            if cls.ARMED:
-                raise RendererRejectionBoom791("_strict_validation_rejection_reason exploded 791")
+            # Declared on FeatureChainParserMixin, so it is none of the counted hooks: enter it by hand to keep
+            # the count-then-raise ordering the armed hooks have.
+            cls._enter_hook("_strict_validation_rejection_reason")
             return None
 
     return _armed(RendererRaisingRejectionFG791)
@@ -1073,10 +893,10 @@ def _build_raising_rejection_group() -> type[CountingFeatureGroup791]:
 def _build_raising_framework_rule_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
     """Build an abstract base plus a concrete subclass whose compute_framework_rule() hook raises."""
 
-    class RendererRaisingAbstractBaseFG791(RaisingHookGroup791):
+    class RendererRaisingAbstractBaseFG791(CountingFeatureGroup791):
         """Abstract base that matches the name but can never be instantiated."""
 
-        MATCHES = frozenset({RAISING_ABSTRACT_FEATURE_791})
+        MATCHED_NAMES = frozenset({RAISING_ABSTRACT_FEATURE_791})
         FRAMEWORK_RULE = {RendererFwOne791}
 
         @classmethod
@@ -1087,14 +907,8 @@ def _build_raising_framework_rule_groups() -> tuple[type[CountingFeatureGroup791
     class RendererRaisingConcreteSubFG791(RendererRaisingAbstractBaseFG791):
         """Concrete implementation whose framework declaration raises."""
 
-        MATCHES = frozenset({RAISING_ABSTRACT_FEATURE_791})
-
-        @classmethod
-        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-            _record(cls.get_class_name(), "compute_framework_rule")
-            if cls.ARMED:
-                raise RendererFrameworkRuleBoom791("compute_framework_rule exploded 791")
-            return cls.FRAMEWORK_RULE
+        MATCHED_NAMES = frozenset({RAISING_ABSTRACT_FEATURE_791})
+        RAISING_HOOKS = frozenset({"compute_framework_rule"})
 
         @classmethod
         def _renderer_raising_abstract_hook_791(cls) -> str:
@@ -1114,7 +928,7 @@ def _build_tie_domain_groups() -> tuple[type[CountingFeatureGroup791], type[Coun
     group_a = _make_tie_group(
         TIE_MODULE_A_791,
         {
-            "MATCHES": frozenset({TIE_FEATURE_791}),
+            "MATCHED_NAMES": frozenset({TIE_FEATURE_791}),
             "DOMAIN_NAME": "renderer_tie_domain_a_791",
             "FRAMEWORK_RULE": {RendererFwOne791},
         },
@@ -1122,7 +936,7 @@ def _build_tie_domain_groups() -> tuple[type[CountingFeatureGroup791], type[Coun
     group_b = _make_tie_group(
         TIE_MODULE_B_791,
         {
-            "MATCHES": frozenset({TIE_FEATURE_791}),
+            "MATCHED_NAMES": frozenset({TIE_FEATURE_791}),
             "DOMAIN_NAME": "renderer_tie_domain_b_791",
             "FRAMEWORK_RULE": {RendererFwOne791},
         },
@@ -1135,7 +949,7 @@ def _build_tie_capability_groups() -> tuple[type[CountingFeatureGroup791], type[
     group_a = _make_tie_group(
         TIE_MODULE_A_791,
         {
-            "MATCHES": frozenset({TIE_CAPABILITY_FEATURE_791}),
+            "MATCHED_NAMES": frozenset({TIE_CAPABILITY_FEATURE_791}),
             "FRAMEWORK_RULE": {RendererFwOne791, RendererFwTwo791},
             "SUPPORTED_FRAMEWORKS": frozenset({"RendererFwOne791"}),
         },
@@ -1143,7 +957,7 @@ def _build_tie_capability_groups() -> tuple[type[CountingFeatureGroup791], type[
     group_b = _make_tie_group(
         TIE_MODULE_B_791,
         {
-            "MATCHES": frozenset({TIE_CAPABILITY_FEATURE_791}),
+            "MATCHED_NAMES": frozenset({TIE_CAPABILITY_FEATURE_791}),
             "FRAMEWORK_RULE": {RendererFwOne791, RendererFwTwo791},
             "SUPPORTED_FRAMEWORKS": frozenset({"RendererFwTwo791"}),
         },
@@ -1685,8 +1499,7 @@ def _suggestions(message: str) -> list[str] | None:
 @pytest.fixture(autouse=True)
 def reset_hook_calls() -> Iterator[None]:
     """Counter state must not leak between tests, and no raising hook may outlive the test that built it."""
-    HOOK_CALLS.clear()
-    PAIR_CALLS.clear()
+    HOOK_COUNTER_791.clear()
     yield
     for group in RAISING_GROUPS_BUILT:
         group.ARMED = False

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -15,7 +15,7 @@ import inspect
 import logging
 from abc import abstractmethod
 from ast import literal_eval
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from difflib import get_close_matches
 from typing import Any, Optional, cast, get_args
 
@@ -257,10 +257,42 @@ class CountingFeatureGroup791(CountingStubFeatureGroup):
     COUNTER = HOOK_COUNTER_791
 
 
-def _counting_fg(name: str, **kwargs: Any) -> type[StubFeatureGroup]:
-    """Mint a counting stub of this module; make_fg reads the calling module through this frame."""
-    kwargs.setdefault("base", CountingFeatureGroup791)
-    return make_fg(name, **kwargs)
+def _counting_fg(
+    name: str,
+    *,
+    matches: str | Iterable[str] | None = None,
+    domain: str | None = None,
+    frameworks: set[type[ComputeFramework]] | None = None,
+    supported_names: str | Iterable[str] | None = None,
+    supported_frameworks: str | Iterable[str] | None = None,
+    index_columns: list[Index] | None = None,
+    supports_index: bool | None = None,
+    abstract: bool = False,
+    base: type[StubFeatureGroup] = CountingFeatureGroup791,
+    doc: str | None = None,
+) -> type[StubFeatureGroup]:
+    """Mint a counting stub of this module; make_fg reads the calling module through this frame.
+
+    Every keyword is spelled out with make_fg's own type: a **kwargs passthrough would let a wrongly
+    typed value (framework names instead of classes) mint a green but inert stub.
+    """
+    minted = make_fg(
+        name,
+        matches=matches,
+        domain=domain,
+        frameworks=frameworks,
+        supported_names=supported_names,
+        supported_frameworks=supported_frameworks,
+        index_columns=index_columns,
+        supports_index=supports_index,
+        abstract=abstract,
+        base=base,
+        doc=doc,
+    )
+    # Pins the one-frame walk to this wrapper: moved into a helper module, every stub would be owned by
+    # that module and the registry-isolation fixture, which filters on this one, would stop seeing them.
+    assert minted.__module__ == __name__, f"{name} was minted into {minted.__module__}, not {__name__}"
+    return minted
 
 
 RendererSuccessFG791 = _counting_fg("RendererSuccessFG791", matches=SUCCESS_FEATURE_791, frameworks=ONE_FRAMEWORK_791)

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -468,7 +468,7 @@ RendererCutoffAFG791 = _counting_fg(
     frameworks=TWO_FRAMEWORKS_791,
 )
 
-# Second eliminated candidate, contributing two more droppable hints: its class name and its prefix.
+# Second eliminated candidate, contributing its class name and its prefix as further droppable hints.
 RendererCutoffBFG791 = _counting_fg("RendererCutoffBFG791", matches=CUTOFF_FEATURE_791, frameworks=TWO_FRAMEWORKS_791)
 
 # Healthy catalog group, named far enough from the request that only its supported name can be suggested.
@@ -479,7 +479,7 @@ SpareNameCatalogFG791 = _counting_fg(
     frameworks=ONE_FRAMEWORK_791,
 )
 
-# Catalog candidate declaring the shared name; the four siblings below declare exactly the same one.
+# Catalog candidate declaring the shared name; the siblings below declare exactly the same one.
 RendererDuplicateNameFG791 = _counting_fg(
     "RendererDuplicateNameFG791", supported_names=DUPLICATE_CATALOG_NAME_791, frameworks=ONE_FRAMEWORK_791
 )
@@ -487,7 +487,7 @@ RendererDuplicateNameFG791 = _counting_fg(
 RendererDuplicateSiblingAFG791 = _counting_fg("RendererDuplicateSiblingAFG791", base=RendererDuplicateNameFG791)
 RendererDuplicateSiblingBFG791 = _counting_fg("RendererDuplicateSiblingBFG791", base=RendererDuplicateNameFG791)
 RendererDuplicateSiblingCFG791 = _counting_fg("RendererDuplicateSiblingCFG791", base=RendererDuplicateNameFG791)
-# The fifth copy of the shared name, enough to fill every suggestion slot.
+# The last copy: together they are enough to fill every suggestion slot.
 RendererDuplicateSiblingDFG791 = _counting_fg("RendererDuplicateSiblingDFG791", base=RendererDuplicateNameFG791)
 
 # Catalog candidate holding the one genuinely different close name the copies push out.


### PR DESCRIPTION
The resolution-failure renderer tests were the largest file in the suite, holding more throwaway plugin-stub class bodies than tests. Those stubs exist for a reason: the renderer is meant to be a pure projection of an `EvaluationResult`, so every stub counts each provider-overridable hook and a renderer that calls one gets caught. The design stays; only the hand-writing goes.

## What changed

`tests/helpers/plugin_stubs.py` gains the counting half of the shared factory:

- `HookCounter`, a tally the consuming module owns, keyed `"<Class>.<hook>"` plus a `(candidate, framework)` tally the hook-name key cannot see.
- `CountingStubFeatureGroup`, which counts the eight provider-overridable hooks and answers exactly what `FeatureGroup` already answers.
- Declarative `RAISING_HOOKS` and `ARMED`, so a stub whose hook must explode is a ClassVar rather than a method body. The call is counted before it raises, because callers assert on the count of the hook that raised.
- `make_raising_fg`, a transient double for tests that must not leave a class behind. It claims no `(module, name)` pair, so the caller reaps it per test.

`make_fg` grows the matching keywords and rejects them on a non-counting base: such a base reads none of those ClassVars, so the keyword would otherwise be dropped in silence.

The renderer tests then declare their stubs instead of writing them out. Twenty-six become factory calls, eight raising builders lose their method bodies, and six near-identical exception classes collapse into one. The sibling plugin-docs tests share the transient double, and a clone group of seven degrade tests becomes one parametrized table.

## Why the counters are safe

Every hook tally and pair tally was diffed against the previous implementation across all thirty-nine scenarios and is byte-identical, and every ClassVar was compared across all forty-five shared classes with no drift. The stubs whose matcher is hand-written kept their class bodies, because re-basing them onto a matcher that answers only declared names would silently change what they match.

## One test that was asserting less than it looked

Collapsing the degrade tests turned each hook into a bare string with nothing tying it to the field asserted afterwards. For five of the seven rows the documented degrade target is also the healthy answer, so a row naming the wrong hook still passed. Each row now also names the guarded read it should degrade, and the test asserts that read's warning was actually emitted. Swapping a row's hook now fails that row.

`tox` green: 8866 passed, 170 skipped, identical collected node ids in both migrated files.
