### PR TITLE
test: collapse the enum-swept duplicate test bodies into parametrized tables

### DIFF
--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -145,8 +145,8 @@ class TestDocsGetterSharedBehaviour:
         all_results = kind.get_docs()
         assert len(all_results) > 0, f"Need at least one {kind.label} for filtering"
 
-        target_name = all_results[0].name
-        assert len(target_name) > 3, f"Need a {kind.label} name long enough to slice a substring from"
+        target_name = next((entry.name for entry in all_results if len(entry.name) > 3), None)
+        assert target_name is not None, f"Need a {kind.label} name long enough to slice a substring from"
 
         partial = target_name[:3]
         filtered = kind.get_docs(name=partial)

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -103,8 +103,6 @@ class TestExtenderInfo:
 
 @dataclass(frozen=True)
 class DocKind:
-    """One plugin-docs getter and the info dataclass its entries carry."""
-
     label: str
     get_docs: Callable[..., list[Any]]
     info_class: type[Any]

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -1,6 +1,7 @@
 import gc
 import inspect
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -100,24 +101,101 @@ class TestExtenderInfo:
         assert info.wraps == ["pandas", "polars"]
 
 
-class TestGetFeatureGroupDocs:
-    def test_get_feature_group_docs_returns_list(self) -> None:
-        """Test that get_feature_group_docs returns a list."""
-        result = get_feature_group_docs()
-        assert isinstance(result, list)
+@dataclass(frozen=True)
+class DocKind:
+    """One plugin-docs getter and the info dataclass its entries carry."""
 
-    def test_get_feature_group_docs_returns_non_empty_list(self) -> None:
-        """Test that get_feature_group_docs returns a non-empty list (feature groups exist in codebase)."""
-        result = get_feature_group_docs()
-        assert len(result) > 0, "Expected at least one feature group to be discovered"
+    label: str
+    get_docs: Callable[..., list[Any]]
+    info_class: type[Any]
 
-    def test_get_feature_group_docs_returns_feature_group_info_objects(self) -> None:
-        """Test that all items in the returned list are FeatureGroupInfo instances."""
-        result = get_feature_group_docs()
+
+DOC_KINDS: list[DocKind] = [
+    DocKind("feature group", get_feature_group_docs, FeatureGroupInfo),
+    DocKind("compute framework", get_compute_framework_docs, ComputeFrameworkInfo),
+    DocKind("extender", get_extender_docs, ExtenderInfo),
+]
+
+
+@pytest.mark.parametrize("kind", DOC_KINDS, ids=[kind.label.replace(" ", "_") for kind in DOC_KINDS])
+class TestDocsGetterSharedBehaviour:
+    """Enumeration and the name=/search= filters behave the same for every doc kind."""
+
+    def test_returns_list(self, kind: DocKind) -> None:
+        assert isinstance(kind.get_docs(), list)
+
+    def test_returns_non_empty_list(self, kind: DocKind) -> None:
+        assert len(kind.get_docs()) > 0, f"Expected at least one {kind.label} to be discovered"
+
+    def test_returns_info_objects(self, kind: DocKind) -> None:
+        result = kind.get_docs()
         assert len(result) > 0, "Need at least one result to validate type"
         for item in result:
-            assert isinstance(item, FeatureGroupInfo)
+            assert isinstance(item, kind.info_class)
 
+    def test_name_filter_exact(self, kind: DocKind) -> None:
+        all_results = kind.get_docs()
+        assert len(all_results) > 0, f"Need at least one {kind.label} for filtering"
+
+        target_name = all_results[0].name
+        filtered = kind.get_docs(name=target_name)
+
+        assert len(filtered) >= 1
+        assert all(target_name.lower() in entry.name.lower() for entry in filtered)
+
+    def test_name_filter_partial(self, kind: DocKind) -> None:
+        all_results = kind.get_docs()
+        assert len(all_results) > 0, f"Need at least one {kind.label} for filtering"
+
+        target_name = all_results[0].name
+        assert len(target_name) > 3, f"Need a {kind.label} name long enough to slice a substring from"
+
+        partial = target_name[:3]
+        filtered = kind.get_docs(name=partial)
+
+        assert len(filtered) >= 1
+        assert all(partial.lower() in entry.name.lower() for entry in filtered)
+
+    def test_name_filter_case_insensitive(self, kind: DocKind) -> None:
+        all_results = kind.get_docs()
+        assert len(all_results) > 0, f"Need at least one {kind.label} for filtering"
+
+        target_name = all_results[0].name
+        filtered_lower = kind.get_docs(name=target_name.lower())
+        filtered_upper = kind.get_docs(name=target_name.upper())
+
+        assert len(filtered_lower) == len(filtered_upper)
+        assert len(filtered_lower) >= 1
+
+    def test_search_filter(self, kind: DocKind) -> None:
+        all_results = kind.get_docs()
+        assert len(all_results) > 0, f"Need at least one {kind.label} for filtering"
+
+        description_words = all_results[0].description.split()
+        assert len(description_words) > 0, f"Need a {kind.label} description to take a search term from"
+
+        search_term = description_words[0]
+        filtered = kind.get_docs(search=search_term)
+
+        assert len(filtered) >= 1
+        assert all(search_term.lower() in entry.description.lower() for entry in filtered)
+
+    def test_search_filter_case_insensitive(self, kind: DocKind) -> None:
+        all_results = kind.get_docs()
+        assert len(all_results) > 0, f"Need at least one {kind.label} for filtering"
+
+        description_words = all_results[0].description.split()
+        assert len(description_words) > 0, f"Need a {kind.label} description to take a search term from"
+
+        search_term = description_words[0]
+        filtered_lower = kind.get_docs(search=search_term.lower())
+        filtered_upper = kind.get_docs(search=search_term.upper())
+
+        assert len(filtered_lower) == len(filtered_upper)
+        assert len(filtered_lower) >= 1
+
+
+class TestGetFeatureGroupDocs:
     def test_get_feature_group_docs_has_required_fields(self) -> None:
         """Test that each FeatureGroupInfo has all required fields populated."""
         result = get_feature_group_docs()
@@ -132,87 +210,6 @@ class TestGetFeatureGroupDocs:
             assert isinstance(fg_info.compute_frameworks, list)
             assert isinstance(fg_info.supported_feature_names, set)
             assert isinstance(fg_info.prefix, str) and len(fg_info.prefix) > 0
