### PR TITLE
docs: separate the shared filter matching gates from filter policy

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -27,7 +27,7 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 
 Containment covers plugin raises only: a framework-owned raise (a two-readers conflict, a forwarded value contradicting the feature name, a rejected effective-options build) still aborts the whole resolution, because it reports a misconfiguration you have to fix.
 
-Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters` as a `match hook` near-miss, as is a typed decline the matcher records; a framework-owned raise still aborts. Every entry names the gate that dropped the filter and that gate's reason.
+Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters` as a `match hook` near-miss, as is a typed decline the matcher records; a framework-owned raise still aborts. Every entry names the gate that dropped the filter and that gate's reason. [How filters reach your FeatureGroup](filter_data.md#how-filters-reach-your-featuregroup) tables the gates the two paths share and where filter policy differs.
 
 The probe runs per feature, but a matched filter attaches to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset).
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -186,25 +186,24 @@ When a user passes a `GlobalFilter`, the framework tests every `SingleFilter` ag
 FeatureGroup that each feature already resolved to, using that feature's options, domain
 and compute framework. Each filter is **deep-copied** first, so everything below happens
 on the copy and never on the filter the user built. The copy is delivered only if it
-clears five gates, in order: the group's own `match_feature_group_criteria()` on the
-filter feature's name and options (plus the run's `DataAccessCollection`), then the filter
-feature's domain against the resolved feature's, then its `feature_group` scope against
-the probed FeatureGroup, honored with the same semantics as feature resolution (the named
-class and its subclasses, class-object and string forms alike), then the group's
-`supports_compute_framework()` on the same name and options, which narrows the frameworks
-the filter rides to the hook-accepted ones (its own pin, else the resolved feature's),
-detaching the filter when none are accepted, then its compute framework against the
-resolved feature's. The domain and compute
-framework gates also backfill: a filter feature that declares no domain or compute
-framework inherits the resolved feature's (the FeatureGroup's domain when the feature
-declares none). Pinning a filter feature to more than one compute framework raises
-`ComputeFrameworkPinError` at `add_filter` time; feature resolution applies the same
-validation. Declaring the filter's column as an input is **not** the test, and links are
-not re-checked here (feature resolution already covered them).
+clears these gates, in the order they run:
+
+| Gate | Shared with feature resolution | Filter policy |
+|------|--------------------------------|---------------|
+| criteria | [one shared probe](feature-group-matching.md) | asked about the filter feature's name and its enriched options, plus the run's `DataAccessCollection` |
+| domain | the comparison | a filter feature declaring no domain adopts the resolved feature's, or the FeatureGroup's when the feature declares none |
+| scope | `matches_feature_group_scope`: the named class and its subclasses, class-object and string forms alike | none |
+| capability | the `supports_compute_framework` hook and its narrowing | asked over the frameworks the filter would ride (its own pin, else the resolved feature's), detaching it when none are accepted |
+| compute framework pin | the cardinality validator, raising `ComputeFrameworkPinError` on more than one pin | validated at `add_filter`, not at probe time; the pin must equal the feature's resolved framework |
+
+Links are deliberately not re-checked: feature resolution already covered them. Declaring
+the filter's column as an input is **not** the test either.
 
 `match_feature_group_criteria()` sees the filter feature's own options enriched from the
 resolved feature's effective (post-default) ones (see
-[Applying declared defaults](property-mapping.md#applying-declared-defaults)). If two
+[Applying declared defaults](property-mapping.md#applying-declared-defaults)), where
+feature resolution passes declared options alone. The option divergence warning fires only
+for a filter that actually attaches, once per distinct message per setup. If two
 FeatureGroups both match the same original filter, they each receive independent copies.
 This means a single `GlobalFilter` can be processed differently by different FeatureGroups
 in the same pipeline: one may use the mask engine for inline masking while another uses
@@ -214,23 +213,6 @@ The return is read for truthiness, so any falsy value is a non-match, exactly li
 that falls off the end of a branch and returns `None` attaches no filter. A falsy value that is not
 `False` is reported once per FeatureGroup and filter feature, so the detached filter is visible;
 return `True` explicitly to keep it.
-
-If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, or returns a
-value whose truthiness test raises, that filter is a non-match for that probe, like a `False`
-return, and the drop is recorded in `GlobalFilter.dropped_filters`. A typed decline the matcher
-records lands in the same ledger, at DEBUG. A framework-owned raise still aborts.
-
-`GlobalFilter.dropped_filters` maps (FeatureGroup, filter feature name) to the gate that dropped the
-filter and that gate's reason, for the current engine setup only. A plain `False` is an ordinary
-non-match and records nothing. A matcher defect takes the key from a stored near-miss; otherwise the
-deepest gate the filter reached keeps it, and two facts at one depth leave the first one in place.
-
-The option divergence warning fires only for a filter that actually attaches, once per distinct
-message per setup. A filter that matches no FeatureGroup at all is reported once after setup
-("matched no feature group"), with its nearest miss appended when one was recorded: the deepest gate
-that filter reached, rendered as `<FeatureGroup> (<gate label>): <reason>`, for example `(scope)` when
-a `feature_group` scope excluded it. Two filters declared on one column name share the ledger key, so
-neither report can quote a fact and both stay the bare sentence.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:
@@ -262,6 +244,33 @@ compute framework, option set, data type and dependency level), and any earlier 
 a reused `GlobalFilter` keeps the matches it has recorded. Which of the two empty states you
 get is therefore decided outside your FeatureGroup. `if features.filters:` covers both;
 `if features.filters is not None:` passes with nothing to iterate.
+
+### Why a filter did not attach
+
+If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, or returns a
+value whose truthiness test raises, that filter is a non-match for that probe, like a `False`
+return, and the drop is recorded in `GlobalFilter.dropped_filters`. A typed decline the matcher
+records lands in the same ledger, at DEBUG. A framework-owned raise still aborts.
+
+`GlobalFilter.dropped_filters` maps (FeatureGroup, filter feature name) to the gate that dropped the
+filter and that gate's reason, for the current engine setup only. A plain `False` is an ordinary
+non-match and records nothing. A matcher defect takes the key from a stored near-miss; otherwise the
+deepest gate the filter reached keeps it, and two facts at one depth leave the first one in place.
+
+A filter that matches no FeatureGroup at all is reported once after setup, with its nearest miss
+appended when one was recorded: across FeatureGroups the deepest gate wins, and a matcher defect
+ranks last.
+
+```text
+Filter feature 'price' matched no feature group. Nearest miss: SalesTotal (scope): outside the requested feature group scope
+```
+
+The parenthesized label, `(scope)` here, names the gate in the vocabulary of the "No feature groups
+found" error's
+[near-miss bullets](troubleshooting/feature-group-resolution-errors.md#the-eliminated-candidates-block).
+
+Two filters declared on one column name share the ledger key, so neither report can quote a fact and
+both stay the bare sentence.
 
 ### Filter scope is the `FeatureSet`
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -190,11 +190,11 @@ clears these gates, in the order they run:
 
 | Gate | Shared with feature resolution | Filter policy |
 |------|--------------------------------|---------------|
-| criteria | [one shared probe](feature-group-matching.md) | asked about the filter feature's name and its enriched options, plus the run's `DataAccessCollection` |
-| domain | the comparison | a filter feature declaring no domain adopts the resolved feature's, or the FeatureGroup's when the feature declares none |
-| scope | `matches_feature_group_scope`: the named class and its subclasses, class-object and string forms alike | none |
-| capability | the `supports_compute_framework` hook and its narrowing | asked over the frameworks the filter would ride (its own pin, else the resolved feature's), detaching it when none are accepted |
-| compute framework pin | the cardinality validator, raising `ComputeFrameworkPinError` on more than one pin | validated at `add_filter`, not at probe time; the pin must equal the feature's resolved framework |
+| criteria | [one shared probe](feature-group-matching.md#modern-unified-matching) | asked about the filter feature's name and its enriched options, plus the run's `DataAccessCollection` |
+| domain | `Domain` equality only: resolution compares the FeatureGroup's domain to the feature's, and passes any candidate for a domainless feature | the filter feature's domain must equal the resolved feature's, or the FeatureGroup's when the feature declares none; a domainless filter copy adopts that domain, though never a default group domain |
+| scope | `matches_feature_group_scope`: the named class and its subclasses, class-object and string forms alike | none, beyond reading the filter feature's own `feature_group=` |
+| capability (`compute framework`) | the `supports_compute_framework` hook and its narrowing | asked over the frameworks the filter would ride (its own pin, else the resolved feature's), skipped when neither carries one; nothing accepted detaches the filter, and an unpinned copy rides the accepted subset, or the feature's frameworks when the hook was never consulted |
+| compute framework pin | only the pin-cardinality validator, which raises `ComputeFrameworkPinError` at `add_filter`, not at this gate | the resolved feature's framework must be the filter feature's pin; resolution instead tests the feature's pin against the candidate's supported frameworks |
 
 Links are deliberately not re-checked: feature resolution already covered them. Declaring
 the filter's column as an input is **not** the test either.

--- a/tests/test_documentation/test_near_miss_labels_in_docs.py
+++ b/tests/test_documentation/test_near_miss_labels_in_docs.py
@@ -138,10 +138,11 @@ def test_a_registered_page_still_renders_the_bullet_of_its_own_stage(
 
 
 # The other form carrying a stage label: the warning GlobalFilter.warn_on_unmatched_filters emits. Unanchored,
-# so a quoted log prefix still reads.
+# so a quoted log prefix still reads. The literal prefix does the disambiguating the bullet needs '[A-Z]' for,
+# so the candidate class stays broad and no rendered warning slips past.
 UNMATCHED_FILTER_PATTERN = re.compile(
     r"Filter feature '(?P<filter_feature>[^']+)' matched no feature group\. Nearest miss: "
-    r"(?P<candidate>[A-Z]\w*) \((?P<label>[^)]+)\): (?P<reason>.+)$"
+    r"(?P<candidate>[^\s(]+) \((?P<label>[^)]+)\): (?P<reason>.+)$"
 )
 
 GLOBAL_FILTER_LOGGER = "mloda.core.filter.global_filter"
@@ -152,9 +153,17 @@ WARNING_FILTER_FEATURE = "near_miss_warning_probe_filter"
 WARNING_MISSING_SCOPE = "NearMissWarningNoSuchScope"  # names no class, so the scope gate drops the filter
 WARNING_STAGE: EliminationStage = "scope"
 
+# The scope gate's own wording, in GlobalFilter.identify_matched_filters. Asserted against the live warning
+# below and against the page pinned in DOC_WARNING_STAGES, so rewording it there names the stale page.
+WARNING_SCOPE_REASON = "outside the requested feature group scope"
+
 
 def _unmatched_filter_warnings(text: str) -> Iterator[tuple[int, re.Match[str]]]:
-    """Yield (1-based line number, match) for every unmatched-filter warning inside a ``` fenced block."""
+    """Yield (1-based line number, match) for the first unmatched-filter warning on each fenced line.
+
+    One warning per line, as a log block renders them: a second on the same line is swallowed by the
+    greedy reason of the first and its label goes unchecked.
+    """
     for number, line in _fenced_lines(text):
         match = UNMATCHED_FILTER_PATTERN.search(line)
         if match is not None:
@@ -178,8 +187,6 @@ def test_rendered_unmatched_filter_warnings_carry_a_current_stage_label(fpath: P
 
 def _make_warning_probe_fg() -> type[FeatureGroup]:
     """A throwaway group matching both probe names, built here so no test local ever holds the class."""
-    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
-    gc.collect()
 
     class NearMissWarningProbeFG(FeatureGroup):
         @classmethod
@@ -218,22 +225,30 @@ def test_the_scanner_pattern_matches_a_rendered_unmatched_filter_warning(caplog:
     assert match.group("filter_feature") == WARNING_FILTER_FEATURE
     assert match.group("candidate") == WARNING_PROBE_CLASS_NAME
     assert match.group("label") == _STAGE_LABELS[WARNING_STAGE]
+    assert match.group("reason") == WARNING_SCOPE_REASON
 
 
-# The same floor as DOC_BULLET_STAGES, for the warning form: pages reproducing it, pinned to their stage.
-DOC_WARNING_STAGES: dict[str, EliminationStage] = {
-    "in_depth/filter_data.md": "scope",
+# The same floor as DOC_BULLET_STAGES, for the warning form: pages reproducing it, pinned to their stage and
+# to the gate's own reason wording, which no label table covers.
+DOC_WARNING_STAGES: dict[str, tuple[EliminationStage, str]] = {
+    "in_depth/filter_data.md": ("scope", WARNING_SCOPE_REASON),
 }
 
 
-@pytest.mark.parametrize(("relative_path", "stage"), sorted(DOC_WARNING_STAGES.items()), ids=sorted(DOC_WARNING_STAGES))
+@pytest.mark.parametrize(
+    ("relative_path", "stage", "reason"),
+    [(path, stage, reason) for path, (stage, reason) in sorted(DOC_WARNING_STAGES.items())],
+    ids=sorted(DOC_WARNING_STAGES),
+)
 def test_a_registered_page_still_renders_the_warning_of_its_own_stage(
-    relative_path: str, stage: EliminationStage
+    relative_path: str, stage: EliminationStage, reason: str
 ) -> None:
     page = DOCS_ROOT / relative_path
     assert page.is_file(), f"{page} was moved or renamed; update DOC_WARNING_STAGES"
 
-    labels = {match.group("label") for _, match in _unmatched_filter_warnings(page.read_text(encoding="utf-8"))}
+    rendered = [match for _, match in _unmatched_filter_warnings(page.read_text(encoding="utf-8"))]
+    labels = {match.group("label") for match in rendered}
+    reasons = {match.group("reason") for match in rendered}
 
     # Containment, not equality: a page may grow a second example.
     assert _STAGE_LABELS[stage] in labels, (
@@ -241,13 +256,21 @@ def test_a_registered_page_still_renders_the_warning_of_its_own_stage(
         f"(found: {sorted(labels)})."
     )
 
+    # The reason is code-owned too, and only this pin ties the page's copy of it to the gate that emits it.
+    assert reason in reasons, (
+        f"{page} quotes no unmatched-filter warning carrying the '{stage}' reason '{reason}' "
+        f"(found: {sorted(reasons)})."
+    )
+
 
 # data-access-patterns.md is in this table AND in DOC_BULLET_STAGES on purpose: its prose mention sits far
 # from its rendered bullet, so the bullet's failure names a line that leaves the prose mention stale.
+# filter_data.md is pinned twice: its example renders the scope label, its prose also names the capability one.
 PROSE_LABEL_PAGES: tuple[tuple[str, EliminationStage], ...] = (
     ("in_depth/data-access-patterns.md", "input_data"),
     ("in_depth/feature-chain-parser.md", "matcher_error"),
     ("in_depth/feature-group-matching.md", "matcher_error"),
+    ("in_depth/filter_data.md", "capability"),
     ("in_depth/filter_data.md", "scope"),
 )
 

--- a/tests/test_documentation/test_near_miss_labels_in_docs.py
+++ b/tests/test_documentation/test_near_miss_labels_in_docs.py
@@ -5,6 +5,8 @@ updating that table turns the suite green with the pages still quoting the old l
 label back off the page, check it against the live table, and name the file and line that went stale.
 """
 
+import gc
+import logging
 import re
 from collections.abc import Iterator
 from pathlib import Path
@@ -13,6 +15,8 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter.filter_type_enum import FilterType
+from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, render_resolution_failure
 from mloda.core.prepare.resolution_types import Elimination, EliminationStage, EvaluationResult
 
@@ -130,6 +134,111 @@ def test_a_registered_page_still_renders_the_bullet_of_its_own_stage(
     # Containment, not equality: a page may grow a second example, and unknown labels fail the scan above.
     assert _STAGE_LABELS[stage] in labels, (
         f"{page} no longer renders a '{_STAGE_LABELS[stage]}' bullet the scanner reads (found: {sorted(labels)})."
+    )
+
+
+# The other form carrying a stage label: the warning GlobalFilter.warn_on_unmatched_filters emits. Unanchored,
+# so a quoted log prefix still reads.
+UNMATCHED_FILTER_PATTERN = re.compile(
+    r"Filter feature '(?P<filter_feature>[^']+)' matched no feature group\. Nearest miss: "
+    r"(?P<candidate>[A-Z]\w*) \((?P<label>[^)]+)\): (?P<reason>.+)$"
+)
+
+GLOBAL_FILTER_LOGGER = "mloda.core.filter.global_filter"
+
+WARNING_PROBE_CLASS_NAME = "NearMissWarningProbeFG"
+WARNING_HOST_FEATURE = "near_miss_warning_probe_host"
+WARNING_FILTER_FEATURE = "near_miss_warning_probe_filter"
+WARNING_MISSING_SCOPE = "NearMissWarningNoSuchScope"  # names no class, so the scope gate drops the filter
+WARNING_STAGE: EliminationStage = "scope"
+
+
+def _unmatched_filter_warnings(text: str) -> Iterator[tuple[int, re.Match[str]]]:
+    """Yield (1-based line number, match) for every unmatched-filter warning inside a ``` fenced block."""
+    for number, line in _fenced_lines(text):
+        match = UNMATCHED_FILTER_PATTERN.search(line)
+        if match is not None:
+            yield number, match
+
+
+@pytest.mark.parametrize("fpath", _docs_pages(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+def test_rendered_unmatched_filter_warnings_carry_a_current_stage_label(fpath: Path) -> None:
+    """Every label a page reproduces in an unmatched-filter warning is still a value of ``_STAGE_LABELS``."""
+    stale = [
+        f"{fpath}:{number} renders near-miss label '{match.group('label')}'"
+        for number, match in _unmatched_filter_warnings(fpath.read_text(encoding="utf-8"))
+        if match.group("label") not in ALLOWED_LABELS
+    ]
+
+    assert not stale, (
+        f"Doc page(s) render an unmatched-filter label no stage carries (current labels: {sorted(ALLOWED_LABELS)}):\n"
+        + "\n".join(stale)
+    )
+
+
+def _make_warning_probe_fg() -> type[FeatureGroup]:
+    """A throwaway group matching both probe names, built here so no test local ever holds the class."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class NearMissWarningProbeFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {WARNING_HOST_FEATURE, WARNING_FILTER_FEATURE}
+
+    return NearMissWarningProbeFG
+
+
+def _emit_unmatched_filter_warning(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
+    """Drive one scope drop through GlobalFilter and return the warnings it logged, leaking no class."""
+    feature_group = _make_warning_probe_fg()
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(WARNING_FILTER_FEATURE, feature_group=WARNING_MISSING_SCOPE), FilterType.EQUAL, {"value": 1}
+    )
+    try:
+        with caplog.at_level(logging.WARNING, logger=GLOBAL_FILTER_LOGGER):
+            # The returned set stays unbound: nothing of this drive may outlive it.
+            global_filter.identify_matched_filters(feature_group, Feature(WARNING_HOST_FEATURE))
+            global_filter.warn_on_unmatched_filters()
+        return tuple(record.getMessage() for record in caplog.records if record.name == GLOBAL_FILTER_LOGGER)
+    finally:
+        del feature_group, global_filter
+        gc.collect()
+
+
+def test_the_scanner_pattern_matches_a_rendered_unmatched_filter_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A changed warning format would otherwise degrade the scan above into a no-op."""
+    # Located by the probe's own filter feature name, never by the prefix under test.
+    emitted = [message for message in _emit_unmatched_filter_warning(caplog) if WARNING_FILTER_FEATURE in message]
+    assert len(emitted) == 1, f"Expected exactly one unmatched-filter warning, got {emitted}"
+
+    match = UNMATCHED_FILTER_PATTERN.search(emitted[0])
+    assert match is not None, f"UNMATCHED_FILTER_PATTERN no longer matches {emitted[0]!r}, so the scan is a no-op."
+    assert match.group("filter_feature") == WARNING_FILTER_FEATURE
+    assert match.group("candidate") == WARNING_PROBE_CLASS_NAME
+    assert match.group("label") == _STAGE_LABELS[WARNING_STAGE]
+
+
+# The same floor as DOC_BULLET_STAGES, for the warning form: pages reproducing it, pinned to their stage.
+DOC_WARNING_STAGES: dict[str, EliminationStage] = {
+    "in_depth/filter_data.md": "scope",
+}
+
+
+@pytest.mark.parametrize(("relative_path", "stage"), sorted(DOC_WARNING_STAGES.items()), ids=sorted(DOC_WARNING_STAGES))
+def test_a_registered_page_still_renders_the_warning_of_its_own_stage(
+    relative_path: str, stage: EliminationStage
+) -> None:
+    page = DOCS_ROOT / relative_path
+    assert page.is_file(), f"{page} was moved or renamed; update DOC_WARNING_STAGES"
+
+    labels = {match.group("label") for _, match in _unmatched_filter_warnings(page.read_text(encoding="utf-8"))}
+
+    # Containment, not equality: a page may grow a second example.
+    assert _STAGE_LABELS[stage] in labels, (
+        f"{page} no longer renders a '{_STAGE_LABELS[stage]}' unmatched-filter warning the scanner reads "
+        f"(found: {sorted(labels)})."
     )
 
 


### PR DESCRIPTION
## Summary

`GlobalFilter` matching and the canonical FeatureGroup resolver now share most of their gates, but neither in_depth page said which gates are shared and which differences are deliberate policy, so telling intent from drift meant reading both seams.

`filter_data.md` now tables the five gates in the order they run, against what each shares with feature resolution and what it decides differently:

- **criteria** runs one shared probe, over the filter feature's name, its enriched options, and the run's `DataAccessCollection`.
- **domain** shares only `Domain` equality. Resolution compares the feature group's domain to the feature's and passes any candidate for a domainless feature; filter matching compares the filter feature's domain and falls back to the group's, so it can drop a filter the canonical gate would keep. The row also covers the branch where the filter declares a domain and the feature does not, and the default group domain a filter copy never adopts.
- **scope** shares `matches_feature_group_scope` outright, reading the filter feature's own `feature_group=`.
- **capability** shares the `supports_compute_framework` hook, is skipped when neither side carries a framework, detaches the filter when nothing is accepted, and decides which frameworks an unpinned copy rides.
- **compute framework pin** shares only the cardinality validator, which runs at `add_filter` rather than at that gate; the gate itself has operands inverted from the canonical one.

Links are named as the gate deliberately not re-checked. The drop ledger and the unmatched-filter report move under their own heading, with the rendered warning quoted. `feature-group-matching.md` links the table rather than restating it.

## Guard

The unmatched-filter warning renders a stage label, and the doc guard read only the resolution failure bullet form, so renaming a label would leave the page quoting the old one. The guard now scans that second rendered form too, pins the page to its stage and to the reason string the example quotes, and drives the real seam so the pattern cannot rot into a no-op.

## Definition of done

- `tox` passes.