### PR TITLE
test: characterize the link planner side binding and orientation

### DIFF
--- a/tests/helpers/probe_runner.py
+++ b/tests/helpers/probe_runner.py
@@ -1,0 +1,29 @@
+"""Runs a probe script in fresh interpreters, so a test can pin what a cold process decides."""
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+_PROBE_TIMEOUT = 30.0
+
+
+def run_probes(probe: Path, count: int) -> list[dict[str, str]]:
+    """Run ``probe`` ``count`` times, each in its own interpreter, and parse the one json line it prints."""
+    assert probe.is_file(), f"{probe} does not exist"
+
+    outputs: list[dict[str, str]] = []
+    for _ in range(count):
+        # Safe: fixed argv, no shell, no user input.
+        completed = subprocess.run(  # nosec B603
+            [sys.executable, str(probe)],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT,
+        )
+        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
+        lines = [line for line in completed.stdout.splitlines() if line.strip()]
+        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
+        parsed: dict[str, str] = json.loads(lines[0])
+        outputs.append(parsed)
+    return outputs

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -1,0 +1,379 @@
+"""Characterizes which feature group's data ends up as the left merge argument of a link."""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+import mloda_plugins.compute_framework.base_implementations.pandas.pandas_pyarrow_transformer  # noqa: F401
+import mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_pyarrow_transformer  # noqa: F401
+
+
+LEFT_KEYS = ["k4", "k3", "k2", "k1"]
+LEFT_PAYLOADS = ["L4", "L3", "L2", "L1"]
+RIGHT_KEYS = ["k3", "k4", "k5"]
+RIGHT_PAYLOADS = ["R3", "R4", "R5"]
+THIRD_KEYS = ["k1", "k3", "k4", "k7"]
+THIRD_PAYLOADS = ["T1", "T3", "T4", "T7"]
+
+MISSING = "-"
+
+# MULTIPROCESSING is opt-in per shape: the flight server still races or fails for the shapes left on these two modes.
+MODES_SYNC_THREADING = pytest.mark.parametrize(
+    "modes",
+    [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}],
+)
+
+MODES_WITH_MULTIPROCESSING = pytest.mark.parametrize(
+    "modes",
+    [
+        {ParallelizationMode.SYNC},
+        {ParallelizationMode.THREADING},
+        # Spawning workers and moving data over the flight server exceeds the suite-wide timeout budget.
+        pytest.param({ParallelizationMode.MULTIPROCESSING}, marks=pytest.mark.timeout(30)),
+    ],
+)
+
+
+def _cell(value: Any) -> str:
+    """Render one joined cell so an unmatched value reads the same in every framework."""
+    if value is None:
+        return MISSING
+    text = str(value)
+    return MISSING if text in ("nan", "None", "<NA>") else text
+
+
+def _columns(data: Any) -> dict[str, list[Any]]:
+    if isinstance(data, dict):
+        return {name: list(values) for name, values in data.items()}
+    if hasattr(data, "column_names"):
+        return {name: data.column(name).to_pylist() for name in data.column_names}
+    return {name: list(data[name]) for name in data.columns}
+
+
+def _pair_rows(data: Any, prefix: str) -> list[str]:
+    columns = _columns(data)
+    return [
+        "|".join(_cell(value) for value in row)
+        for row in zip(
+            columns[f"{prefix}_left_key"],
+            columns[f"{prefix}_left_payload"],
+            columns[f"{prefix}_right_key"],
+            columns[f"{prefix}_right_payload"],
+        )
+    ]
+
+
+def _pair_features(prefix: str) -> set[Feature]:
+    return {
+        Feature(name=f"{prefix}_left_key"),
+        Feature(name=f"{prefix}_left_payload"),
+        Feature(name=f"{prefix}_right_key"),
+        Feature(name=f"{prefix}_right_payload"),
+    }
+
+
+def _packed_rows(results: Any, column: str) -> list[str]:
+    frames = [_columns(frame) for frame in results]
+    matching = [frame[column] for frame in frames if column in frame]
+    assert len(matching) == 1, f"Expected exactly one result frame carrying {column}, got {len(matching)}."
+    return [str(value) for value in matching[0]]
+
+
+class OrientCharLeftInPandas(FeatureGroup):
+    """Declared left side of pair A, so a Pandas child joins in the declared orientation."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"oc_a_left_key", "oc_a_left_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"oc_a_left_key": LEFT_KEYS, "oc_a_left_payload": LEFT_PAYLOADS}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class OrientCharRightInArrow(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"oc_a_right_key", "oc_a_right_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"oc_a_right_key": RIGHT_KEYS, "oc_a_right_payload": RIGHT_PAYLOADS}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class OrientCharLeftInArrow(FeatureGroup):
+    """Declared left side of pair B, so a Pandas child inverts the declared orientation."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"oc_b_left_key", "oc_b_left_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"oc_b_left_key": LEFT_KEYS, "oc_b_left_payload": LEFT_PAYLOADS}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class OrientCharRightInPandas(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"oc_b_right_key", "oc_b_right_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"oc_b_right_key": RIGHT_KEYS, "oc_b_right_payload": RIGHT_PAYLOADS}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class OrientCharThirdInDict(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"oc_c_key", "oc_c_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"oc_c_key": THIRD_KEYS, "oc_c_payload": THIRD_PAYLOADS}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+
+class OrientCharDeclaredChild(FeatureGroup):
+    """Runs in the framework of pair A's declared left parent."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _pair_features("oc_a")
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): _pair_rows(data, "oc_a")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class OrientCharInvertedChild(FeatureGroup):
+    """Runs in the framework of pair B's declared right parent."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _pair_features("oc_b")
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): _pair_rows(data, "oc_b")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class OrientCharArrowChild(FeatureGroup):
+    """Runs in the framework of pair B's declared left parent."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _pair_features("oc_b")
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): _pair_rows(data, "oc_b")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class OrientCharChainChild(FeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name="oc_a_left_key"),
+            Feature(name="oc_a_left_payload"),
+            Feature(name="oc_a_right_payload"),
+            Feature(name="oc_c_payload"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        columns = _columns(data)
+        rows = [
+            "|".join(_cell(value) for value in row)
+            for row in zip(
+                columns["oc_a_left_key"],
+                columns["oc_a_left_payload"],
+                columns["oc_a_right_payload"],
+                columns["oc_c_payload"],
+            )
+        ]
+        return {cls.get_class_name(): rows}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+PAIR_A = (OrientCharLeftInPandas, OrientCharRightInArrow, "oc_a")
+PAIR_B = (OrientCharLeftInArrow, OrientCharRightInPandas, "oc_b")
+
+
+def _pair_link(pair: tuple[type[FeatureGroup], type[FeatureGroup], str], jointype: str) -> Link:
+    left_group, right_group, prefix = pair
+    return Link(
+        jointype,
+        JoinSpec(left_group, Index((f"{prefix}_left_key",))),
+        JoinSpec(right_group, Index((f"{prefix}_right_key",))),
+    )
+
+
+def _run_pair(
+    pair: tuple[type[FeatureGroup], type[FeatureGroup], str],
+    jointype: str,
+    child: type[FeatureGroup],
+    modes: set[ParallelizationMode],
+    flight_server: Any,
+) -> list[str]:
+    left_group, right_group, _ = pair
+    result = mloda.run_all(
+        [Feature(name=child.get_class_name())],
+        links={_pair_link(pair, jointype)},
+        compute_frameworks={PandasDataFrame, PyArrowTable},
+        plugin_collector=PluginCollector.enabled_feature_groups({left_group, right_group, child}),
+        flight_server=flight_server,
+        parallelization_modes=modes,
+    )
+    return _packed_rows(result, child.get_class_name())
+
+
+INNER_ROWS = ["k4|L4|k4|R4", "k3|L3|k3|R3"]
+LEFT_JOIN_ROWS = INNER_ROWS + [f"k2|L2|{MISSING}|{MISSING}", f"k1|L1|{MISSING}|{MISSING}"]
+RIGHT_JOIN_ROWS = ["k3|L3|k3|R3", "k4|L4|k4|R4", f"{MISSING}|{MISSING}|k5|R5"]
+CHAIN_ROWS = ["k4|L4|R4|T4", "k3|L3|R3|T3"]
+
+RIGHT_SIDE_BINDING_REASON = (
+    "plain RIGHT joins bind the merge arguments to the resolved frameworks instead of the "
+    "declared sides, so the declared left index is looked up in the right group's data"
+)
+
+
+@MODES_WITH_MULTIPROCESSING
+def test_inner_join_declared_orientation_keeps_left_group_first(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    rows = _run_pair(PAIR_A, "inner", OrientCharDeclaredChild, modes, flight_server)
+
+    assert len(rows) == 2
+    assert rows == INNER_ROWS
+
+
+@MODES_SYNC_THREADING
+def test_inner_join_inverted_orientation_keeps_left_group_first(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    rows = _run_pair(PAIR_B, "inner", OrientCharInvertedChild, modes, flight_server)
+
+    assert len(rows) == 2
+    assert rows == INNER_ROWS
+
+
+@MODES_WITH_MULTIPROCESSING
+def test_left_join_declared_orientation_keeps_every_left_row(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    rows = _run_pair(PAIR_A, "left", OrientCharDeclaredChild, modes, flight_server)
+
+    assert len(rows) == 4
+    assert rows == LEFT_JOIN_ROWS
+
+
+@MODES_SYNC_THREADING
+def test_left_join_inverted_orientation_keeps_every_left_row(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    rows = _run_pair(PAIR_B, "left", OrientCharInvertedChild, modes, flight_server)
+
+    assert len(rows) == 4
+    assert rows == LEFT_JOIN_ROWS
+
+
+@MODES_SYNC_THREADING
+def test_right_join_keeps_every_right_row_for_a_child_on_the_left_framework(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    rows = _run_pair(PAIR_B, "right", OrientCharArrowChild, modes, flight_server)
+
+    assert len(rows) == 3
+    assert rows == RIGHT_JOIN_ROWS
+
+
+@MODES_SYNC_THREADING
+def test_right_join_raises_for_a_child_on_the_right_framework(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    with pytest.raises(KeyError, match="oc_b_left_key"):
+        _run_pair(PAIR_B, "right", OrientCharInvertedChild, modes, flight_server)
+
+
+@pytest.mark.xfail(strict=True, reason=RIGHT_SIDE_BINDING_REASON)
+@MODES_SYNC_THREADING
+def test_right_join_should_keep_every_right_row_for_a_child_on_the_right_framework(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    rows = _run_pair(PAIR_B, "right", OrientCharInvertedChild, modes, flight_server)
+
+    assert len(rows) == 3
+    assert sorted(rows) == sorted(RIGHT_JOIN_ROWS)
+
+
+@MODES_SYNC_THREADING
+def test_chained_join_across_three_frameworks_keeps_left_group_order(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    first = JoinSpec(OrientCharLeftInPandas, Index(("oc_a_left_key",)))
+    second = JoinSpec(OrientCharRightInArrow, Index(("oc_a_right_key",)))
+    third = JoinSpec(OrientCharThirdInDict, Index(("oc_c_key",)))
+
+    result = mloda.run_all(
+        [Feature(name=OrientCharChainChild.get_class_name())],
+        links={Link.inner(first, second), Link.inner(second, third)},
+        compute_frameworks={PandasDataFrame, PyArrowTable, PythonDictFramework},
+        plugin_collector=PluginCollector.enabled_feature_groups(
+            {OrientCharLeftInPandas, OrientCharRightInArrow, OrientCharThirdInDict, OrientCharChainChild}
+        ),
+        flight_server=flight_server,
+        parallelization_modes=modes,
+    )
+    rows = _packed_rows(result, OrientCharChainChild.get_class_name())
+
+    assert len(rows) == 2
+    assert rows == CHAIN_ROWS

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -34,7 +34,7 @@ THIRD_PAYLOADS = ["T1", "T3", "T4", "T7"]
 
 MISSING = "-"
 
-# MULTIPROCESSING is opt-in per shape: the flight server still races or fails for the shapes left on these two modes.
+# MULTIPROCESSING is opt-in per shape: the rest fail in the transform hop, on a flight the server has no table for.
 MODES_SYNC_THREADING = pytest.mark.parametrize(
     "modes",
     [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}],
@@ -89,11 +89,14 @@ def _pair_features(prefix: str) -> set[Feature]:
     }
 
 
-def _packed_rows(results: Any, column: str) -> list[str]:
-    frames = [_columns(frame) for frame in results]
-    matching = [frame[column] for frame in frames if column in frame]
+def _packed_frame(results: Any, column: str) -> Any:
+    matching = [frame for frame in results if column in _columns(frame)]
     assert len(matching) == 1, f"Expected exactly one result frame carrying {column}, got {len(matching)}."
-    return [str(value) for value in matching[0]]
+    return matching[0]
+
+
+def _packed_rows(results: Any, column: str) -> list[str]:
+    return [str(value) for value in _columns(_packed_frame(results, column))[column]]
 
 
 class OrientCharLeftInPandas(FeatureGroup):
@@ -201,7 +204,7 @@ class OrientCharInvertedChild(FeatureGroup):
 
 
 class OrientCharArrowChild(FeatureGroup):
-    """Runs in the framework of pair B's declared left parent."""
+    """Declares the framework of pair B's declared left parent."""
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
         return _pair_features("oc_b")