-
-    def test_get_feature_group_docs_name_filter_exact(self) -> None:
-        """Test that name filter works with exact match."""
-        # First get all to find a name to filter on
-        all_results = get_feature_group_docs()
-        assert len(all_results) > 0, "Need at least one feature group for filtering"
-
-        # Pick the first one and filter by exact name
-        target_name = all_results[0].name
-        filtered = get_feature_group_docs(name=target_name)
-
-        assert len(filtered) >= 1
-        assert all(target_name.lower() in fg.name.lower() for fg in filtered)
-
-    def test_get_feature_group_docs_name_filter_partial(self) -> None:
-        """Test that name filter works with partial match."""
-        # First get all to find a name to filter on
-        all_results = get_feature_group_docs()
-        assert len(all_results) > 0, "Need at least one feature group for filtering"
-
-        # Pick the first one and use a substring of its name
-        target_name = all_results[0].name
-        if len(target_name) > 3:
-            partial = target_name[:3]
-            filtered = get_feature_group_docs(name=partial)
-
-            assert len(filtered) >= 1
-            assert all(partial.lower() in fg.name.lower() for fg in filtered)
-
-    def test_get_feature_group_docs_name_filter_case_insensitive(self) -> None:
-        """Test that name filter is case-insensitive."""
-        all_results = get_feature_group_docs()
-        assert len(all_results) > 0, "Need at least one feature group for filtering"
-
-        target_name = all_results[0].name
-
-        # Filter with lowercase
-        filtered_lower = get_feature_group_docs(name=target_name.lower())
-        # Filter with uppercase
-        filtered_upper = get_feature_group_docs(name=target_name.upper())
-
-        # Both should return the same results
-        assert len(filtered_lower) == len(filtered_upper)
-        assert len(filtered_lower) >= 1
-
-    def test_get_feature_group_docs_search_filter(self) -> None:
-        """Test that search filter works on description."""
-        all_results = get_feature_group_docs()
-        assert len(all_results) > 0, "Need at least one feature group for filtering"
-
-        # Find a feature group with a description we can search for
-        target = all_results[0]
-        # Pick a word from the description (if multi-word)
-        description_words = target.description.split()
-        if len(description_words) > 0:
-            search_term = description_words[0]
-            filtered = get_feature_group_docs(search=search_term)
-
-            # Should find at least the target
-            assert len(filtered) >= 1
-            # All results should have the search term in their description
-            assert all(search_term.lower() in fg.description.lower() for fg in filtered)
-
-    def test_get_feature_group_docs_search_filter_case_insensitive(self) -> None:
-        """Test that search filter is case-insensitive."""
-        all_results = get_feature_group_docs()
-        assert len(all_results) > 0, "Need at least one feature group for filtering"
-
-        target = all_results[0]
-        description_words = target.description.split()
-        if len(description_words) > 0:
-            search_term = description_words[0]
-
-            # Filter with lowercase
-            filtered_lower = get_feature_group_docs(search=search_term.lower())
-            # Filter with uppercase
-            filtered_upper = get_feature_group_docs(search=search_term.upper())
-
-            # Both should return the same results
-            assert len(filtered_lower) == len(filtered_upper)
-            assert len(filtered_lower) >= 1
 
     def test_get_feature_group_docs_compute_framework_filter_case_insensitive(self) -> None:
         """Test that the compute_framework filter matches the framework name case-insensitively.
@@ -697,23 +694,6 @@ class TestDegradedReadLogging:
 
 
 class TestGetComputeFrameworkDocs:
-    def test_get_compute_framework_docs_returns_list(self) -> None:
-        """Test that get_compute_framework_docs returns a list."""
-        result = get_compute_framework_docs()
-        assert isinstance(result, list)
-
-    def test_get_compute_framework_docs_returns_non_empty_list(self) -> None:
-        """Test that get_compute_framework_docs returns a non-empty list (compute frameworks exist in codebase)."""
-        result = get_compute_framework_docs()
-        assert len(result) > 0, "Expected at least one compute framework to be discovered"
-
-    def test_get_compute_framework_docs_returns_compute_framework_info_objects(self) -> None:
-        """Test that all items in the returned list are ComputeFrameworkInfo instances."""
-        result = get_compute_framework_docs()
-        assert len(result) > 0, "Need at least one result to validate type"
-        for item in result:
-            assert isinstance(item, ComputeFrameworkInfo)
-
     def test_get_compute_framework_docs_has_required_fields(self) -> None:
         """Test that each ComputeFrameworkInfo has all required fields populated."""
         result = get_compute_framework_docs()
@@ -728,87 +708,6 @@ class TestGetComputeFrameworkDocs:
             assert isinstance(cfw_info.expected_data_framework, str)
             assert isinstance(cfw_info.has_merge_engine, bool)
             assert isinstance(cfw_info.has_filter_engine, bool)
-
-    def test_get_compute_framework_docs_name_filter_exact(self) -> None:
-        """Test that name filter works with exact match."""
-        # First get all to find a name to filter on
-        all_results = get_compute_framework_docs()
-        assert len(all_results) > 0, "Need at least one compute framework for filtering"
-
-        # Pick the first one and filter by exact name
-        target_name = all_results[0].name
-        filtered = get_compute_framework_docs(name=target_name)
-
-        assert len(filtered) >= 1
-        assert all(target_name.lower() in cfw.name.lower() for cfw in filtered)
-
-    def test_get_compute_framework_docs_name_filter_partial(self) -> None:
-        """Test that name filter works with partial match."""
-        # First get all to find a name to filter on
-        all_results = get_compute_framework_docs()
-        assert len(all_results) > 0, "Need at least one compute framework for filtering"
-
-        # Pick the first one and use a substring of its name
-        target_name = all_results[0].name
-        if len(target_name) > 3:
-            partial = target_name[:3]
-            filtered = get_compute_framework_docs(name=partial)
-
-            assert len(filtered) >= 1
-            assert all(partial.lower() in cfw.name.lower() for cfw in filtered)
-
-    def test_get_compute_framework_docs_name_filter_case_insensitive(self) -> None:
-        """Test that name filter is case-insensitive."""
-        all_results = get_compute_framework_docs()
-        assert len(all_results) > 0, "Need at least one compute framework for filtering"
-
-        target_name = all_results[0].name
-
-        # Filter with lowercase
-        filtered_lower = get_compute_framework_docs(name=target_name.lower())
-        # Filter with uppercase
-        filtered_upper = get_compute_framework_docs(name=target_name.upper())
-
-        # Both should return the same results
-        assert len(filtered_lower) == len(filtered_upper)
-        assert len(filtered_lower) >= 1
-
-    def test_get_compute_framework_docs_search_filter(self) -> None:
-        """Test that search filter works on description."""
-        all_results = get_compute_framework_docs()
-        assert len(all_results) > 0, "Need at least one compute framework for filtering"
-
-        # Find a compute framework with a description we can search for
-        target = all_results[0]
-        # Pick a word from the description (if multi-word)
-        description_words = target.description.split()
-        if len(description_words) > 0:
-            search_term = description_words[0]
-            filtered = get_compute_framework_docs(search=search_term)
-
-            # Should find at least the target
-            assert len(filtered) >= 1
-            # All results should have the search term in their description
-            assert all(search_term.lower() in cfw.description.lower() for cfw in filtered)
-
-    def test_get_compute_framework_docs_search_filter_case_insensitive(self) -> None:
-        """Test that search filter is case-insensitive."""
-        all_results = get_compute_framework_docs()
-        assert len(all_results) > 0, "Need at least one compute framework for filtering"
-
-        target = all_results[0]
-        description_words = target.description.split()
-        if len(description_words) > 0:
-            search_term = description_words[0]
-
-            # Filter with lowercase
-            filtered_lower = get_compute_framework_docs(search=search_term.lower())
-            # Filter with uppercase
-            filtered_upper = get_compute_framework_docs(search=search_term.upper())
-
-            # Both should return the same results
-            assert len(filtered_lower) == len(filtered_upper)
-            assert len(filtered_lower) >= 1
 
     def test_get_compute_framework_docs_available_only_true_filters_correctly(self) -> None:
         """Test that available_only=True filters to only available frameworks."""
@@ -929,23 +828,6 @@ class TestSafeVersionGuard:
 
 
 class TestGetExtenderDocs:
-    def test_get_extender_docs_returns_list(self) -> None:
-        """Test that get_extender_docs returns a list."""
-        result = get_extender_docs()
-        assert isinstance(result, list)
-
-    def test_get_extender_docs_returns_non_empty_list(self) -> None:
-        """Test that get_extender_docs returns a non-empty list (extenders exist in codebase)."""
-        result = get_extender_docs()
-        assert len(result) > 0, "Expected at least one extender to be discovered"
-
-    def test_get_extender_docs_returns_extender_info_objects(self) -> None:
-        """Test that all items in the returned list are ExtenderInfo instances."""
-        result = get_extender_docs()
-        assert len(result) > 0, "Need at least one result to validate type"
-        for item in result:
-            assert isinstance(item, ExtenderInfo)
-
     def test_get_extender_docs_has_required_fields(self) -> None:
         """Test that each ExtenderInfo has all required fields populated."""
         result = get_extender_docs()
@@ -957,87 +839,6 @@ class TestGetExtenderDocs:
             assert isinstance(ext_info.description, str) and len(ext_info.description) > 0
             assert isinstance(ext_info.module, str) and len(ext_info.module) > 0
             assert isinstance(ext_info.wraps, list)
-
-    def test_get_extender_docs_name_filter_exact(self) -> None:
-        """Test that name filter works with exact match."""
-        # First get all to find a name to filter on
-        all_results = get_extender_docs()
-        assert len(all_results) > 0, "Need at least one extender for filtering"
-
-        # Pick the first one and filter by exact name
-        target_name = all_results[0].name
-        filtered = get_extender_docs(name=target_name)
-
-        assert len(filtered) >= 1
-        assert all(target_name.lower() in ext.name.lower() for ext in filtered)
-
-    def test_get_extender_docs_name_filter_partial(self) -> None:
-        """Test that name filter works with partial match."""
-        # First get all to find a name to filter on
-        all_results = get_extender_docs()
-        assert len(all_results) > 0, "Need at least one extender for filtering"
-
-        # Pick the first one and use a substring of its name
-        target_name = all_results[0].name
-        if len(target_name) > 3:
-            partial = target_name[:3]
-            filtered = get_extender_docs(name=partial)
-
-            assert len(filtered) >= 1
-            assert all(partial.lower() in ext.name.lower() for ext in filtered)
-
-    def test_get_extender_docs_name_filter_case_insensitive(self) -> None:
-        """Test that name filter is case-insensitive."""
-        all_results = get_extender_docs()
-        assert len(all_results) > 0, "Need at least one extender for filtering"
-
-        target_name = all_results[0].name
-
-        # Filter with lowercase
-        filtered_lower = get_extender_docs(name=target_name.lower())
-        # Filter with uppercase
-        filtered_upper = get_extender_docs(name=target_name.upper())
-
-        # Both should return the same results
-        assert len(filtered_lower) == len(filtered_upper)
-        assert len(filtered_lower) >= 1
-
-    def test_get_extender_docs_search_filter(self) -> None:
-        """Test that search filter works on description."""
-        all_results = get_extender_docs()
-        assert len(all_results) > 0, "Need at least one extender for filtering"
-
-        # Find an extender with a description we can search for
-        target = all_results[0]
-        # Pick a word from the description (if multi-word)
-        description_words = target.description.split()
-        if len(description_words) > 0:
-            search_term = description_words[0]
-            filtered = get_extender_docs(search=search_term)
-
-            # Should find at least the target
-            assert len(filtered) >= 1
-            # All results should have the search term in their description
-            assert all(search_term.lower() in ext.description.lower() for ext in filtered)
-
-    def test_get_extender_docs_search_filter_case_insensitive(self) -> None:
-        """Test that search filter is case-insensitive."""
-        all_results = get_extender_docs()
-        assert len(all_results) > 0, "Need at least one extender for filtering"
-
-        target = all_results[0]
-        description_words = target.description.split()
-        if len(description_words) > 0:
-            search_term = description_words[0]
-
-            # Filter with lowercase
-            filtered_lower = get_extender_docs(search=search_term.lower())
-            # Filter with uppercase
-            filtered_upper = get_extender_docs(search=search_term.upper())
-
-            # Both should return the same results
-            assert len(filtered_lower) == len(filtered_upper)
-            assert len(filtered_lower) >= 1
 
     def test_get_extender_docs_wraps_filter(self) -> None:
         """Test that wraps filter works when filtering by wrapped function type."""

--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -8,15 +8,16 @@ independent concerns.
 The matrix of (FG final_filters, Engine final_filters, uses mask_engine) combinations:
 
   FG=False, Engine=True,  mask=yes -- test_inline_filter_without_custom_compute_framework
-  FG=None,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows[regular_default_fg]
+  FG=None,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows, case regular_default_fg
   FG=False, Engine=False, mask=yes -- test_fg_skip_with_inline_engine
-  FG=True,  Engine=False, mask=no  -- test_final_filtering_eliminates_rows[fg_overrides_inline_engine]
-  FG=True,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows[fg_and_engine_agree]
+  FG=True,  Engine=False, mask=no  -- test_final_filtering_eliminates_rows, case fg_overrides_inline_engine
+  FG=True,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows, case fg_and_engine_agree
+  FG=True,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows, case compatible_dtype
   FG=True,  Engine=True,  mask=yes -- test_inline_mask_with_final_elimination
 
 Validation (filter column must be present when row elimination applies):
-  FG=True,  drops filter column       -- test_filter_column_validation_raises[fg_force_final_drops_column]
-  FG=None,  drops filter column       -- test_filter_column_validation_raises[default_fg_drops_column]
+  FG=True,  drops filter column       -- test_filter_column_validation_raises, case fg_force_final_drops_column
+  FG=None,  drops filter column       -- test_filter_column_validation_raises, case default_fg_drops_column
 """
 
 from dataclasses import dataclass

--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -431,8 +431,6 @@ class CompatibleDtypeFeatureGroup(FeatureGroup):
 
 @dataclass(frozen=True)
 class FinalEliminationCase:
-    """One feature group whose run must end in row elimination, plus the framework it runs on."""
-
     case_id: str
     feature_group: type[FeatureGroup]
     compute_framework: type[ComputeFramework]
@@ -451,8 +449,6 @@ STRING_FILTER_ON_NON_STRING = "expects string comparison but column has type"
 
 @dataclass(frozen=True)
 class FilterColumnValidationCase:
-    """One feature group that breaks the filter-column contract, plus the error its run must raise."""
-
     case_id: str
     feature_group: type[FeatureGroup]
     match: str
@@ -510,13 +506,7 @@ class TestFeatureGroupFinalFilters:
     def test_final_filtering_eliminates_rows(
         self, case: FinalEliminationCase, modes: set[ParallelizationMode], flight_server: Any
     ) -> None:
-        """Every route into row elimination drops the "inactive" rows, leaving [10, 30].
-
-        The rows differ in how elimination is reached: no final_filters() override
-        (engine decides), an override that beats an inline engine, an override that
-        agrees with the engine, and an override whose filter column keeps a
-        filter-compatible dtype. Each case is documented on its FeatureGroup class.
-        """
+        """Every route into row elimination drops the inactive rows; each case is documented on its FeatureGroup."""
         feature_name = case.feature_group.get_class_name()
 
         features = Features([Feature(name=feature_name, initial_requested_data=True)])
@@ -657,11 +647,7 @@ class TestFeatureGroupFinalFilters:
     def test_filter_column_validation_raises(
         self, case: FilterColumnValidationCase, modes: set[ParallelizationMode], flight_server: Any
     ) -> None:
-        """A dropped or retyped filter column is rejected, on the FG=True path and the engine fallback path alike.
-
-        ValueError from _validate_filter_columns is wrapped in a generic Exception
-        by the threading/worker layer (see thread_worker.py).
-        """
+        """FG-override and engine-fallback paths both reject; the worker wraps the ValueError generically."""
         feature_name = case.feature_group.get_class_name()
 
         features = Features([Feature(name=feature_name, initial_requested_data=True)])

--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -8,17 +8,18 @@ independent concerns.
 The matrix of (FG final_filters, Engine final_filters, uses mask_engine) combinations:
 
   FG=False, Engine=True,  mask=yes -- test_inline_filter_without_custom_compute_framework
-  FG=None,  Engine=True,  mask=no  -- test_regular_feature_group_still_uses_final_filters
+  FG=None,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows[regular_default_fg]
   FG=False, Engine=False, mask=yes -- test_fg_skip_with_inline_engine
-  FG=True,  Engine=False, mask=no  -- test_fg_force_final_overrides_inline_engine
-  FG=True,  Engine=True,  mask=no  -- test_fg_force_final_with_final_engine
+  FG=True,  Engine=False, mask=no  -- test_final_filtering_eliminates_rows[fg_overrides_inline_engine]
+  FG=True,  Engine=True,  mask=no  -- test_final_filtering_eliminates_rows[fg_and_engine_agree]
   FG=True,  Engine=True,  mask=yes -- test_inline_mask_with_final_elimination
 
 Validation (filter column must be present when row elimination applies):
-  FG=True,  drops filter column       -- test_dropped_filter_column_raises_error
-  FG=None,  drops filter column       -- test_default_fg_drops_filter_column_raises_error
+  FG=True,  drops filter column       -- test_filter_column_validation_raises[fg_force_final_drops_column]
+  FG=None,  drops filter column       -- test_filter_column_validation_raises[default_fg_drops_column]
 """
 
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import pytest
@@ -428,6 +429,45 @@ class CompatibleDtypeFeatureGroup(FeatureGroup):
         )
 
 
+@dataclass(frozen=True)
+class FinalEliminationCase:
+    """One feature group whose run must end in row elimination, plus the framework it runs on."""
+
+    case_id: str
+    feature_group: type[FeatureGroup]
+    compute_framework: type[ComputeFramework]
+
+
+FINAL_ELIMINATION_CASES: list[FinalEliminationCase] = [
+    FinalEliminationCase("regular_default_fg", RegularFeatureGroupForFilterTest, PyArrowTable),
+    FinalEliminationCase("fg_overrides_inline_engine", ForceFinalOnInlineEngine, PyArrowTableInlineEngine),
+    FinalEliminationCase("fg_and_engine_agree", ForceFinalOnFinalEngine, PyArrowTable),
+    FinalEliminationCase("compatible_dtype", CompatibleDtypeFeatureGroup, PyArrowTable),
+]
+
+MISSING_FILTER_COLUMN = "missing filter column.*status.*bug in the FeatureGroup"
+STRING_FILTER_ON_NON_STRING = "expects string comparison but column has type"
+
+
+@dataclass(frozen=True)
+class FilterColumnValidationCase:
+    """One feature group that breaks the filter-column contract, plus the error its run must raise."""
+
+    case_id: str
+    feature_group: type[FeatureGroup]
+    match: str
+
+
+FILTER_COLUMN_VALIDATION_CASES: list[FilterColumnValidationCase] = [
+    FilterColumnValidationCase("fg_force_final_drops_column", DropsFilterColumnFeatureGroup, MISSING_FILTER_COLUMN),
+    FilterColumnValidationCase("default_fg_drops_column", DefaultFGDropsFilterColumn, MISSING_FILTER_COLUMN),
+    FilterColumnValidationCase("fg_force_final_dtype_mismatch", MutatesFilterColumnToInt, STRING_FILTER_ON_NON_STRING),
+    FilterColumnValidationCase(
+        "default_fg_dtype_mismatch", DefaultFGMutatesFilterColumnToInt, STRING_FILTER_ON_NON_STRING
+    ),
+]
+
+
 @PARALLELIZATION_MODES_SYNC_THREADING
 class TestFeatureGroupFinalFilters:
     """Tests that FeatureGroup.final_filters() controls inline vs. final filter application."""
@@ -466,18 +506,18 @@ class TestFeatureGroupFinalFilters:
             data = res.to_pydict()
             assert data[feature_name] == [10, 10, 30, 30]
 
-    def test_regular_feature_group_still_uses_final_filters(
-        self, modes: set[ParallelizationMode], flight_server: Any
+    @pytest.mark.parametrize("case", FINAL_ELIMINATION_CASES, ids=[case.case_id for case in FINAL_ELIMINATION_CASES])
+    def test_final_filtering_eliminates_rows(
+        self, case: FinalEliminationCase, modes: set[ParallelizationMode], flight_server: Any
     ) -> None:
-        """A FeatureGroup without final_filters() override should still have rows eliminated.
+        """Every route into row elimination drops the "inactive" rows, leaving [10, 30].
 
-        RegularFeatureGroupForFilterTest does NOT override final_filters(), so the
-        framework's default behavior applies: the PyArrowFilterEngine (which returns
-        final_filters() -> True) filters rows after calculate_feature().
-
-        With filter status=="active", only the two "active" rows should remain.
+        The rows differ in how elimination is reached: no final_filters() override
+        (engine decides), an override that beats an inline engine, an override that
+        agrees with the engine, and an override whose filter column keeps a
+        filter-compatible dtype. Each case is documented on its FeatureGroup class.
         """
-        feature_name = "RegularFeatureGroupForFilterTest"
+        feature_name = case.feature_group.get_class_name()
 
         features = Features([Feature(name=feature_name, initial_requested_data=True)])
 