@@ -256,6 +259,24 @@ def _pair_link(pair: tuple[type[FeatureGroup], type[FeatureGroup], str], jointyp
     )
 
 
+def _run_pair_results(
+    pair: tuple[type[FeatureGroup], type[FeatureGroup], str],
+    jointype: str,
+    child: type[FeatureGroup],
+    modes: set[ParallelizationMode],
+    flight_server: Any,
+) -> Any:
+    left_group, right_group, _ = pair
+    return mloda.run_all(
+        [Feature(name=child.get_class_name())],
+        links={_pair_link(pair, jointype)},
+        compute_frameworks={PandasDataFrame, PyArrowTable},
+        plugin_collector=PluginCollector.enabled_feature_groups({left_group, right_group, child}),
+        flight_server=flight_server if ParallelizationMode.MULTIPROCESSING in modes else None,
+        parallelization_modes=modes,
+    )
+
+
 def _run_pair(
     pair: tuple[type[FeatureGroup], type[FeatureGroup], str],
     jointype: str,
@@ -263,16 +284,8 @@ def _run_pair(
     modes: set[ParallelizationMode],
     flight_server: Any,
 ) -> list[str]:
-    left_group, right_group, _ = pair
-    result = mloda.run_all(
-        [Feature(name=child.get_class_name())],
-        links={_pair_link(pair, jointype)},
-        compute_frameworks={PandasDataFrame, PyArrowTable},
-        plugin_collector=PluginCollector.enabled_feature_groups({left_group, right_group, child}),
-        flight_server=flight_server,
-        parallelization_modes=modes,
-    )
-    return _packed_rows(result, child.get_class_name())
+    results = _run_pair_results(pair, jointype, child, modes, flight_server)
+    return _packed_rows(results, child.get_class_name())
 
 
 INNER_ROWS = ["k4|L4|k4|R4", "k3|L3|k3|R3"]
@@ -292,7 +305,6 @@ def test_inner_join_declared_orientation_keeps_left_group_first(
 ) -> None:
     rows = _run_pair(PAIR_A, "inner", OrientCharDeclaredChild, modes, flight_server)
 
-    assert len(rows) == 2
     assert rows == INNER_ROWS
 
 
@@ -302,7 +314,6 @@ def test_inner_join_inverted_orientation_keeps_left_group_first(
 ) -> None:
     rows = _run_pair(PAIR_B, "inner", OrientCharInvertedChild, modes, flight_server)
 
-    assert len(rows) == 2
     assert rows == INNER_ROWS
 
 
@@ -312,7 +323,6 @@ def test_left_join_declared_orientation_keeps_every_left_row(
 ) -> None:
     rows = _run_pair(PAIR_A, "left", OrientCharDeclaredChild, modes, flight_server)
 
-    assert len(rows) == 4
     assert rows == LEFT_JOIN_ROWS
 
 
@@ -322,25 +332,27 @@ def test_left_join_inverted_orientation_keeps_every_left_row(
 ) -> None:
     rows = _run_pair(PAIR_B, "left", OrientCharInvertedChild, modes, flight_server)
 
-    assert len(rows) == 4
     assert rows == LEFT_JOIN_ROWS
 
 
 @MODES_SYNC_THREADING
-def test_right_join_keeps_every_right_row_for_a_child_on_the_left_framework(
+def test_right_join_keeps_every_right_row_for_a_child_declaring_the_left_framework(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
-    rows = _run_pair(PAIR_B, "right", OrientCharArrowChild, modes, flight_server)
+    results = _run_pair_results(PAIR_B, "right", OrientCharArrowChild, modes, flight_server)
+    frame = _packed_frame(results, OrientCharArrowChild.get_class_name())
 
-    assert len(rows) == 3
-    assert rows == RIGHT_JOIN_ROWS
+    # The planner rewrote the child off its declared PyArrowTable, without asking whether it supports the new one.
+    assert type(frame) is PandasDataFrame.expected_data_framework()
+    assert _packed_rows(results, OrientCharArrowChild.get_class_name()) == RIGHT_JOIN_ROWS
 
 
 @MODES_SYNC_THREADING
 def test_right_join_raises_for_a_child_on_the_right_framework(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
-    with pytest.raises(KeyError, match="oc_b_left_key"):
+    # The exception type is incidental: the column-semantics guard reaches the key column before the merge does.
+    with pytest.raises((KeyError, ValueError), match="oc_b_left_key"):
         _run_pair(PAIR_B, "right", OrientCharInvertedChild, modes, flight_server)
 
 
@@ -351,7 +363,6 @@ def test_right_join_should_keep_every_right_row_for_a_child_on_the_right_framewo
 ) -> None:
     rows = _run_pair(PAIR_B, "right", OrientCharInvertedChild, modes, flight_server)
 
-    assert len(rows) == 3
     assert sorted(rows) == sorted(RIGHT_JOIN_ROWS)
 
 
@@ -370,10 +381,9 @@ def test_chained_join_across_three_frameworks_keeps_left_group_order(
         plugin_collector=PluginCollector.enabled_feature_groups(
             {OrientCharLeftInPandas, OrientCharRightInArrow, OrientCharThirdInDict, OrientCharChainChild}
         ),
-        flight_server=flight_server,
+        flight_server=flight_server if ParallelizationMode.MULTIPROCESSING in modes else None,
         parallelization_modes=modes,
     )
     rows = _packed_rows(result, OrientCharChainChild.get_class_name())
 
-    assert len(rows) == 2
     assert rows == CHAIN_ROWS

--- a/tests/test_core/test_prepare/link_planner_probe.py
+++ b/tests/test_core/test_prepare/link_planner_probe.py
@@ -1,0 +1,65 @@
+"""Prints one json line with the link orientation a fresh interpreter plans.
+No test_ prefix, so pytest never collects it; the link planner characterization runs it as a script.
+"""
+
+import json
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker, ResolveLinks
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+class LinkPlannerProbeLeft(FeatureGroup):
+    pass
+
+
+class LinkPlannerProbeRight(FeatureGroup):
+    pass
+
+
+class LinkPlannerProbeChild(FeatureGroup):
+    pass
+
+
+def collect() -> dict[str, str]:
+    """Each side reduces from a framework set; the child then decides which reduction survives."""
+    left_side: set[type[ComputeFramework]] = {PandasDataFrame, PyArrowTable}
+    right_side: set[type[ComputeFramework]] = {PythonDictFramework, PyArrowTable}
+
+    link = Link.inner(JoinSpec(LinkPlannerProbeLeft, "idx"), JoinSpec(LinkPlannerProbeRight, "idx"))
+    key = ResolveLinks(Graph()).create_link_trekker_key(link, left_side, right_side)
+
+    child = Feature("link_planner_probe_child")
+    child.compute_frameworks = {PyArrowTable}
+
+    trekker = LinkTrekker()
+    trekked = {child.uuid}
+    trekker.data[key] = trekked
+    trekker.data_ordered[key] = trekked
+
+    planned_queue: list[Any] = [key, (LinkPlannerProbeChild, {child})]
+    ResolveComputeFrameworks(Graph()).links(planned_queue, trekker)
+
+    orientations = [orientation for orientation in trekker.data if orientation[0] is link]
+    planned = orientations[0] if len(orientations) == 1 else (link, ComputeFramework, ComputeFramework)
+
+    return {
+        "child": child.get_compute_framework().get_class_name(),
+        "orientation_count": str(len(orientations)),
+        "planned_left": planned[1].get_class_name(),
+        "planned_right": planned[2].get_class_name(),
+        "trekker_left": key[1].get_class_name(),
+        "trekker_right": key[2].get_class_name(),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(collect(), sort_keys=True))

--- a/tests/test_core/test_prepare/test_deterministic_framework_selection.py
+++ b/tests/test_core/test_prepare/test_deterministic_framework_selection.py
@@ -2,9 +2,6 @@
 Set iteration over class objects is id-based, so the reduction pins to the lowest class name.
 """
 
-import json
-import subprocess  # nosec B404
-import sys
 from pathlib import Path
 
 import pytest
@@ -18,9 +15,9 @@ from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_links import ResolveLinks
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from tests.helpers.probe_runner import run_probes
 
 _PROBE = Path(__file__).with_name("determinism_probe.py")
-_PROBE_TIMEOUT = 30.0
 # Each probe is a fresh interpreter importing PyArrowTable, so the count is what the gate budget allows.
 _PROBE_PROCESSES = 5
 _PROBE_EXPECTED = {"feature": "PyArrowTable", "trekker_left": "PyArrowTable", "trekker_right": "PyArrowTable"}
@@ -88,26 +85,6 @@ def _link() -> Link:
         JoinSpec(DeterminismLeftFeatureGroup, "idx"),
         JoinSpec(DeterminismRightFeatureGroup, "idx"),
     )
-
-
-def _run_probes(count: int) -> list[dict[str, str]]:
-    assert _PROBE.is_file(), f"{_PROBE} does not exist"
-
-    outputs: list[dict[str, str]] = []
-    for _ in range(count):
-        # Safe: fixed argv, no shell, no user input.
-        completed = subprocess.run(  # nosec B603
-            [sys.executable, str(_PROBE)],
-            capture_output=True,
-            text=True,
-            timeout=_PROBE_TIMEOUT,
-        )
-        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
-        lines = [line for line in completed.stdout.splitlines() if line.strip()]
-        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
-        parsed: dict[str, str] = json.loads(lines[0])
-        outputs.append(parsed)
-    return outputs
 
 
 def test_select_deterministic_ignores_input_order() -> None:
@@ -236,7 +213,7 @@ def test_feature_compute_framework_rejects_an_empty_set() -> None:
 # Fresh interpreters cost roughly a second each, so this one needs more than the suite-wide per-test budget.
 @pytest.mark.timeout(60)
 def test_fresh_interpreters_reduce_to_the_same_frameworks() -> None:
-    outputs = _run_probes(_PROBE_PROCESSES)
+    outputs = run_probes(_PROBE, _PROBE_PROCESSES)
 
     assert len(outputs) == _PROBE_PROCESSES, f"expected {_PROBE_PROCESSES} probe results, got {len(outputs)}"
     for position, output in enumerate(outputs):

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -1,8 +1,5 @@
 """Characterizes what the link planner plans, and what it declines to plan."""
 
-import json
-import subprocess  # nosec B404
-import sys
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional
 from uuid import UUID
@@ -10,12 +7,6 @@ from uuid import UUID
 import pyarrow as pa
 import pytest
 
-from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.link import JoinSpec, JoinType, Link
-from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.prepare.execution_plan import ExecutionPlan
@@ -24,14 +15,21 @@ from mloda.core.prepare.graph.properties import NodeProperties
 from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
 from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker
 from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
 from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
 from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, JoinType, Link
 from mloda.user import Options
 from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from tests.helpers.probe_runner import run_probes
 
 
 SHARED_LEFT_KEY = "link_plan_shared_left_key"
@@ -54,10 +52,16 @@ PAIR_RIGHT_INDEX = Index(("link_plan_pair_right_key",))
 STACK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link.union]
 LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
 
+STACK_INVERSION_REASON = (
+    "the inverted orientation is dropped before the JoinStep is built; a fix has to move the left-framework "
+    "invariant in create_joinstep_in_case_of_append_or_union with it, since neither append nor union commutes"
+)
+
+MODES = pytest.mark.parametrize("modes", [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}])
+
 _PROBE = Path(__file__).with_name("link_planner_probe.py")
-_PROBE_TIMEOUT = 30.0
-# Each probe is a fresh interpreter importing three frameworks, so the count stays within the gate budget.
-_PROBE_PROCESSES = 5
+# The reduction is deterministic within a process, so a second cold interpreter is the whole cross-process signal.
+_PROBE_PROCESSES = 2
 _PROBE_EXPECTED = {
     "child": "PyArrowTable",
     "orientation_count": "1",
@@ -95,7 +99,7 @@ def _paired_payloads(data: Any) -> list[str]:
 
 
 class LinkPlanSharedLeft(FeatureGroup):
-    """Pinned to the framework the link declares as its left side."""
+    """Pinned to the framework the link declares as its left side, with descending keys as an order oracle."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -103,7 +107,7 @@ class LinkPlanSharedLeft(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return {SHARED_LEFT_KEY: [1, 2, 3, 4], SHARED_LEFT_PAYLOAD: ["l1", "l2", "l3", "l4"]}
+        return {SHARED_LEFT_KEY: [4, 3, 2, 1], SHARED_LEFT_PAYLOAD: ["l4", "l3", "l2", "l1"]}
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
@@ -290,11 +294,12 @@ def _run(planned: Planned, left_cfw: type[ComputeFramework], right_cfw: type[Com
 
 def _pair_scenario(
     *,
+    link_factory: Callable[[JoinSpec, JoinSpec], Link] = Link.inner,
     left_cfw: type[ComputeFramework] = PyArrowTable,
     right_cfw: type[ComputeFramework] = PandasDataFrame,
     child_cfw: type[ComputeFramework] = PyArrowTable,
 ) -> Planned:
-    link = Link.inner(JoinSpec(LinkPlanPairLeft, PAIR_LEFT_INDEX), JoinSpec(LinkPlanPairRight, PAIR_RIGHT_INDEX))
+    link = link_factory(JoinSpec(LinkPlanPairLeft, PAIR_LEFT_INDEX), JoinSpec(LinkPlanPairRight, PAIR_RIGHT_INDEX))
     return _plan(
         link,
         _feature("link_plan_pair_left_payload", left_cfw, PAIR_LEFT_INDEX),
@@ -354,27 +359,7 @@ def _orientations(planned: Planned) -> list[tuple[str, str]]:
     ]
 
 
-def _run_probes(count: int) -> list[dict[str, str]]:
-    assert _PROBE.is_file(), f"{_PROBE} does not exist"
-
-    outputs: list[dict[str, str]] = []
-    for _ in range(count):
-        # Safe: fixed argv, no shell, no user input.
-        completed = subprocess.run(  # nosec B603
-            [sys.executable, str(_PROBE)],
-            capture_output=True,
-            text=True,
-            timeout=_PROBE_TIMEOUT,
-        )
-        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
-        lines = [line for line in completed.stdout.splitlines() if line.strip()]
-        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
-        parsed: dict[str, str] = json.loads(lines[0])
-        outputs.append(parsed)
-    return outputs
-
-
-@pytest.mark.parametrize("modes", [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}])
+@MODES
 class TestSharedLinkServingTwoChildren:
     """One link between one parent pair, consumed by a flexible child and a pinned child."""
 
@@ -401,32 +386,21 @@ class TestSharedLinkServingTwoChildren:
             for child in children:
                 name = child.get_class_name()
                 if name in _column_names(result):
-                    collected[name] = sorted(_column_values(result, name))
+                    collected[name] = _column_values(result, name)
         return collected
 
-    def test_each_child_gets_the_two_rows_both_parents_share(
-        self, modes: set[ParallelizationMode], flight_server: Any
-    ) -> None:
-        collected = self._run_both_children(modes, flight_server)
-
-        assert sorted(collected) == [
-            LinkPlanSharedFlexibleChild.get_class_name(),
-            LinkPlanSharedPinnedChild.get_class_name(),
-        ]
-        assert [len(rows) for _, rows in sorted(collected.items())] == [2, 2]
-
-    def test_each_child_pairs_every_key_with_both_parent_payloads(
+    def test_each_child_pairs_every_shared_key_with_both_parent_payloads(
         self, modes: set[ParallelizationMode], flight_server: Any
     ) -> None:
         collected = self._run_both_children(modes, flight_server)
 
         assert collected == {
-            LinkPlanSharedFlexibleChild.get_class_name(): ["l3|r3", "l4|r4"],
-            LinkPlanSharedPinnedChild.get_class_name(): ["l3|r3", "l4|r4"],
+            LinkPlanSharedFlexibleChild.get_class_name(): ["l4|r4", "l3|r3"],
+            LinkPlanSharedPinnedChild.get_class_name(): ["l4|r4", "l3|r3"],
         }
 
 
-def _run_self_join(left_side: str, right_side: str) -> list[Any]:
+def _run_self_join(left_side: str, right_side: str, modes: set[ParallelizationMode], flight_server: Any) -> list[Any]:
     link = Link.left(
         JoinSpec(LinkPlanSelfSource, Index((SELF_LEFT_KEY,))),
         JoinSpec(LinkPlanSelfSource, Index((SELF_RIGHT_KEY,))),
@@ -439,22 +413,30 @@ def _run_self_join(left_side: str, right_side: str) -> list[Any]:
             links={link},
             compute_frameworks=["PyArrowTable"],
             plugin_collector=PluginCollector.enabled_feature_groups({LinkPlanSelfSource, LinkPlanSelfConsumer}),
-            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+            parallelization_modes=modes,
         )
     )
 
 
-def test_self_join_keeps_every_row_of_the_node_the_left_discriminator_names() -> None:
-    results = _run_self_join("left", "right")
+@MODES
+def test_self_join_keeps_every_row_of_the_node_the_left_discriminator_names(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    results = _run_self_join("left", "right", modes, flight_server)
 
     joined = sorted(_column_values(results[0], LinkPlanSelfConsumer.get_class_name()))
     assert joined == ["1|None", "2|None", "3|r3", "4|r4"]
 
 
-def test_swapped_discriminators_bind_the_other_node_as_the_left_side() -> None:
-    """The bound left node then lacks the left index column, and the merge says so."""
-    with pytest.raises(KeyError, match=SELF_LEFT_KEY):
-        _run_self_join("right", "left")
+@MODES
+def test_swapped_discriminators_bind_the_other_node_as_the_left_side(
+    modes: set[ParallelizationMode], flight_server: Any
+) -> None:
+    """The bound left node then lacks the left index column, and the run says so."""
+    # The exception type is incidental: the column-semantics guard reaches the key column before the merge does.
+    with pytest.raises((KeyError, ValueError), match=SELF_LEFT_KEY):
+        _run_self_join("right", "left", modes, flight_server)
 
 
 def test_planner_binds_the_left_discriminator_node_as_the_join_destination() -> None:
@@ -506,7 +488,7 @@ def test_an_inverted_cross_group_stack_link_still_plans_the_declared_orientation
     assert join_step.swap_merge_sides is False
 
 
-@pytest.mark.xfail(strict=True, reason="the inverted orientation is dropped before the JoinStep is built")
+@pytest.mark.xfail(strict=True, reason=STACK_INVERSION_REASON)
 @pytest.mark.parametrize("link_factory", STACK_FACTORIES)
 def test_an_inverted_cross_group_stack_link_joins_where_its_consumer_runs(
     link_factory: Callable[[JoinSpec, JoinSpec], Link],
@@ -518,6 +500,10 @@ def test_an_inverted_cross_group_stack_link_joins_where_its_consumer_runs(
 
     assert isinstance(join_step, JoinStep)
     assert join_step.destination_framework is PandasDataFrame
+    assert join_step.source_framework is PyArrowTable
+    assert join_step.destination_framework_uuids == {planned.right_uuid}
+    assert join_step.source_framework_uuids == {planned.left_uuid}
+    assert join_step.swap_merge_sides is True
 
 
 @pytest.mark.parametrize("link_factory", STACK_FACTORIES)
@@ -582,13 +568,15 @@ def test_a_trekker_inverted_after_queueing_swaps_the_merge_sides() -> None:
     assert join_step.swap_merge_sides is True
 
 
-def test_a_swapped_joinstep_keeps_the_uuids_the_pairing_returned() -> None:
-    """A child left on the declared left framework makes the pairing outvote the framework filter."""
+def test_a_hand_built_inconsistent_trekker_key_yields_an_inconsistent_joinstep() -> None:
+    """This trekker key contradicts the graph, so create_link_trekker_key never reaches this state."""
     planned = _pair_scenario()
     _trek(planned, PandasDataFrame, PyArrowTable)
 
     join_step = _run(planned, PyArrowTable, PandasDataFrame)
 
+    # The frameworks and the uuid sets disagree: the destination is Pandas while its uuid runs in PyArrow.
+    # A rewrite that carries one record per join decision is free to answer differently here.
     assert isinstance(join_step, JoinStep)
     assert join_step.destination_framework is PandasDataFrame
     assert join_step.destination_framework_uuids == {planned.left_uuid}
@@ -596,10 +584,35 @@ def test_a_swapped_joinstep_keeps_the_uuids_the_pairing_returned() -> None:
     assert join_step.swap_merge_sides is True
 
 
+def test_a_right_join_plans_the_joinstep_where_the_declared_right_side_runs() -> None:
+    """RIGHT swaps the frameworks before the trekker lookup, so only the merge order still follows the trekker."""
+    declared = _pair_scenario(link_factory=Link.right, child_cfw=PandasDataFrame)
+    _trek(declared, PyArrowTable, PandasDataFrame)
+    inverted = _pair_scenario(link_factory=Link.right, child_cfw=PandasDataFrame)
+    _trek(inverted, PandasDataFrame, PyArrowTable)
+
+    declared_step = _run(declared, PyArrowTable, PandasDataFrame)
+    inverted_step = _run(inverted, PyArrowTable, PandasDataFrame)
+
+    assert isinstance(declared_step, JoinStep)
+    assert declared_step.destination_framework is PandasDataFrame
+    assert declared_step.source_framework is PyArrowTable
+    assert declared_step.destination_framework_uuids == {declared.right_uuid}
+    assert declared_step.source_framework_uuids == {declared.left_uuid}
+    assert declared_step.swap_merge_sides is False
+
+    assert isinstance(inverted_step, JoinStep)
+    assert inverted_step.destination_framework is PandasDataFrame
+    assert inverted_step.source_framework is PyArrowTable
+    assert inverted_step.destination_framework_uuids == {inverted.right_uuid}
+    assert inverted_step.source_framework_uuids == {inverted.left_uuid}
+    assert inverted_step.swap_merge_sides is True
+
+
 # Fresh interpreters are slow to start, so this one needs more than the suite-wide per-test budget.
 @pytest.mark.timeout(60)
 def test_fresh_interpreters_plan_the_same_link_orientation() -> None:
-    outputs = _run_probes(_PROBE_PROCESSES)
+    outputs = run_probes(_PROBE, _PROBE_PROCESSES)
 
     assert len(outputs) == _PROBE_PROCESSES, f"expected {_PROBE_PROCESSES} probe results, got {len(outputs)}"
     for position, output in enumerate(outputs):

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -1,0 +1,606 @@
+"""Characterizes what the link planner plans, and what it declines to plan."""
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+from typing import Any, Callable, NamedTuple, Optional
+from uuid import UUID
+
+import pyarrow as pa
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, JoinType, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+SHARED_LEFT_KEY = "link_plan_shared_left_key"
+SHARED_LEFT_PAYLOAD = "link_plan_shared_left_payload"
+SHARED_RIGHT_KEY = "link_plan_shared_right_key"
+SHARED_RIGHT_PAYLOAD = "link_plan_shared_right_payload"
+
+SELF_SIDE = "link_plan_self_side"
+SELF_LEFT_KEY = "link_plan_self_left_key"
+SELF_LEFT_PAYLOAD = "link_plan_self_left_payload"
+SELF_RIGHT_KEY = "link_plan_self_right_key"
+SELF_RIGHT_PAYLOAD = "link_plan_self_right_payload"
+
+STACK_LEFT_INDEX = Index(("link_plan_stack_left_key",))
+STACK_RIGHT_INDEX = Index(("link_plan_stack_right_key",))
+
+PAIR_LEFT_INDEX = Index(("link_plan_pair_left_key",))
+PAIR_RIGHT_INDEX = Index(("link_plan_pair_right_key",))
+
+STACK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link.union]
+LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
+
+_PROBE = Path(__file__).with_name("link_planner_probe.py")
+_PROBE_TIMEOUT = 30.0
+# Each probe is a fresh interpreter importing three frameworks, so the count stays within the gate budget.
+_PROBE_PROCESSES = 5
+_PROBE_EXPECTED = {
+    "child": "PyArrowTable",
+    "orientation_count": "1",
+    "planned_left": "PyArrowTable",
+    "planned_right": "PandasDataFrame",
+    "trekker_left": "PandasDataFrame",
+    "trekker_right": "PyArrowTable",
+}
+
+
+def _column_names(data: Any) -> list[str]:
+    if isinstance(data, pa.Table):
+        return list(data.column_names)
+    return list(data.columns)
+
+
+def _column_values(data: Any, column: str) -> list[Any]:
+    if isinstance(data, pa.Table):
+        return list(data.column(column).to_pylist())
+    return list(data[column])
+
+
+def _with_column(data: Any, column: str, values: list[Any]) -> Any:
+    if isinstance(data, pa.Table):
+        return data.append_column(column, pa.array(values))
+    data[column] = values
+    return data
+
+
+def _paired_payloads(data: Any) -> list[str]:
+    """One string per joined row, so a dropped parent or a swapped merge changes the value."""
+    left = _column_values(data, SHARED_LEFT_PAYLOAD)
+    right = _column_values(data, SHARED_RIGHT_PAYLOAD)
+    return [f"{a}|{b}" for a, b in zip(left, right)]
+
+
+class LinkPlanSharedLeft(FeatureGroup):
+    """Pinned to the framework the link declares as its left side."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={SHARED_LEFT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {SHARED_LEFT_KEY: [1, 2, 3, 4], SHARED_LEFT_PAYLOAD: ["l1", "l2", "l3", "l4"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class LinkPlanSharedRight(FeatureGroup):
+    """Pinned to the right framework, with keys that only partly overlap the left side."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={SHARED_RIGHT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {SHARED_RIGHT_KEY: [3, 4, 5], SHARED_RIGHT_PAYLOAD: ["r3", "r4", "r5"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+def _shared_parents() -> set[Feature]:
+    return {Feature(name=SHARED_LEFT_PAYLOAD), Feature(name=SHARED_RIGHT_PAYLOAD)}
+
+
+class LinkPlanSharedFlexibleChild(FeatureGroup):
+    """Takes either framework, so on its own it would keep the declared orientation."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _shared_parents()
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return _with_column(data, cls.get_class_name(), _paired_payloads(data))
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+class LinkPlanSharedPinnedChild(FeatureGroup):
+    """Takes the right framework only, so it forces the shared link into its inverted orientation."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _shared_parents()
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return _with_column(data, cls.get_class_name(), _paired_payloads(data))
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class LinkPlanSelfSource(FeatureGroup):
+    """Serves both sides of the self join; the requested feature name picks the side."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={SELF_LEFT_PAYLOAD, SELF_RIGHT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if SELF_LEFT_PAYLOAD in {str(feature.name) for feature in features.features}:
+            return {SELF_LEFT_KEY: [1, 2, 3, 4], SELF_LEFT_PAYLOAD: ["l1", "l2", "l3", "l4"]}
+        return {SELF_RIGHT_KEY: [3, 4, 5], SELF_RIGHT_PAYLOAD: ["r3", "r4", "r5"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class LinkPlanSelfConsumer(FeatureGroup):
+    """Consumes both sides; the options are what the discriminators match on."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name=SELF_LEFT_PAYLOAD, options={SELF_SIDE: "left"}),
+            Feature(name=SELF_RIGHT_PAYLOAD, options={SELF_SIDE: "right"}),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        keys = _column_values(data, SELF_LEFT_KEY)
+        payloads = _column_values(data, SELF_RIGHT_PAYLOAD)
+        return _with_column(data, cls.get_class_name(), [f"{key}|{payload}" for key, payload in zip(keys, payloads)])
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class LinkPlanStackLeft(FeatureGroup):
+    pass
+
+
+class LinkPlanStackRight(FeatureGroup):
+    pass
+
+
+class LinkPlanStackConsumer(FeatureGroup):
+    pass
+
+
+class LinkPlanPairLeft(FeatureGroup):
+    pass
+
+
+class LinkPlanPairRight(FeatureGroup):
+    pass
+
+
+class LinkPlanPairChild(FeatureGroup):
+    pass
+
+
+class Planned(NamedTuple):
+    plan: ExecutionPlan
+    link: Link
+    link_trekker: LinkTrekker
+    graph: Graph
+    pre_execution_plan: list[Any]
+    left_uuid: UUID
+    right_uuid: UUID
+    child_uuid: UUID
+
+
+def _feature(name: str, cfw: type[ComputeFramework], index: Index | None = None, **kwargs: Any) -> Feature:
+    feature = Feature(name, index=index, **kwargs)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _step(fg: type[FeatureGroup], feature: Feature, cfw: type[ComputeFramework]) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    feature_set.add(feature)
+    return FeatureGroupStep(fg, feature_set, set(), cfw)
+
+
+def _plan(
+    link: Link,
+    left: Feature,
+    right: Feature,
+    child: Feature,
+    left_fg: type[FeatureGroup],
+    right_fg: type[FeatureGroup],
+    child_fg: type[FeatureGroup],
+) -> Planned:
+    """Hand-built two-parent graph, the smallest shape run_link accepts."""
+    graph = Graph()
+    graph.add_node(left.uuid, NodeProperties(left, left_fg))
+    graph.add_node(right.uuid, NodeProperties(right, right_fg))
+    graph.add_node(child.uuid, NodeProperties(child, child_fg))
+    graph.adjacency_list[left.uuid] = [child.uuid]
+    graph.adjacency_list[right.uuid] = [child.uuid]
+    graph.adjacency_list[child.uuid] = []
+    graph.parent_to_children_mapping[child.uuid] = {left.uuid, right.uuid}
+
+    pre_execution_plan: list[Any] = [
+        _step(left_fg, left, left.get_compute_framework()),
+        _step(right_fg, right, right.get_compute_framework()),
+        _step(child_fg, child, child.get_compute_framework()),
+    ]
+
+    plan = ExecutionPlan()
+    plan.feature_set_collections = [{left.uuid}, {right.uuid}, {child.uuid}]
+
+    return Planned(plan, link, LinkTrekker(), graph, pre_execution_plan, left.uuid, right.uuid, child.uuid)
+
+
+def _trek(planned: Planned, left_cfw: type[ComputeFramework], right_cfw: type[ComputeFramework]) -> None:
+    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
+    trekked = {planned.child_uuid}
+    planned.link_trekker.data[(planned.link, left_cfw, right_cfw)] = trekked
+    planned.link_trekker.data_ordered[(planned.link, left_cfw, right_cfw)] = trekked
+
+
+def _run(planned: Planned, left_cfw: type[ComputeFramework], right_cfw: type[ComputeFramework]) -> Optional[JoinStep]:
+    link_fw: LinkFrameworkTrekker = (planned.link, left_cfw, right_cfw)
+    return planned.plan.run_link(link_fw, planned.link_trekker, planned.graph, planned.pre_execution_plan)
+
+
+def _pair_scenario(
+    *,
+    left_cfw: type[ComputeFramework] = PyArrowTable,
+    right_cfw: type[ComputeFramework] = PandasDataFrame,
+    child_cfw: type[ComputeFramework] = PyArrowTable,
+) -> Planned:
+    link = Link.inner(JoinSpec(LinkPlanPairLeft, PAIR_LEFT_INDEX), JoinSpec(LinkPlanPairRight, PAIR_RIGHT_INDEX))
+    return _plan(
+        link,
+        _feature("link_plan_pair_left_payload", left_cfw, PAIR_LEFT_INDEX),
+        _feature("link_plan_pair_right_payload", right_cfw, PAIR_RIGHT_INDEX),
+        _feature("link_plan_pair_child", child_cfw),
+        LinkPlanPairLeft,
+        LinkPlanPairRight,
+        LinkPlanPairChild,
+    )
+
+
+def _self_join_scenario(left_side: str, right_side: str) -> Planned:
+    link = Link.left(
+        JoinSpec(LinkPlanSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(LinkPlanSelfSource, Index((SELF_RIGHT_KEY,))),
+        left_discriminator={SELF_SIDE: left_side},
+        right_discriminator={SELF_SIDE: right_side},
+    )
+    return _plan(
+        link,
+        _feature(SELF_LEFT_PAYLOAD, PyArrowTable, options={SELF_SIDE: "left"}),
+        _feature(SELF_RIGHT_PAYLOAD, PyArrowTable, options={SELF_SIDE: "right"}),
+        _feature("link_plan_self_child", PyArrowTable),
+        LinkPlanSelfSource,
+        LinkPlanSelfSource,
+        LinkPlanSelfConsumer,
+    )
+
+
+def _stack_scenario(link_factory: Callable[[JoinSpec, JoinSpec], Link], *, same_feature_group: bool) -> Planned:
+    """Declared orientation PyArrow to Pandas, consumer on Pandas only, so the trekker inverts."""
+    right_fg: type[FeatureGroup] = LinkPlanStackLeft if same_feature_group else LinkPlanStackRight
+    link = link_factory(JoinSpec(LinkPlanStackLeft, STACK_LEFT_INDEX), JoinSpec(right_fg, STACK_RIGHT_INDEX))
+
+    left = _feature("link_plan_stack_left_payload", PyArrowTable, STACK_LEFT_INDEX)
+    right = _feature("link_plan_stack_right_payload", PandasDataFrame, STACK_RIGHT_INDEX)
+    child = _feature("link_plan_stack_consumer", PandasDataFrame)
+
+    planned = _plan(link, left, right, child, LinkPlanStackLeft, right_fg, LinkPlanStackConsumer)
+    _trek(planned, PyArrowTable, PandasDataFrame)
+
+    planned_queue: list[Any] = [
+        (LinkPlanStackLeft, {left}),
+        (right_fg, {right}),
+        (link, PyArrowTable, PandasDataFrame),
+        (LinkPlanStackConsumer, {child}),
+    ]
+    ResolveComputeFrameworks(Graph()).links(planned_queue, planned.link_trekker)
+    return planned
+
+
+def _orientations(planned: Planned) -> list[tuple[str, str]]:
+    return [
+        (key[1].get_class_name(), key[2].get_class_name())
+        for key in planned.link_trekker.data
+        if key[0] is planned.link
+    ]
+
+
+def _run_probes(count: int) -> list[dict[str, str]]:
+    assert _PROBE.is_file(), f"{_PROBE} does not exist"
+
+    outputs: list[dict[str, str]] = []
+    for _ in range(count):
+        # Safe: fixed argv, no shell, no user input.
+        completed = subprocess.run(  # nosec B603
+            [sys.executable, str(_PROBE)],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT,
+        )
+        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
+        lines = [line for line in completed.stdout.splitlines() if line.strip()]
+        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
+        parsed: dict[str, str] = json.loads(lines[0])
+        outputs.append(parsed)
+    return outputs
+
+
+@pytest.mark.parametrize("modes", [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}])
+class TestSharedLinkServingTwoChildren:
+    """One link between one parent pair, consumed by a flexible child and a pinned child."""
+
+    def _run_both_children(self, modes: set[ParallelizationMode], flight_server: Any) -> dict[str, list[str]]:
+        link = Link.inner(
+            left=JoinSpec(LinkPlanSharedLeft, Index((SHARED_LEFT_KEY,))),
+            right=JoinSpec(LinkPlanSharedRight, Index((SHARED_RIGHT_KEY,))),
+        )
+        children = (LinkPlanSharedFlexibleChild, LinkPlanSharedPinnedChild)
+
+        results = mloda.run_all(
+            [Feature(name=child.get_class_name()) for child in children],
+            links={link},
+            compute_frameworks=["PyArrowTable", "PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {LinkPlanSharedLeft, LinkPlanSharedRight, *children}
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        collected: dict[str, list[str]] = {}
+        for result in results:
+            for child in children:
+                name = child.get_class_name()
+                if name in _column_names(result):
+                    collected[name] = sorted(_column_values(result, name))
+        return collected
+
+    def test_each_child_gets_the_two_rows_both_parents_share(
+        self, modes: set[ParallelizationMode], flight_server: Any
+    ) -> None:
+        collected = self._run_both_children(modes, flight_server)
+
+        assert sorted(collected) == [
+            LinkPlanSharedFlexibleChild.get_class_name(),
+            LinkPlanSharedPinnedChild.get_class_name(),
+        ]
+        assert [len(rows) for _, rows in sorted(collected.items())] == [2, 2]
+
+    def test_each_child_pairs_every_key_with_both_parent_payloads(
+        self, modes: set[ParallelizationMode], flight_server: Any
+    ) -> None:
+        collected = self._run_both_children(modes, flight_server)
+
+        assert collected == {
+            LinkPlanSharedFlexibleChild.get_class_name(): ["l3|r3", "l4|r4"],
+            LinkPlanSharedPinnedChild.get_class_name(): ["l3|r3", "l4|r4"],
+        }
+
+
+def _run_self_join(left_side: str, right_side: str) -> list[Any]:
+    link = Link.left(
+        JoinSpec(LinkPlanSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(LinkPlanSelfSource, Index((SELF_RIGHT_KEY,))),
+        left_discriminator={SELF_SIDE: left_side},
+        right_discriminator={SELF_SIDE: right_side},
+    )
+    return list(
+        mloda.run_all(
+            [Feature(name=LinkPlanSelfConsumer.get_class_name())],
+            links={link},
+            compute_frameworks=["PyArrowTable"],
+            plugin_collector=PluginCollector.enabled_feature_groups({LinkPlanSelfSource, LinkPlanSelfConsumer}),
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+    )
+
+
+def test_self_join_keeps_every_row_of_the_node_the_left_discriminator_names() -> None:
+    results = _run_self_join("left", "right")
+
+    joined = sorted(_column_values(results[0], LinkPlanSelfConsumer.get_class_name()))
+    assert joined == ["1|None", "2|None", "3|r3", "4|r4"]
+
+
+def test_swapped_discriminators_bind_the_other_node_as_the_left_side() -> None:
+    """The bound left node then lacks the left index column, and the merge says so."""
+    with pytest.raises(KeyError, match=SELF_LEFT_KEY):
+        _run_self_join("right", "left")
+
+
+def test_planner_binds_the_left_discriminator_node_as_the_join_destination() -> None:
+    planned = _self_join_scenario("left", "right")
+    _trek(planned, PyArrowTable, PyArrowTable)
+
+    join_step = _run(planned, PyArrowTable, PyArrowTable)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework_uuids == {planned.left_uuid}
+    assert join_step.source_framework_uuids == {planned.right_uuid}
+
+
+def test_planner_follows_swapped_discriminators_without_complaint() -> None:
+    planned = _self_join_scenario("right", "left")
+    _trek(planned, PyArrowTable, PyArrowTable)
+
+    join_step = _run(planned, PyArrowTable, PyArrowTable)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework_uuids == {planned.right_uuid}
+    assert join_step.source_framework_uuids == {planned.left_uuid}
+
+
+@pytest.mark.parametrize("link_factory", STACK_FACTORIES)
+def test_a_pinned_consumer_inverts_the_stack_link_orientation(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _stack_scenario(link_factory, same_feature_group=False)
+
+    assert _orientations(planned) == [("PandasDataFrame", "PyArrowTable")]
+
+
+@pytest.mark.parametrize("link_factory", STACK_FACTORIES)
+def test_an_inverted_cross_group_stack_link_still_plans_the_declared_orientation(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    """The inversion reaches the trekker but not the JoinStep, so the declared sides survive."""
+    planned = _stack_scenario(link_factory, same_feature_group=False)
+
+    join_step = _run(planned, PyArrowTable, PandasDataFrame)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.link.jointype in (JoinType.APPEND, JoinType.UNION)
+    assert join_step.destination_framework is PyArrowTable
+    assert join_step.source_framework is PandasDataFrame
+    assert join_step.destination_framework_uuids == {planned.left_uuid}
+    assert join_step.source_framework_uuids == {planned.right_uuid}
+    assert join_step.swap_merge_sides is False
+
+
+@pytest.mark.xfail(strict=True, reason="the inverted orientation is dropped before the JoinStep is built")
+@pytest.mark.parametrize("link_factory", STACK_FACTORIES)
+def test_an_inverted_cross_group_stack_link_joins_where_its_consumer_runs(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    """The consumer resolved to the right framework, so the join it feeds should run there too."""
+    planned = _stack_scenario(link_factory, same_feature_group=False)
+
+    join_step = _run(planned, PyArrowTable, PandasDataFrame)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework is PandasDataFrame
+
+
+@pytest.mark.parametrize("link_factory", STACK_FACTORIES)
+def test_an_inverted_self_group_stack_link_plans_nothing_for_the_declared_orientation(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _stack_scenario(link_factory, same_feature_group=True)
+
+    assert _run(planned, PyArrowTable, PandasDataFrame) is None
+
+
+@pytest.mark.parametrize("link_factory", STACK_FACTORIES)
+def test_an_inverted_self_group_stack_link_is_rejected_naming_link_and_frameworks(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _stack_scenario(link_factory, same_feature_group=True)
+
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned, PandasDataFrame, PyArrowTable)
+
+    message = str(excinfo.value)
+    assert LEFT_FRAMEWORK_INVARIANT in message
+    assert str(planned.link) in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
+
+
+def test_the_declared_orientation_plans_the_declared_joinstep() -> None:
+    planned = _pair_scenario()
+    _trek(planned, PyArrowTable, PandasDataFrame)
+
+    join_step = _run(planned, PyArrowTable, PandasDataFrame)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework is PyArrowTable
+    assert join_step.source_framework is PandasDataFrame
+    assert join_step.destination_framework_uuids == {planned.left_uuid}
+    assert join_step.source_framework_uuids == {planned.right_uuid}
+    assert join_step.swap_merge_sides is False
+
+
+def test_an_orientation_without_a_valid_pairing_plans_no_joinstep() -> None:
+    """No parent is both a left-side feature group and on the left framework, so nothing pairs up."""
+    planned = _pair_scenario(child_cfw=PandasDataFrame)
+    _trek(planned, PandasDataFrame, PyArrowTable)
+
+    assert _run(planned, PandasDataFrame, PyArrowTable) is None
+
+
+def test_a_trekker_inverted_after_queueing_swaps_the_merge_sides() -> None:
+    """The queue keeps the declared orientation, so run_link rediscovers the inverted one."""
+    planned = _pair_scenario(child_cfw=PandasDataFrame)
+    _trek(planned, PandasDataFrame, PyArrowTable)
+
+    join_step = _run(planned, PyArrowTable, PandasDataFrame)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework is PandasDataFrame
+    assert join_step.source_framework is PyArrowTable
+    assert join_step.destination_framework_uuids == {planned.right_uuid}
+    assert join_step.source_framework_uuids == {planned.left_uuid}
+    assert join_step.swap_merge_sides is True
+
+
+def test_a_swapped_joinstep_keeps_the_uuids_the_pairing_returned() -> None:
+    """A child left on the declared left framework makes the pairing outvote the framework filter."""
+    planned = _pair_scenario()
+    _trek(planned, PandasDataFrame, PyArrowTable)
+
+    join_step = _run(planned, PyArrowTable, PandasDataFrame)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework is PandasDataFrame
+    assert join_step.destination_framework_uuids == {planned.left_uuid}
+    assert join_step.source_framework_uuids == {planned.right_uuid}
+    assert join_step.swap_merge_sides is True
+
+
+# Fresh interpreters are slow to start, so this one needs more than the suite-wide per-test budget.
+@pytest.mark.timeout(60)
+def test_fresh_interpreters_plan_the_same_link_orientation() -> None:
+    outputs = _run_probes(_PROBE_PROCESSES)
+
+    assert len(outputs) == _PROBE_PROCESSES, f"expected {_PROBE_PROCESSES} probe results, got {len(outputs)}"
+    for position, output in enumerate(outputs):
+        assert output == _PROBE_EXPECTED, f"probe {position} planned {output}, expected {_PROBE_EXPECTED}"


### PR DESCRIPTION
Pins current link planner behaviour for the shapes where a link's declared join
sides and its resolved compute frameworks can disagree. Tests only, no production
changes, so it can land ahead of the planner work it is meant to guard.

## What is covered

End-to-end (`test_link_planner_orientation_characterization.py`):

- inner and left joins in both the declared and the inverted orientation
- a plain RIGHT join, both for a child declaring the left framework and for one
  on the right framework
- a chained join across three compute frameworks

Planning level (`test_link_planner_plan_characterization.py`):

- one link shared by two child groups, one flexible and one pinned
- a self join disambiguated by discriminators, including the swapped case
- inverted APPEND and UNION links, both across feature groups and within one
- the JoinStep fields `run_link` derives per orientation, including
  `swap_merge_sides`, and the orientation that plans no JoinStep at all
- the RIGHT branch, which swaps the frameworks before the trekker lookup and
  then re-flips the merge order when no child wants the declared orientation

## Why the fixtures look like this

Key sets are asymmetric, the two sides use different index column names, and
every parent carries a distinguishable payload. Symmetric fixtures produce the
same result whichever way the merge arguments are bound, which is what lets a
side-binding bug pass unnoticed. Each child packs one string per joined row, so
row count, row order and the pairing itself are all read off a single column.

Two shapes are marked `xfail(strict=True)` and assert the correct behaviour, so
the marker flips when the underlying issue is fixed:

- a plain RIGHT join whose child runs in the right framework binds the merge
  arguments to the resolved frameworks instead of the declared sides, so the
  declared left index is looked up in the right group's data
- an inverted APPEND or UNION link is dropped before the JoinStep is built

MULTIPROCESSING is opted into per shape rather than across the board. The
remaining shapes fail in the transform hop on a flight the server has no table
for, which predates this change and is tracked separately.

A fresh-interpreter probe runner is now shared between this suite and the
existing framework-selection probe.