@@ -486,7 +526,7 @@ class TestFeatureGroupFinalFilters:
 
         result = MlodaTestRunner.run_api(
             features,
-            compute_frameworks={PyArrowTable},
+            compute_frameworks={case.compute_framework},
             parallelization_modes=modes,
             flight_server=flight_server,
             global_filter=global_filter,
@@ -494,7 +534,6 @@ class TestFeatureGroupFinalFilters:
 
         for res in result.results:
             data = res.to_pydict()
-            # Final filtering should have eliminated the "inactive" rows
             assert data[feature_name] == [10, 30]
 
     def test_mixed_final_and_inline_filters_in_same_run(
@@ -577,62 +616,6 @@ class TestFeatureGroupFinalFilters:
             # Both FG and engine say skip: inline masking preserves all 4 rows
             assert data[feature_name] == [10, 10, 30, 30]
 
-    def test_fg_force_final_overrides_inline_engine(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
-        """FG=True, Engine=False. FG overrides engine. Rows eliminated.
-
-        ForceFinalOnInlineEngine explicitly returns final_filters()=True, while
-        PyArrowTableInlineEngine's filter engine returns False. The FeatureGroup's
-        decision should override the engine: final filtering is applied and
-        non-matching rows are eliminated, leaving only [10, 30].
-        """
-        feature_name = "ForceFinalOnInlineEngine"
-
-        features = Features([Feature(name=feature_name, initial_requested_data=True)])
-
-        global_filter = GlobalFilter()
-        global_filter.add_filter("status", "equal", {"value": "active"})
-
-        result = MlodaTestRunner.run_api(
-            features,
-            compute_frameworks={PyArrowTableInlineEngine},
-            parallelization_modes=modes,
-            flight_server=flight_server,
-            global_filter=global_filter,
-        )
-
-        for res in result.results:
-            data = res.to_pydict()
-            # FG overrides engine: rows eliminated despite engine saying skip
-            assert data[feature_name] == [10, 30]
-
-    def test_fg_force_final_with_final_engine(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
-        """FG=True, Engine=True. Both agree to apply final filtering. Rows eliminated.
-
-        ForceFinalOnFinalEngine explicitly returns final_filters()=True and runs on
-        standard PyArrowTable (whose PyArrowFilterEngine also returns True). Since
-        both agree, final filtering is applied and non-matching rows are eliminated,
-        leaving only [10, 30].
-        """
-        feature_name = "ForceFinalOnFinalEngine"
-
-        features = Features([Feature(name=feature_name, initial_requested_data=True)])
-
-        global_filter = GlobalFilter()
-        global_filter.add_filter("status", "equal", {"value": "active"})
-
-        result = MlodaTestRunner.run_api(
-            features,
-            compute_frameworks={PyArrowTable},
-            parallelization_modes=modes,
-            flight_server=flight_server,
-            global_filter=global_filter,
-        )
-
-        for res in result.results:
-            data = res.to_pydict()
-            # Both FG and engine agree: rows eliminated
-            assert data[feature_name] == [10, 30]
-
     def test_inline_mask_with_final_elimination(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
         """FG=True, Engine=True, uses mask engine. Masking AND elimination are independent.
 
@@ -668,75 +651,25 @@ class TestFeatureGroupFinalFilters:
             # Inline masking changed values (15 not 10/5), elimination removed inactive row
             assert data[feature_name] == [15, 15, 30]
 
-    def test_dropped_filter_column_raises_error(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
-        """FG=True but filter column missing from output. Framework must raise ValueError.
-
-        DropsFilterColumnFeatureGroup returns final_filters()=True but omits the
-        "status" column from its output table. The framework's validation should
-        catch this and raise a clear error instead of crashing in the filter engine.
-        """
-        feature_name = "DropsFilterColumnFeatureGroup"
-
-        features = Features([Feature(name=feature_name, initial_requested_data=True)])
-
-        global_filter = GlobalFilter()
-        global_filter.add_filter("status", "equal", {"value": "active"})
-
-        # ValueError from _validate_filter_columns is wrapped in a generic
-        # Exception by the threading/worker layer (see thread_worker.py).
-        with pytest.raises(Exception, match="missing filter column.*status.*bug in the FeatureGroup"):
-            MlodaTestRunner.run_api(
-                features,
-                compute_frameworks={PyArrowTable},
-                parallelization_modes=modes,
-                flight_server=flight_server,
-                global_filter=global_filter,
-            )
-
-    def test_default_fg_drops_filter_column_raises_error(
-        self, modes: set[ParallelizationMode], flight_server: Any
+    @pytest.mark.parametrize(
+        "case", FILTER_COLUMN_VALIDATION_CASES, ids=[case.case_id for case in FILTER_COLUMN_VALIDATION_CASES]
+    )
+    def test_filter_column_validation_raises(
+        self, case: FilterColumnValidationCase, modes: set[ParallelizationMode], flight_server: Any
     ) -> None:
-        """FG=None (default), Engine=True, filter column missing. Framework must raise ValueError.
+        """A dropped or retyped filter column is rejected, on the FG=True path and the engine fallback path alike.
 
-        DefaultFGDropsFilterColumn does not override final_filters(), so the
-        engine fallback path applies row elimination. The validation must catch
-        the missing column on this path too, not only when the FG returns True.
+        ValueError from _validate_filter_columns is wrapped in a generic Exception
+        by the threading/worker layer (see thread_worker.py).
         """
-        feature_name = "DefaultFGDropsFilterColumn"
+        feature_name = case.feature_group.get_class_name()
 
         features = Features([Feature(name=feature_name, initial_requested_data=True)])
 
         global_filter = GlobalFilter()
         global_filter.add_filter("status", "equal", {"value": "active"})
 
-        # ValueError from _validate_filter_columns is wrapped in a generic
-        # Exception by the threading/worker layer (see thread_worker.py).
-        with pytest.raises(Exception, match="missing filter column.*status.*bug in the FeatureGroup"):
-            MlodaTestRunner.run_api(
-                features,
-                compute_frameworks={PyArrowTable},
-                parallelization_modes=modes,
-                flight_server=flight_server,
-                global_filter=global_filter,
-            )
-
-    def test_string_filter_on_int_column_raises_error(
-        self, modes: set[ParallelizationMode], flight_server: Any
-    ) -> None:
-        """FG=True, string filter on int column. Framework must raise ValueError.
-
-        MutatesFilterColumnToInt returns final_filters()=True but maps the
-        "status" column from strings to integers. The filter expects
-        status=="active" (string), so the dtype mismatch should be detected.
-        """
-        feature_name = "MutatesFilterColumnToInt"
-
-        features = Features([Feature(name=feature_name, initial_requested_data=True)])
-
-        global_filter = GlobalFilter()
-        global_filter.add_filter("status", "equal", {"value": "active"})
-
-        with pytest.raises(Exception, match="expects string comparison but column has type"):
+        with pytest.raises(Exception, match=case.match):
             MlodaTestRunner.run_api(
                 features,
                 compute_frameworks={PyArrowTable},
@@ -769,52 +702,3 @@ class TestFeatureGroupFinalFilters:
                 flight_server=flight_server,
                 global_filter=global_filter,
             )
-
-    def test_default_fg_dtype_mismatch_raises_error(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
-        """FG=None (default), Engine=True, dtype mismatch. Framework must raise ValueError.
-
-        DefaultFGMutatesFilterColumnToInt does not override final_filters(),
-        so the engine fallback path applies. The dtype mismatch should be caught
-        on this path too, not only when the FG returns True.
-        """
-        feature_name = "DefaultFGMutatesFilterColumnToInt"
-
-        features = Features([Feature(name=feature_name, initial_requested_data=True)])
-
-        global_filter = GlobalFilter()
-        global_filter.add_filter("status", "equal", {"value": "active"})
-
-        with pytest.raises(Exception, match="expects string comparison but column has type"):
-            MlodaTestRunner.run_api(
-                features,
-                compute_frameworks={PyArrowTable},
-                parallelization_modes=modes,
-                flight_server=flight_server,
-                global_filter=global_filter,
-            )
-
-    def test_compatible_dtype_passes_validation(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
-        """FG=True with compatible dtypes. No error should be raised.
-
-        CompatibleDtypeFeatureGroup returns final_filters()=True and the
-        "status" column is string, matching the filter value type. Row
-        elimination should proceed normally.
-        """
-        feature_name = "CompatibleDtypeFeatureGroup"
-
-        features = Features([Feature(name=feature_name, initial_requested_data=True)])
-
-        global_filter = GlobalFilter()
-        global_filter.add_filter("status", "equal", {"value": "active"})
-
-        result = MlodaTestRunner.run_api(
-            features,
-            compute_frameworks={PyArrowTable},
-            parallelization_modes=modes,
-            flight_server=flight_server,
-            global_filter=global_filter,
-        )
-
-        for res in result.results:
-            data = res.to_pydict()
-            assert data[feature_name] == [10, 30]

--- a/tests/test_core/test_prepare/test_execution_plan_invariant_error_messages.py
+++ b/tests/test_core/test_prepare/test_execution_plan_invariant_error_messages.py
@@ -40,7 +40,9 @@ class TestCheckPointerDiscriminatorErrors:
         return ExecutionPlan()
 
     @pytest.mark.parametrize(("discriminator", "none_side", "expected_match"), _DISCRIMINATOR_CASES)
-    def test_discriminator_none_error(self, discriminator: dict[str, str], none_side: str, expected_match: str) -> None:
+    def test_discriminator_invariant_error_message(
+        self, discriminator: dict[str, str], none_side: str, expected_match: str
+    ) -> None:
         ep = self._make_execution_plan()
         graph = MagicMock(spec=Graph)
 

--- a/tests/test_core/test_prepare/test_execution_plan_invariant_error_messages.py
+++ b/tests/test_core/test_prepare/test_execution_plan_invariant_error_messages.py
@@ -20,73 +20,35 @@ class MockComputeFramework(ComputeFramework):
     pass
 
 
+_DISCRIMINATOR_CASES = [
+    pytest.param(
+        {"key": "value"}, "right", "Internal error.*right_discriminator is None", id="right_side_none_is_actionable"
+    ),
+    pytest.param(
+        {"key": "value"}, "left", "Internal error.*left_discriminator is None", id="left_side_none_is_actionable"
+    ),
+    pytest.param({"CsvReader": "file_a.csv"}, "right", "CsvReader.*file_a.csv", id="contains_actual_values"),
+    pytest.param({"key": "value"}, "right", "mloda-ai/mloda/issues", id="contains_report_url"),
+    pytest.param({"key": "value"}, "right", "both.*left_discriminator and right_discriminator", id="contains_guidance"),
+]
+
+
 class TestCheckPointerDiscriminatorErrors:
     """Tests for check_pointer discriminator invariant messages."""
 
     def _make_execution_plan(self) -> ExecutionPlan:
         return ExecutionPlan()
 
-    def test_right_discriminator_none_error_is_actionable(self) -> None:
+    @pytest.mark.parametrize(("discriminator", "none_side", "expected_match"), _DISCRIMINATOR_CASES)
+    def test_discriminator_none_error(self, discriminator: dict[str, str], none_side: str, expected_match: str) -> None:
         ep = self._make_execution_plan()
         graph = MagicMock(spec=Graph)
 
         link = MagicMock(spec=Link)
-        link.left_discriminator = {"key": "value"}
-        link.right_discriminator = None
+        link.left_discriminator = None if none_side == "left" else discriminator
+        link.right_discriminator = None if none_side == "right" else discriminator
 
         link_fw = (link, MockComputeFramework, MockComputeFramework)
 
-        with pytest.raises(ValueError, match="Internal error.*right_discriminator is None"):
-            ep.check_pointer({"key": "value"}, link_fw, graph, uuid4())
-
-    def test_left_discriminator_none_error_is_actionable(self) -> None:
-        ep = self._make_execution_plan()
-        graph = MagicMock(spec=Graph)
-
-        link = MagicMock(spec=Link)
-        link.left_discriminator = None
-        link.right_discriminator = {"key": "value"}
-
-        link_fw = (link, MockComputeFramework, MockComputeFramework)
-
-        with pytest.raises(ValueError, match="Internal error.*left_discriminator is None"):
-            ep.check_pointer({"key": "value"}, link_fw, graph, uuid4())
-
-    def test_discriminator_error_contains_actual_values(self) -> None:
-        ep = self._make_execution_plan()
-        graph = MagicMock(spec=Graph)
-
-        link = MagicMock(spec=Link)
-        link.left_discriminator = {"CsvReader": "file_a.csv"}
-        link.right_discriminator = None
-
-        link_fw = (link, MockComputeFramework, MockComputeFramework)
-
-        with pytest.raises(ValueError, match="CsvReader.*file_a.csv"):
-            ep.check_pointer({"CsvReader": "file_a.csv"}, link_fw, graph, uuid4())
-
-    def test_discriminator_error_contains_report_url(self) -> None:
-        ep = self._make_execution_plan()
-        graph = MagicMock(spec=Graph)
-
-        link = MagicMock(spec=Link)
-        link.left_discriminator = {"key": "value"}
-        link.right_discriminator = None
-
-        link_fw = (link, MockComputeFramework, MockComputeFramework)
-
-        with pytest.raises(ValueError, match="mloda-ai/mloda/issues"):
-            ep.check_pointer({"key": "value"}, link_fw, graph, uuid4())
-
-    def test_discriminator_error_contains_guidance(self) -> None:
-        ep = self._make_execution_plan()
-        graph = MagicMock(spec=Graph)
-
-        link = MagicMock(spec=Link)
-        link.left_discriminator = {"key": "value"}
-        link.right_discriminator = None
-
-        link_fw = (link, MockComputeFramework, MockComputeFramework)
-
-        with pytest.raises(ValueError, match="both.*left_discriminator and right_discriminator"):
-            ep.check_pointer({"key": "value"}, link_fw, graph, uuid4())
+        with pytest.raises(ValueError, match=expected_match):
+            ep.check_pointer(discriminator, link_fw, graph, uuid4())

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -46,14 +46,16 @@ class ConflictingFeatureGroupB(StubFeatureGroup):
 class TestIdentifyFeatureGroupErrorMessageFormat:
     """Tests for the error message format when multiple feature groups are found."""
 
-    def test_error_message_contains_formatted_class_names(self) -> None:
-        """Test that the ValueError message contains formatted class names.
-
-        When multiple feature groups match the same feature, the error message
-        should contain formatted class names like:
-          - ConflictingFeatureGroupA (module.path) [domain: domain_a]
-          - ConflictingFeatureGroupB (module.path) [domain: domain_b]
-        """
+    @pytest.mark.parametrize(
+        "expected_fragment",
+        [
+            pytest.param("  - ConflictingFeatureGroupA", id="formatted_class_name"),
+            pytest.param("(tests.test_core.test_prepare.test_identify_feature_group_error_message)", id="module_path"),
+            pytest.param("'conflicting_test_feature'", id="feature_name"),
+        ],
+    )
+    def test_error_message_contains(self, expected_fragment: str) -> None:
+        """Each candidate renders as 'ClassName (module.path)' and the message names the failing feature."""
         feature = Feature("conflicting_test_feature")
 
         accessible_plugins: FeatureGroupEnvironmentMapping = {
@@ -71,36 +73,8 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
 
         error_message = str(exc_info.value)
 
-        assert "  - ConflictingFeatureGroupA" in error_message, (
-            f"Error message should contain formatted class name '  - ConflictingFeatureGroupA', "
-            f"but got: {error_message}"
-        )
-
-    def test_error_message_contains_module_path_in_parentheses(self) -> None:
-        """Test that the error message contains module path in parentheses.
-
-        Expected format includes module path like:
-          - ClassName (tests.test_core.test_prepare.test_identify_feature_group_error_message)
-        """
-        feature = Feature("conflicting_test_feature")
-
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            ConflictingFeatureGroupA: {MockComputeFramework},
-            ConflictingFeatureGroupB: {MockComputeFramework},
-        }
-
-        with pytest.raises(ValueError) as exc_info:
-            evaluate_or_raise(
-                feature=feature,
-                accessible_plugins=accessible_plugins,
-                links=None,
-                data_access_collection=None,
-            )
-
-        error_message = str(exc_info.value)
-
-        assert "(tests.test_core.test_prepare.test_identify_feature_group_error_message)" in error_message, (
-            f"Error message should contain module path in parentheses, but got: {error_message}"
+        assert expected_fragment in error_message, (
+            f"Error message should contain '{expected_fragment}', but got: {error_message}"
         )
 
     def test_error_message_contains_domain_info(self) -> None:
@@ -160,29 +134,6 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
 
         assert "{<class" not in error_message, (
             f"Error message should NOT contain raw class representation '{{<class', but got: {error_message}"
-        )
-
-    def test_error_message_contains_feature_name(self) -> None:
-        """Test that the error message mentions the feature name."""
-        feature = Feature("conflicting_test_feature")
-
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            ConflictingFeatureGroupA: {MockComputeFramework},
-            ConflictingFeatureGroupB: {MockComputeFramework},
-        }
-
-        with pytest.raises(ValueError) as exc_info:
-            evaluate_or_raise(
-                feature=feature,
-                accessible_plugins=accessible_plugins,
-                links=None,
-                data_access_collection=None,
-            )
-
-        error_message = str(exc_info.value)
-
-        assert "'conflicting_test_feature'" in error_message, (
-            f"Error message should contain feature name in quotes, but got: {error_message}"
         )
 
 

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -55,7 +55,6 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         ],
     )
     def test_error_message_contains(self, expected_fragment: str) -> None:
-        """Each candidate renders as 'ClassName (module.path)' and the message names the failing feature."""
         feature = Feature("conflicting_test_feature")
 
         accessible_plugins: FeatureGroupEnvironmentMapping = {

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -171,20 +171,57 @@ def _identify(
     return identify_winner(feature, accessible_plugins)
 
 
+_ROUTING_CASES = [
+    pytest.param(
+        "value__median_subdeclmw",
+        SubDeclMatchWindowFG,
+        "'median' is unsupported on SubDeclMatchFwBeta and must be routed around",
+        id="keyed_literal_subtype",
+    ),
+    pytest.param(
+        "value__ntile_2_subdeclmw",
+        SubDeclMatchWindowFG,
+        "Family 'ntile' is unsupported on SubDeclMatchFwBeta, so 'ntile_2' must be routed around",
+        id="keyed_parametric_instance",
+    ),
+    pytest.param(
+        "value__ntile_2_subdeclmrank",
+        SubDeclMatchRankLikeFG,
+        "'ntile' is only supported on SubDeclMatchFwAlpha",
+        id="rank_like_parametric_instance",
+    ),
+    pytest.param(
+        "subdeclm_price__rows_7_frame",
+        SubDeclMatchFrameSpecFG,
+        "'rows_7' is unsupported on SubDeclMatchFwBeta",
+        id="frame_spec_resolved_literal",
+    ),
+    pytest.param(
+        "value__median_subdeclmcompiled",
+        SubDeclMatchCompiledWindowFG,
+        "'median' is unsupported on SubDeclMatchFwBeta and must be routed around even when PREFIX_PATTERN "
+        "is compiled; the dropped pattern fails open",
+        id="compiled_prefix_pattern",
+    ),
+]
+
+
+@pytest.mark.parametrize(("feature_name", "expected_feature_group", "reason"), _ROUTING_CASES)
+def test_unsupported_subtype_routes_around_incapable_framework(
+    feature_name: str, expected_feature_group: type[FeatureGroup], reason: str
+) -> None:
+    feature = Feature(feature_name)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        expected_feature_group: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+    }
+
+    feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
+    assert feature_group_class is expected_feature_group
+    assert compute_frameworks == {SubDeclMatchFwAlpha}, f"{reason}; got {compute_frameworks}"
+
+
 class TestMatchTimeIntegration:
     """The declaration is enforced through IdentifyFeatureGroupClass."""
-
-    def test_unsupported_subtype_is_routed_to_capable_framework(self) -> None:
-        feature = Feature("value__median_subdeclmw")
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
-        }
-
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
-        assert feature_group_class is SubDeclMatchWindowFG
-        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
-            f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around; got {compute_frameworks}"
-        )
 
     def test_pin_to_incapable_framework_raises_capability_error(self) -> None:
         feature = Feature("value__median_subdeclmw")
@@ -206,19 +243,6 @@ class TestMatchTimeIntegration:
         assert SubDeclMatchFwBeta.get_class_name() in message
         assert SubDeclMatchFwAlpha.get_class_name() in message
         assert "Did you mean" not in message
-
-    def test_parametric_instance_is_routed_around(self) -> None:
-        feature = Feature("value__ntile_2_subdeclmw")
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
-        }
-
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
-        assert feature_group_class is SubDeclMatchWindowFG
-        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
-            f"Family 'ntile' is unsupported on SubDeclMatchFwBeta, so 'ntile_2' must be routed around; "
-            f"got {compute_frameworks}"
-        )
 
     def test_unknown_subtype_keeps_every_framework(self) -> None:
         assert SubDeclMatchWindowFG.canonical_subtype("zzz") == "zzz"
@@ -260,18 +284,6 @@ class TestRankLikeFamily:
     def test_parametric_instance_canonicalizes_to_family(self) -> None:
         assert SubDeclMatchRankLikeFG.canonical_subtype("ntile_2") == "ntile"
 
-    def test_parametric_instance_routes_only_to_capable_framework(self) -> None:
-        feature = Feature("value__ntile_2_subdeclmrank")
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            SubDeclMatchRankLikeFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
-        }
-
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
-        assert feature_group_class is SubDeclMatchRankLikeFG
-        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
-            f"'ntile' is only supported on SubDeclMatchFwAlpha; got {compute_frameworks}"
-        )
-
     def test_supported_subtype_runs_on_both_frameworks(self) -> None:
         feature = Feature("value__dense_subdeclmrank")
         accessible_plugins: FeatureGroupEnvironmentMapping = {
@@ -295,18 +307,6 @@ class TestFrameSpecLikeFamily:
         # 'rows_7' is a declared literal; 'rows' looking like a family stem must not swallow it.
         assert SubDeclMatchFrameSpecFG.canonical_subtype("rows_7") == "rows_7"
         assert SubDeclMatchFrameSpecFG.canonical_subtype("rows_9") == "rows"
-
-    def test_routing_honors_supported_narrowing(self) -> None:
-        feature = Feature("subdeclm_price__rows_7_frame")
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            SubDeclMatchFrameSpecFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
-        }
-
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
-        assert feature_group_class is SubDeclMatchFrameSpecFG
-        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
-            f"'rows_7' is unsupported on SubDeclMatchFwBeta; got {compute_frameworks}"
-        )
 
     def test_supported_literal_runs_on_both_frameworks(self) -> None:
         feature = Feature("subdeclm_price__rows_1_frame")
@@ -369,19 +369,6 @@ class TestCompiledPrefixPatternParity:
         assert compiled_subtype == string_subtype, (
             f"A compiled PREFIX_PATTERN must resolve the subtype like the string form '{string_subtype}'; "
             f"the guard drops the re.Pattern and returns {compiled_subtype}."
-        )
-
-    def test_unsupported_subtype_routes_around_incapable_framework(self) -> None:
-        feature = Feature("value__median_subdeclmcompiled")
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            SubDeclMatchCompiledWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
-        }
-
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
-        assert feature_group_class is SubDeclMatchCompiledWindowFG
-        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
-            f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around even when PREFIX_PATTERN "
-            f"is compiled; the dropped pattern fails open and keeps {compute_frameworks}"
         )
 
     def test_supported_subtype_runs_on_both_frameworks(self) -> None:

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -276,7 +276,7 @@ class TestMatchTimeIntegration:
 
 
 class TestRankLikeFamily:
-    """Definition of done: a keyed parametric registry-like family routes by declaration alone."""
+    """Universe, parametric canonicalization, and both-framework support for a keyed registry-like family."""
 
     def test_universe_enumerates_family_without_probing(self) -> None:
         assert SubDeclMatchRankLikeFG.subtype_universe() == RANK_UNIVERSE
@@ -295,7 +295,7 @@ class TestRankLikeFamily:
 
 
 class TestFrameSpecLikeFamily:
-    """Definition of done: a shape B registry-like family resolves from names and routes by narrowing."""
+    """Universe, name resolution, literal-vs-family canonicalization, and both-framework support for shape B."""
 
     def test_universe_unions_literals_and_family(self) -> None:
         assert SubDeclMatchFrameSpecFG.subtype_universe() == FRAME_UNIVERSE

--- a/tests/test_core/test_setup/test_join_spec.py
+++ b/tests/test_core/test_setup/test_join_spec.py
@@ -351,7 +351,6 @@ class TestLinkWithJoinSpec:
         left_spec = JoinSpec(feature_group=MockFeatureGroup, index=left_idx)
         right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
 
-        # Factory method should accept JoinSpec objects
         link = factory(
             left=left_spec,
             right=right_spec,

--- a/tests/test_core/test_setup/test_join_spec.py
+++ b/tests/test_core/test_setup/test_join_spec.py
@@ -8,6 +8,7 @@ These tests MUST fail initially because JoinSpec does not exist yet.
 They will pass once JoinSpec is implemented as a frozen dataclass.
 """
 
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 from typing import Any, Optional
 
@@ -17,6 +18,7 @@ from mloda.provider import FeatureGroup
 from mloda.user import FeatureName
 from mloda.user import Index
 from mloda.user import JoinSpec  # This import will fail
+from mloda.user import JoinType, Link
 from mloda.user import Options
 
 
@@ -329,10 +331,20 @@ class TestLinkWithJoinSpec:
         assert link.right_index is right_idx
         assert link.right_index == right_idx
 
-    def test_link_factory_method_inner_with_join_spec(self) -> None:
-        """Test Link.inner factory method works with JoinSpec objects."""
-        from mloda.user import Link, JoinType
-
+    @pytest.mark.parametrize(
+        ("factory", "expected_jointype"),
+        [
+            pytest.param(Link.inner, JoinType.INNER, id="inner"),
+            pytest.param(Link.left, JoinType.LEFT, id="left"),
+            pytest.param(Link.right, JoinType.RIGHT, id="right"),
+            pytest.param(Link.outer, JoinType.OUTER, id="outer"),
+            pytest.param(Link.append, JoinType.APPEND, id="append"),
+            pytest.param(Link.union, JoinType.UNION, id="union"),
+        ],
+    )
+    def test_link_factory_method_with_join_spec(
+        self, factory: Callable[..., Link], expected_jointype: JoinType
+    ) -> None:
         left_idx = Index(("id",))
         right_idx = Index(("id",))
 
@@ -340,112 +352,12 @@ class TestLinkWithJoinSpec:
         right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
 
         # Factory method should accept JoinSpec objects
-        link = Link.inner(
+        link = factory(
             left=left_spec,
             right=right_spec,
         )
 
-        assert link.jointype == JoinType.INNER
-        assert link.left_feature_group is MockFeatureGroup
-        assert link.right_feature_group is AnotherMockFeatureGroup
-
-    def test_link_factory_method_left_with_join_spec(self) -> None:
-        """Test Link.left factory method works with JoinSpec objects."""
-        from mloda.user import Link, JoinType
-
-        left_idx = Index(("id",))
-        right_idx = Index(("id",))
-
-        left_spec = JoinSpec(feature_group=MockFeatureGroup, index=left_idx)
-        right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
-
-        # Factory method should accept JoinSpec objects
-        link = Link.left(
-            left=left_spec,
-            right=right_spec,
-        )
-
-        assert link.jointype == JoinType.LEFT
-        assert link.left_feature_group is MockFeatureGroup
-        assert link.right_feature_group is AnotherMockFeatureGroup
-
-    def test_link_factory_method_right_with_join_spec(self) -> None:
-        """Test Link.right factory method works with JoinSpec objects."""
-        from mloda.user import Link, JoinType
-
-        left_idx = Index(("id",))
-        right_idx = Index(("id",))
-
-        left_spec = JoinSpec(feature_group=MockFeatureGroup, index=left_idx)
-        right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
-
-        # Factory method should accept JoinSpec objects
-        link = Link.right(
-            left=left_spec,
-            right=right_spec,
-        )
-
-        assert link.jointype == JoinType.RIGHT
-        assert link.left_feature_group is MockFeatureGroup
-        assert link.right_feature_group is AnotherMockFeatureGroup
-
-    def test_link_factory_method_outer_with_join_spec(self) -> None:
-        """Test Link.outer factory method works with JoinSpec objects."""
-        from mloda.user import Link, JoinType
-
-        left_idx = Index(("id",))
-        right_idx = Index(("id",))
-
-        left_spec = JoinSpec(feature_group=MockFeatureGroup, index=left_idx)
-        right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
-
-        # Factory method should accept JoinSpec objects
-        link = Link.outer(
-            left=left_spec,
-            right=right_spec,
-        )
-
-        assert link.jointype == JoinType.OUTER
-        assert link.left_feature_group is MockFeatureGroup
-        assert link.right_feature_group is AnotherMockFeatureGroup
-
-    def test_link_factory_method_append_with_join_spec(self) -> None:
-        """Test Link.append factory method works with JoinSpec objects."""
-        from mloda.user import Link, JoinType
-
-        left_idx = Index(("id",))
-        right_idx = Index(("id",))
-
-        left_spec = JoinSpec(feature_group=MockFeatureGroup, index=left_idx)
-        right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
-
-        # Factory method should accept JoinSpec objects
-        link = Link.append(
-            left=left_spec,
-            right=right_spec,
-        )
-
-        assert link.jointype == JoinType.APPEND
-        assert link.left_feature_group is MockFeatureGroup
-        assert link.right_feature_group is AnotherMockFeatureGroup
-
-    def test_link_factory_method_union_with_join_spec(self) -> None:
-        """Test Link.union factory method works with JoinSpec objects."""
-        from mloda.user import Link, JoinType
-
-        left_idx = Index(("id",))
-        right_idx = Index(("id",))
-
-        left_spec = JoinSpec(feature_group=MockFeatureGroup, index=left_idx)
-        right_spec = JoinSpec(feature_group=AnotherMockFeatureGroup, index=right_idx)
-
-        # Factory method should accept JoinSpec objects
-        link = Link.union(
-            left=left_spec,
-            right=right_spec,
-        )
-
-        assert link.jointype == JoinType.UNION
+        assert link.jointype == expected_jointype
         assert link.left_feature_group is MockFeatureGroup
         assert link.right_feature_group is AnotherMockFeatureGroup
 

--- a/tests/test_core/test_setup/test_join_spec.py
+++ b/tests/test_core/test_setup/test_join_spec.py
@@ -234,8 +234,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_instantiation_with_join_spec_objects(self) -> None:
         """Test Link can be instantiated with JoinSpec objects for left and right."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("user_id",))
         right_idx = Index(("user_id",))
 
@@ -255,8 +253,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_left_feature_group_from_join_spec(self) -> None:
         """Test Link.left_feature_group returns the feature_group from left JoinSpec."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("user_id",))
         right_idx = Index(("order_id",))
 
@@ -274,8 +270,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_right_feature_group_from_join_spec(self) -> None:
         """Test Link.right_feature_group returns the feature_group from right JoinSpec."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("user_id",))
         right_idx = Index(("order_id",))
 
@@ -293,8 +287,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_left_index_from_join_spec(self) -> None:
         """Test Link.left_index returns the index from left JoinSpec."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("user_id",))
         right_idx = Index(("order_id",))
 
@@ -313,8 +305,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_right_index_from_join_spec(self) -> None:
         """Test Link.right_index returns the index from right JoinSpec."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("user_id",))
         right_idx = Index(("order_id",))
 
@@ -362,8 +352,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_with_join_spec_and_pointers(self) -> None:
         """Test Link works with JoinSpec objects and pointer arguments."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("id",))
         right_idx = Index(("id",))
 
@@ -387,8 +375,6 @@ class TestLinkWithJoinSpec:
 
     def test_link_with_multi_index_join_spec(self) -> None:
         """Test Link works with JoinSpec objects containing multi-column indexes."""
-        from mloda.user import Link, JoinType
-
         left_idx = Index(("user_id", "timestamp"))
         right_idx = Index(("user_id", "timestamp"))
 

--- a/tests/test_core/test_setup/test_polymorphic_link.py
+++ b/tests/test_core/test_setup/test_polymorphic_link.py
@@ -14,6 +14,8 @@ Expected behavior after implementation:
 
 from typing import Any, Optional, cast
 
+import pytest
+
 from mloda.provider import FeatureGroup
 from mloda.core.prepare.graph.graph import Graph
 from mloda.user import FeatureName
@@ -99,39 +101,28 @@ class ChildGroupA(ParentGroupA):
 class TestLinkMatchesPolymorphic:
     """Unit tests for Link.matches() polymorphic behavior."""
 
-    def test_exact_match(self) -> None:
-        """Test that exact class match still works."""
-        # Link defined with ConcreteGroupA and ConcreteGroupB
+    @pytest.mark.parametrize(
+        ("link_left", "link_right", "queried_left", "queried_right"),
+        [
+            pytest.param(ConcreteGroupA, ConcreteGroupB, ConcreteGroupA, ConcreteGroupB, id="exact"),
+            pytest.param(BaseGroupA, BaseGroupB, ConcreteGroupA, ConcreteGroupB, id="subclass_both_sides"),
+            pytest.param(BaseGroupA, BaseGroupB, BaseGroupA, BaseGroupB, id="base_class_itself"),
+            pytest.param(BaseGroupA, ConcreteGroupB, ConcreteGroupA, ConcreteGroupB, id="one_base_one_exact"),
+        ],
+    )
+    def test_matches_declared_or_subclassed_groups(
+        self,
+        link_left: type[FeatureGroup],
+        link_right: type[FeatureGroup],
+        queried_left: type[FeatureGroup],
+        queried_right: type[FeatureGroup],
+    ) -> None:
         link = Link.inner(
-            JoinSpec(ConcreteGroupA, Index(("id",))),
-            JoinSpec(ConcreteGroupB, Index(("id",))),
+            JoinSpec(link_left, Index(("id",))),
+            JoinSpec(link_right, Index(("id",))),
         )
 
-        # Should match the exact same classes
-        assert link.matches(ConcreteGroupA, ConcreteGroupB) is True
-
-    def test_polymorphic_match_subclass(self) -> None:
-        """Test that link with base class matches concrete subclass."""
-        # Link defined with BASE classes
-        link = Link.inner(
-            JoinSpec(BaseGroupA, Index(("id",))),
-            JoinSpec(BaseGroupB, Index(("id",))),
-        )
-
-        # Should match when we provide CONCRETE subclasses
-        # This is the KEY polymorphic behavior: base type accepts subtype
-        assert link.matches(ConcreteGroupA, ConcreteGroupB) is True
-
-    def test_polymorphic_match_base_class_itself(self) -> None:
-        """Test that link with base class matches the base class itself."""
-        # Link defined with base classes
-        link = Link.inner(
-            JoinSpec(BaseGroupA, Index(("id",))),
-            JoinSpec(BaseGroupB, Index(("id",))),
-        )
-
-        # Should match the base classes themselves (exact match is also valid)
-        assert link.matches(BaseGroupA, BaseGroupB) is True
+        assert link.matches(queried_left, queried_right) is True
 
     def test_no_match_wrong_hierarchy(self) -> None:
         """Test that link does NOT match unrelated classes."""
@@ -181,18 +172,6 @@ class TestLinkMatchesPolymorphic:
         # Left side does NOT match (UnrelatedGroup is not subclass of BaseGroupA)
         # Right side matches (ConcreteGroupB is subclass of BaseGroupB)
         assert link.matches(UnrelatedGroup, ConcreteGroupB) is False
-
-    def test_polymorphic_match_mixed(self) -> None:
-        """Test polymorphic match with one exact match and one subclass match."""
-        # Link defined with one base and one concrete
-        link = Link.inner(
-            JoinSpec(BaseGroupA, Index(("id",))),
-            JoinSpec(ConcreteGroupB, Index(("id",))),
-        )
-
-        # Left: subclass of BaseGroupA (polymorphic match)
-        # Right: exact match with ConcreteGroupB
-        assert link.matches(ConcreteGroupA, ConcreteGroupB) is True
 
     def test_different_join_types_work_same(self) -> None:
         """Test that polymorphic matching works for all join types."""

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_base_encoding_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_base_encoding_feature_group.py
@@ -15,40 +15,16 @@ from mloda_plugins.feature_group.experimental.sklearn.encoding.pandas import Pan
 class TestEncodingFeatureGroup:
     """Test cases for the base EncodingFeatureGroup class."""
 
-    def test_match_feature_group_criteria_valid_onehot(self) -> None:
-        """Test that valid onehot encoding feature names match the criteria."""
-        valid_names = [
-            "category__onehot_encoded",
-            "status__onehot_encoded",
-            "product_type__onehot_encoded",
-        ]
-
-        for name in valid_names:
-            assert EncodingFeatureGroup.match_feature_group_criteria(FeatureName(name), Options({})), (
-                f"Feature name '{name}' should match criteria"
-            )
-
-    def test_match_feature_group_criteria_valid_label(self) -> None:
-        """Test that valid label encoding feature names match the criteria."""
-        valid_names = [
-            "category__label_encoded",
-            "status__label_encoded",
-            "priority__label_encoded",
-        ]
-
-        for name in valid_names:
-            assert EncodingFeatureGroup.match_feature_group_criteria(FeatureName(name), Options({})), (
-                f"Feature name '{name}' should match criteria"
-            )
-
-    def test_match_feature_group_criteria_valid_ordinal(self) -> None:
-        """Test that valid ordinal encoding feature names match the criteria."""
-        valid_names = [
-            "category__ordinal_encoded",
-            "grade__ordinal_encoded",
-            "size__ordinal_encoded",
-        ]
-
+    @pytest.mark.parametrize(
+        "valid_names",
+        [
+            ["category__onehot_encoded", "status__onehot_encoded", "product_type__onehot_encoded"],
+            ["category__label_encoded", "status__label_encoded", "priority__label_encoded"],
+            ["category__ordinal_encoded", "grade__ordinal_encoded", "size__ordinal_encoded"],
+        ],
+        ids=["onehot", "label", "ordinal"],
+    )
+    def test_match_feature_group_criteria_valid(self, valid_names: list[str]) -> None:
         for name in valid_names:
             assert EncodingFeatureGroup.match_feature_group_criteria(FeatureName(name), Options({})), (
                 f"Feature name '{name}' should match criteria"

--- a/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_pandas_clustering_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_pandas_clustering_feature_group.py
@@ -68,13 +68,14 @@ class TestPandasClusteringFeatureGroup:
         assert len(updated_data["cluster_result"]) == len(sample_data)
         assert (updated_data["cluster_result"].values == result).all()
 
-    def test_perform_kmeans_clustering(self, sample_data: pd.DataFrame) -> None:
-        """Test the _perform_kmeans_clustering method."""
+    @pytest.mark.parametrize("algorithm", ["kmeans", "hierarchical", "spectral"])
+    def test_perform_clustering_with_fixed_k(self, sample_data: pd.DataFrame, algorithm: str) -> None:
+        """These algorithms take an explicit k and return exactly that many clusters."""
         # Extract features
         X = sample_data[["feature1", "feature2"]].values
 
-        # Perform K-means clustering
-        result = PandasClusteringFeatureGroup._perform_kmeans_clustering(X, 2)
+        cluster = getattr(PandasClusteringFeatureGroup, f"_perform_{algorithm}_clustering")
+        result = cluster(X, 2)
 
         # Check that the result has the expected shape
         assert len(result) == len(sample_data)
@@ -97,34 +98,6 @@ class TestPandasClusteringFeatureGroup:
         # So we check that there are at least 2 unique clusters (excluding noise)
         unique_clusters = np.unique(result)
         assert len(unique_clusters[unique_clusters >= 0]) >= 1
-
-    def test_perform_hierarchical_clustering(self, sample_data: pd.DataFrame) -> None:
-        """Test the _perform_hierarchical_clustering method."""
-        # Extract features
-        X = sample_data[["feature1", "feature2"]].values
-
-        # Perform hierarchical clustering
-        result = PandasClusteringFeatureGroup._perform_hierarchical_clustering(X, 2)
-
-        # Check that the result has the expected shape
-        assert len(result) == len(sample_data)
-
-        # Check that there are exactly 2 unique clusters
-        assert len(np.unique(result)) == 2
-
-    def test_perform_spectral_clustering(self, sample_data: pd.DataFrame) -> None:
-        """Test the _perform_spectral_clustering method."""
-        # Extract features
-        X = sample_data[["feature1", "feature2"]].values
-
-        # Perform spectral clustering
-        result = PandasClusteringFeatureGroup._perform_spectral_clustering(X, 2)
-
-        # Check that the result has the expected shape
-        assert len(result) == len(sample_data)
-
-        # Check that there are exactly 2 unique clusters
-        assert len(np.unique(result)) == 2
 
     def test_perform_affinity_clustering(self, sample_data: pd.DataFrame) -> None:
         """Test the _perform_affinity_clustering method."""

--- a/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_pandas_clustering_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_pandas_clustering_feature_group.py
@@ -70,6 +70,7 @@ class TestPandasClusteringFeatureGroup:
 
     @pytest.mark.parametrize("algorithm", ["kmeans", "hierarchical", "spectral"])
     def test_perform_clustering_with_fixed_k(self, sample_data: pd.DataFrame, algorithm: str) -> None:
+        """These take an explicit k and return exactly that many clusters; dbscan and affinity infer k instead."""
         # Extract features
         X = sample_data[["feature1", "feature2"]].values
 

--- a/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_pandas_clustering_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_pandas_clustering_feature_group.py
@@ -70,7 +70,6 @@ class TestPandasClusteringFeatureGroup:
 
     @pytest.mark.parametrize("algorithm", ["kmeans", "hierarchical", "spectral"])
     def test_perform_clustering_with_fixed_k(self, sample_data: pd.DataFrame, algorithm: str) -> None:
-        """These algorithms take an explicit k and return exactly that many clusters."""
         # Extract features
         X = sample_data[["feature1", "feature2"]].values
 

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
@@ -105,6 +105,7 @@ class TestPandasNodeCentralityFeatureGroup:
 
     @pytest.mark.parametrize("algorithm", ["closeness", "betweenness", "eigenvector", "pagerank"])
     def test_calculate_bounded_centrality(self, sample_data: pd.DataFrame, algorithm: str) -> None:
+        """These take (adj_matrix, nodes) and score every node within [0, 1]; degree is separate, it may exceed 1."""
         # Get unique nodes
         nodes = pd.concat([sample_data["source"], sample_data["target"]]).unique()
 

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
@@ -105,7 +105,6 @@ class TestPandasNodeCentralityFeatureGroup:
 
     @pytest.mark.parametrize("algorithm", ["closeness", "betweenness", "eigenvector", "pagerank"])
     def test_calculate_bounded_centrality(self, sample_data: pd.DataFrame, algorithm: str) -> None:
-        """These algorithms take (adj_matrix, nodes) and score every node within [0, 1]."""
         # Get unique nodes
         nodes = pd.concat([sample_data["source"], sample_data["target"]]).unique()
 

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
@@ -103,8 +103,9 @@ class TestPandasNodeCentralityFeatureGroup:
         assert centrality["C"] > 0
         assert centrality["D"] > 0
 
-    def test_calculate_closeness_centrality(self, sample_data: pd.DataFrame) -> None:
-        """Test the _calculate_closeness_centrality method."""
+    @pytest.mark.parametrize("algorithm", ["closeness", "betweenness", "eigenvector", "pagerank"])
+    def test_calculate_bounded_centrality(self, sample_data: pd.DataFrame, algorithm: str) -> None:
+        """These algorithms take (adj_matrix, nodes) and score every node within [0, 1]."""
         # Get unique nodes
         nodes = pd.concat([sample_data["source"], sample_data["target"]]).unique()
 
@@ -113,68 +114,8 @@ class TestPandasNodeCentralityFeatureGroup:
             sample_data, nodes, "source", "target", "weight", "undirected"
         )
 
-        # Calculate closeness centrality
-        centrality = PandasNodeCentralityFeatureGroup._calculate_closeness_centrality(adj_matrix, nodes)
-
-        # Check that the centrality has the correct shape
-        assert len(centrality) == len(nodes)
-
-        # Check that the centrality values are between 0 and 1
-        assert (centrality >= 0).all()
-        assert (centrality <= 1).all()
-
-    def test_calculate_betweenness_centrality(self, sample_data: pd.DataFrame) -> None:
-        """Test the _calculate_betweenness_centrality method."""
-        # Get unique nodes
-        nodes = pd.concat([sample_data["source"], sample_data["target"]]).unique()
-
-        # Create adjacency matrix
-        adj_matrix = PandasNodeCentralityFeatureGroup._create_adjacency_matrix(
-            sample_data, nodes, "source", "target", "weight", "undirected"
-        )
-
-        # Calculate betweenness centrality
-        centrality = PandasNodeCentralityFeatureGroup._calculate_betweenness_centrality(adj_matrix, nodes)
-
-        # Check that the centrality has the correct shape
-        assert len(centrality) == len(nodes)
-
-        # Check that the centrality values are between 0 and 1
-        assert (centrality >= 0).all()
-        assert (centrality <= 1).all()
-
-    def test_calculate_eigenvector_centrality(self, sample_data: pd.DataFrame) -> None:
-        """Test the _calculate_eigenvector_centrality method."""
-        # Get unique nodes
-        nodes = pd.concat([sample_data["source"], sample_data["target"]]).unique()
-
-        # Create adjacency matrix
-        adj_matrix = PandasNodeCentralityFeatureGroup._create_adjacency_matrix(
-            sample_data, nodes, "source", "target", "weight", "undirected"
-        )
-
-        # Calculate eigenvector centrality
-        centrality = PandasNodeCentralityFeatureGroup._calculate_eigenvector_centrality(adj_matrix, nodes)
-
-        # Check that the centrality has the correct shape
-        assert len(centrality) == len(nodes)
-
-        # Check that the centrality values are between 0 and 1
-        assert (centrality >= 0).all()
-        assert (centrality <= 1).all()
-
-    def test_calculate_pagerank_centrality(self, sample_data: pd.DataFrame) -> None:
-        """Test the _calculate_pagerank_centrality method."""
-        # Get unique nodes
-        nodes = pd.concat([sample_data["source"], sample_data["target"]]).unique()
-
-        # Create adjacency matrix
-        adj_matrix = PandasNodeCentralityFeatureGroup._create_adjacency_matrix(
-            sample_data, nodes, "source", "target", "weight", "undirected"
-        )
-
-        # Calculate PageRank centrality
-        centrality = PandasNodeCentralityFeatureGroup._calculate_pagerank_centrality(adj_matrix, nodes)
+        calculate = getattr(PandasNodeCentralityFeatureGroup, f"_calculate_{algorithm}_centrality")
+        centrality = calculate(adj_matrix, nodes)
 
         # Check that the centrality has the correct shape
         assert len(centrality) == len(nodes)


### PR DESCRIPTION
Ten test files carried groups of test functions whose bodies were identical once names and string constants were erased: the same body copy-pasted once per enum member, per join kind, per centrality algorithm, per plugin-docs getter. Each group is now one `pytest.mark.parametrize` table whose rows carry only what genuinely varies.

`tests/` drops 663 lines. The collected node count is unchanged at 9299, and `tox` reports the same 8955 passed / 170 skipped / 4 xfailed as before, so every case that ran before still runs.

## What collapsed

| File | Table | Rows |
|---|---|---|
| `test_join_spec.py` | `test_link_factory_method_with_join_spec` | the six `Link` factory methods |
| `test_plugin_docs.py` | `TestDocsGetterSharedBehaviour`, eight shared tests | feature group, compute framework, extender |
| `test_feature_group_final_filters.py` | row elimination, filter-column validation | four each |
| `test_pandas_node_centrality_feature_group.py` | `test_calculate_bounded_centrality` | four algorithms |
| `test_subtype_matching.py` | `_ROUTING_CASES` | five routing shapes |
| `test_identify_feature_group_error_message.py` | `test_error_message_contains` | three fragments |
| `test_execution_plan_invariant_error_messages.py` | `_DISCRIMINATOR_CASES` | five |
| `test_polymorphic_link.py` | `test_matches_declared_or_subclassed_groups` | four hierarchies |
| `test_pandas_clustering_feature_group.py` | `test_perform_clustering_with_fixed_k` | three algorithms |
| `test_base_encoding_feature_group.py` | `test_match_feature_group_criteria_valid` | three encoders |

Every table uses named ids, so a failure still names its case.

## What deliberately stayed longhand

A copy only joined a table when its assertions matched the others exactly. Siblings that look similar but assert something different were left alone rather than folded in on a weaker shared assertion: `test_calculate_degree_centrality` has no upper bound, the dbscan and affinity clustering tests infer their cluster count instead of taking a fixed one, `test_numeric_filter_on_string_column_raises_error` uses a different filter column and error, and the three `has_required_fields` tests check genuinely different field sets. Each parametrized test says in one line what makes a case eligible, so the exclusions are not mistaken for oversights.

Three plugin-docs filter tests wrapped their assertions in `if len(...) > 0:` and would have passed without asserting anything had the guard been false. Those guards are now asserts, and `test_name_filter_partial` selects a suitable entry rather than assuming the first one qualifies.
