### PR TITLE
fix: raise on a stalled scheduler instead of hanging

### DIFF
--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -30,20 +30,41 @@ from mloda.core.abstract_plugins.feature_group import format_feature_group_class
 logger = logging.getLogger(__name__)
 
 
+_MAX_RENDERED_ENTRIES = 10
+
+
+def _capped_join(entries: Sequence[str], separator: str, limit: int = _MAX_RENDERED_ENTRIES) -> str:
+    """Join at most ``limit`` entries and name how many were left out."""
+    if len(entries) <= limit:
+        return separator.join(entries)
+    return f"{separator.join(entries[:limit])}{separator}... and {len(entries) - limit} more"
+
+
 def _describe_step(step: Any) -> str:
-    """Render a step for error messages without relying on its repr."""
+    """Render a step for error messages without relying on its repr.
+
+    Every branch falls back to the generic rendering: an error renderer may not raise.
+    """
     if isinstance(step, FeatureGroupStep):
-        return (
-            f"FeatureGroupStep {format_feature_group_class(step.feature_group)} "
-            f"for features {list(step.features.get_all_names())}"
-        )
+        feature_group = getattr(step, "feature_group", None)
+        features = getattr(step, "features", None)
+        if feature_group is not None and features is not None:
+            names = ", ".join(str(name) for name in features.get_all_names())
+            return f"FeatureGroupStep {format_feature_group_class(feature_group)} for features {names}"
     if isinstance(step, JoinStep):
-        return (
-            f"JoinStep {step.link} into {step.destination_framework.get_class_name()} "
-            f"from {step.source_framework.get_class_name()}"
-        )
+        link = getattr(step, "link", None)
+        destination_framework = getattr(step, "destination_framework", None)
+        source_framework = getattr(step, "source_framework", None)
+        if link is not None and destination_framework is not None and source_framework is not None:
+            return (
+                f"JoinStep {link} into {destination_framework.get_class_name()} "
+                f"from {source_framework.get_class_name()}"
+            )
     if isinstance(step, TransformFrameworkStep):
-        return f"TransformFrameworkStep {step.from_framework.get_class_name()} to {step.to_framework.get_class_name()}"
+        from_framework = getattr(step, "from_framework", None)
+        to_framework = getattr(step, "to_framework", None)
+        if from_framework is not None and to_framework is not None:
+            return f"TransformFrameworkStep {from_framework.get_class_name()} to {to_framework.get_class_name()}"
     return f"{type(step).__name__} {getattr(step, 'uuid', None)}"
 
 
@@ -168,25 +189,31 @@ class ExecutionOrchestrator:
         raise MlodaRunError(self._stalled_plan_message(finished_ids))
 
     def _stalled_plan_message(self, finished_ids: set[UUID]) -> str:
-        """Name every unfinished step, what it waits for, and which tokens no step produces."""
+        """Name the root-cause steps, what they wait for, and which tokens no step produces."""
         producible: set[UUID] = set()
-        unfinished: list[Any] = []
+        unfinished: list[tuple[Any, set[UUID]]] = []
         for step in self.execution_planner:
             producible.update(step.get_uuids())
             if not self._is_step_done(step.get_uuids(), finished_ids):
-                unfinished.append(step)
+                unfinished.append((step, step.required_uuids - finished_ids))
 
-        waiting: list[str] = []
         never_produced: set[UUID] = set()
-        for step in unfinished:
-            missing = step.required_uuids - finished_ids
+        for _, missing in unfinished:
             never_produced.update(missing - producible)
-            waiting.append(f"{_describe_step(step)} waits for {sorted(str(uuid) for uuid in missing)}")
 
+        # A step waiting only on producible tokens is blocked by another step, not a cause. A cycle
+        # produces every token it waits for, so that filter can select nothing: then all are causes.
+        root_causes = [entry for entry in unfinished if entry[1] & never_produced] or unfinished
+
+        waiting = [
+            f"{_describe_step(step)} waits for {_capped_join(sorted(str(uuid) for uuid in missing), ', ')}"
+            for step, missing in root_causes
+        ]
+        tokens = _capped_join(sorted(str(uuid) for uuid in never_produced), ", ")
         return internal_invariant_error(
             "the execution plan stalled: no step can run and none is in flight.",
-            f"Unfinished steps: {'; '.join(waiting)}. "
-            f"Required tokens no step of the plan produces: {sorted(str(uuid) for uuid in never_produced)}.",
+            f"Stalled steps: {_capped_join(waiting, '; ')}. "
+            f"Required tokens no step of the plan produces: {tokens or 'none'}.",
             "A step producing a required token is missing from the plan, e.g. a dropped join step.",
         )
 

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -23,10 +23,28 @@ from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
+from mloda.core.abstract_plugins.components.error_utils import MlodaRunError, internal_invariant_error
+from mloda.core.abstract_plugins.feature_group import format_feature_group_class
 
 
 logger = logging.getLogger(__name__)
+
+
+def _describe_step(step: Any) -> str:
+    """Render a step for error messages without relying on its repr."""
+    if isinstance(step, FeatureGroupStep):
+        return (
+            f"FeatureGroupStep {format_feature_group_class(step.feature_group)} "
+            f"for features {list(step.features.get_all_names())}"
+        )
+    if isinstance(step, JoinStep):
+        return (
+            f"JoinStep {step.link} into {step.destination_framework.get_class_name()} "
+            f"from {step.source_framework.get_class_name()}"
+        )
+    if isinstance(step, TransformFrameworkStep):
+        return f"TransformFrameworkStep {step.from_framework.get_class_name()} to {step.to_framework.get_class_name()}"
+    return f"{type(step).__name__} {getattr(step, 'uuid', None)}"
 
 
 class ExecutionOrchestrator:
@@ -110,7 +128,10 @@ class ExecutionOrchestrator:
 
     def _run_planner_pass(
         self, finished_ids: set[UUID], to_finish_ids: set[UUID], currently_running_steps: set[UUID]
-    ) -> None:
+    ) -> bool:
+        """Run one pass over the plan. Returns True if a step was executed or marked finished."""
+        made_progress = False
+
         for step in self.execution_planner:
             to_finish_ids.update(step.get_uuids())
 
@@ -124,6 +145,7 @@ class ExecutionOrchestrator:
             if self.currently_running_step(step.get_uuids(), currently_running_steps):
                 if self._process_step_result(step):
                     self._mark_step_as_finished(step.get_uuids(), finished_ids, currently_running_steps)
+                    made_progress = True
                 continue
 
             if not self._can_run_step(
@@ -131,6 +153,42 @@ class ExecutionOrchestrator:
             ):
                 continue
             self._execute_step(step)
+            made_progress = True
+
+        return made_progress
+
+    def _raise_if_stalled(
+        self, made_progress: bool, finished_ids: set[UUID], currently_running_steps: set[UUID]
+    ) -> None:
+        """Abort a pass that scheduled nothing, finished nothing and left nothing in flight."""
+        # A dispatched step sits in currently_running_steps while step_is_done is still False,
+        # so a pass that only polls it is progress.
+        if made_progress or currently_running_steps:
+            return
+        raise MlodaRunError(self._stalled_plan_message(finished_ids))
+
+    def _stalled_plan_message(self, finished_ids: set[UUID]) -> str:
+        """Name every unfinished step, what it waits for, and which tokens no step produces."""
+        producible: set[UUID] = set()
+        unfinished: list[Any] = []
+        for step in self.execution_planner:
+            producible.update(step.get_uuids())
+            if not self._is_step_done(step.get_uuids(), finished_ids):
+                unfinished.append(step)
+
+        waiting: list[str] = []
+        never_produced: set[UUID] = set()
+        for step in unfinished:
+            missing = step.required_uuids - finished_ids
+            never_produced.update(missing - producible)
+            waiting.append(f"{_describe_step(step)} waits for {sorted(str(uuid) for uuid in missing)}")
+
+        return internal_invariant_error(
+            "the execution plan stalled: no step can run and none is in flight.",
+            f"Unfinished steps: {'; '.join(waiting)}. "
+            f"Required tokens no step of the plan produces: {sorted(str(uuid) for uuid in never_produced)}.",
+            "A step producing a required token is missing from the plan, e.g. a dropped join step.",
+        )
 
     def _finalize(self) -> None:
         self.data_lifecycle_manager.set_artifacts(self.cfw_register.get_artifacts())
@@ -171,7 +229,12 @@ class ExecutionOrchestrator:
                 if self._check_for_error():
                     break
 
-                self._run_planner_pass(finished_ids, to_finish_ids, currently_running_steps)
+                made_progress = self._run_planner_pass(finished_ids, to_finish_ids, currently_running_steps)
+
+                if len(to_finish_ids) == 0:
+                    break
+
+                self._raise_if_stalled(made_progress, finished_ids, currently_running_steps)
 
                 if ParallelizationMode.MULTIPROCESSING in self.cfw_register.get_parallelization_modes():
                     time.sleep(0.01)
@@ -184,7 +247,7 @@ class ExecutionOrchestrator:
 
         Each yielded tuple is ``(step_uuid, result)`` where *result* is a fully
         materialized compute-framework object (e.g. ``pa.Table``).  Results are
-        emitted at feature-group granularity — there is no intra-group partial
+        emitted at feature-group granularity, there is no intra-group partial
         streaming.
         """
         finished_ids, to_finish_ids, currently_running_steps = self._init_run()
@@ -193,12 +256,14 @@ class ExecutionOrchestrator:
                 if self._check_for_error():
                     break
 
-                self._run_planner_pass(finished_ids, to_finish_ids, currently_running_steps)
+                made_progress = self._run_planner_pass(finished_ids, to_finish_ids, currently_running_steps)
 
                 yield from self.data_lifecycle_manager.pop_result_data_collection()
 
                 if len(to_finish_ids) == 0:
                     break
+
+                self._raise_if_stalled(made_progress, finished_ids, currently_running_steps)
 
                 time.sleep(0.01)
 

--- a/tests/test_core/test_runtime/test_scheduler_stall.py
+++ b/tests/test_core/test_runtime/test_scheduler_stall.py
@@ -17,10 +17,14 @@ import pytest
 from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.core.cfw_manager import CfwManager
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
-from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.core.runtime.run import ExecutionOrchestrator, _describe_step
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 from tests.helpers.plugin_stubs import make_fg
 
@@ -60,6 +64,23 @@ class InFlightStep:
             self.step_is_done = True
 
 
+class ProducerStep:
+    """A parent step that runs, finishes, and hands its uuid to a child as a satisfied token."""
+
+    def __init__(self) -> None:
+        self.uuid = uuid4()
+        self.required_uuids: set[UUID] = set()
+        self.step_is_done = False
+
+    def get_uuids(self) -> set[UUID]:
+        return {self.uuid}
+
+
+def _finish_on_execute(step: Any) -> None:
+    """Stands in for sync_execute_step, which sets step_is_done before returning."""
+    step.step_is_done = True
+
+
 def _orchestrator(*steps: Any) -> ExecutionOrchestrator:
     """Wire a SYNC-mode orchestrator over the given steps; no compute framework is ever created."""
     orchestrator = ExecutionOrchestrator(ReiterablePlan(*steps))
@@ -72,11 +93,6 @@ def _feature_group_step(feature_name: str, required_uuids: set[UUID]) -> Feature
     return FeatureGroupStep(StallFeatureGroup, FeatureSet([Feature(feature_name)]), required_uuids, PythonDictFramework)
 
 
-def _unique_identifiers(step: FeatureGroupStep) -> tuple[str, ...]:
-    """Tokens that point at this step and no other: its feature names and its uuids."""
-    return (*step.features.get_all_names(), str(step.uuid), *(str(uuid) for uuid in step.get_uuids()))
-
-
 def test_compute_raises_when_a_required_uuid_is_never_produced() -> None:
     dangling = uuid4()
     step = _feature_group_step("stall_orphan_feature", {dangling})
@@ -87,10 +103,7 @@ def test_compute_raises_when_a_required_uuid_is_never_produced() -> None:
 
     message = str(exc_info.value)
     assert str(dangling) in message, f"the unsatisfied completion token must be named; got: {message}"
-    identifiers = ("FeatureGroupStep", StallFeatureGroup.get_class_name(), *_unique_identifiers(step))
-    assert any(token in message for token in identifiers), (
-        f"the waiting step must be identifiable via one of {identifiers}; got: {message}"
-    )
+    assert "stall_orphan_feature" in message, f"the waiting step must be named by its feature; got: {message}"
 
 
 def test_compute_stream_raises_when_a_required_uuid_is_never_produced() -> None:
@@ -118,11 +131,108 @@ def test_stall_message_describes_every_step_waiting_on_the_dropped_link_token() 
 
     message = str(exc_info.value)
     assert str(link_token) in message, f"the dropped link token must be named; got: {message}"
-    for step in (left, right):
-        identifiers = _unique_identifiers(step)
-        assert any(token in message for token in identifiers), (
-            f"every waiting step must be described via one of {identifiers}; got: {message}"
-        )
+    for feature_name in ("stall_left_feature", "stall_right_feature"):
+        assert feature_name in message, f"every root-cause step must be described; {feature_name} missing: {message}"
+
+
+def test_stall_after_a_finished_step_names_only_the_token_still_missing() -> None:
+    """The real bug shape: a parent runs and finishes, then its child stalls on the dropped token."""
+    producer = ProducerStep()
+    dangling = uuid4()
+    child = _feature_group_step("stall_child_feature", {producer.uuid, dangling})
+    orchestrator = _orchestrator(producer, child)
+    orchestrator._execute_step = Mock(side_effect=_finish_on_execute)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        orchestrator.compute()
+
+    message = str(exc_info.value)
+    orchestrator._execute_step.assert_called_once_with(producer)
+    assert "stall_child_feature" in message, f"the stalled child must be described; got: {message}"
+    assert str(dangling) in message, f"the unsatisfied completion token must be named; got: {message}"
+    assert str(producer.uuid) not in message, (
+        f"a token the finished parent already produced is not a cause; got: {message}"
+    )
+
+
+def test_stall_message_names_the_root_cause_not_the_transitively_blocked_step() -> None:
+    dangling = uuid4()
+    root_cause = _feature_group_step("stall_root_cause_feature", {dangling})
+    transitive = _feature_group_step("stall_transitive_feature", set())
+    transitive.required_uuids = set(root_cause.get_uuids())
+    orchestrator = _orchestrator(root_cause, transitive)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        orchestrator.compute()
+
+    message = str(exc_info.value)
+    assert "stall_root_cause_feature" in message, f"the root-cause step must be described; got: {message}"
+    assert "stall_transitive_feature" not in message, (
+        f"a step blocked only by a producible token is not a cause; got: {message}"
+    )
+
+
+def test_stall_message_is_bounded_when_many_steps_share_one_dangling_token() -> None:
+    dangling = uuid4()
+    steps = [_feature_group_step(f"stall_capped_feature_{index:02d}", {dangling}) for index in range(40)]
+    orchestrator = _orchestrator(*steps)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        orchestrator.compute()
+
+    message = str(exc_info.value)
+    assert str(dangling) in message, f"the unsatisfied completion token must be named; got: {message}"
+    assert "more" in message, f"a truncated listing must say how many steps it left out; got: {message}"
+    assert len(message) < 4000, f"the stall message must stay bounded; got {len(message)} chars"
+
+
+def test_stall_message_falls_back_to_unfinished_steps_when_every_token_is_producible() -> None:
+    """A cycle has no never-produced token, so the root-cause filter must not render an empty list."""
+    first = _feature_group_step("stall_cycle_first_feature", set())
+    second = _feature_group_step("stall_cycle_second_feature", set())
+    first.required_uuids = set(second.get_uuids())
+    second.required_uuids = set(first.get_uuids())
+    orchestrator = _orchestrator(first, second)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        orchestrator.compute()
+
+    message = str(exc_info.value)
+    for feature_name in ("stall_cycle_first_feature", "stall_cycle_second_feature"):
+        assert feature_name in message, f"a deadlocked cycle must name both steps; {feature_name} missing: {message}"
+
+
+def test_describe_step_renders_a_join_step() -> None:
+    link = Link.inner(JoinSpec(StallFeatureGroup, "stall_idx"), JoinSpec(StallFeatureGroup, "stall_idx"))
+    step = JoinStep(link, PythonDictFramework, PyArrowTable, set(), set(), set())
+
+    rendered = _describe_step(step)
+
+    assert str(link.uuid) in rendered, f"the link must be identifiable; got: {rendered}"
+    assert PythonDictFramework.get_class_name() in rendered, f"the destination framework is missing: {rendered}"
+    assert PyArrowTable.get_class_name() in rendered, f"the source framework is missing: {rendered}"
+
+
+def test_describe_step_renders_a_transform_framework_step() -> None:
+    step = TransformFrameworkStep(
+        PythonDictFramework, PyArrowTable, set(), StallFeatureGroup, StallFeatureGroup, None, set()
+    )
+
+    rendered = _describe_step(step)
+
+    assert PythonDictFramework.get_class_name() in rendered, f"the source framework is missing: {rendered}"
+    assert PyArrowTable.get_class_name() in rendered, f"the target framework is missing: {rendered}"
+    assert rendered.index(PythonDictFramework.get_class_name()) < rendered.index(PyArrowTable.get_class_name()), (
+        f"the from framework must be rendered before the to framework; got: {rendered}"
+    )
+
+
+def test_describe_step_survives_a_step_without_the_attributes_it_reads() -> None:
+    """An error path may not raise: a stall message must survive a step that answers nothing."""
+    rendered = _describe_step(Mock(spec=FeatureGroupStep))
+
+    assert isinstance(rendered, str)
+    assert rendered, "a step must always render to something non-empty"
 
 
 def test_compute_does_not_raise_while_a_step_is_in_flight() -> None:
@@ -152,12 +262,14 @@ def test_compute_stream_does_not_raise_while_a_step_is_in_flight() -> None:
 
 
 def test_compute_returns_on_empty_plan() -> None:
+    """Pins a second, independent hang: an empty plan spun forever in compute()."""
     orchestrator = _orchestrator()
 
     orchestrator.compute()
 
 
 def test_compute_stream_yields_nothing_on_empty_plan() -> None:
+    """Pins the ordering: the empty-plan break runs before the stall check, which would raise here."""
     orchestrator = _orchestrator()
 
     assert list(orchestrator.compute_stream()) == []

--- a/tests/test_core/test_runtime/test_scheduler_stall.py
+++ b/tests/test_core/test_runtime/test_scheduler_stall.py
@@ -1,0 +1,163 @@
+# mypy: disable-error-code="arg-type, method-assign"
+"""The run loop must abort when a required completion token is never produced.
+
+A dropped JoinStep leaves child steps waiting on a link uuid nothing produces. A pass that
+schedules nothing, completes nothing and has nothing in flight must raise MlodaRunError.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import Mock
+from uuid import UUID, uuid4
+
+import pytest
+
+from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.core.cfw_manager import CfwManager
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.helpers.plugin_stubs import make_fg
+
+# Below the suite-wide timeout on purpose: a stall regression must fail fast, not hang.
+pytestmark = pytest.mark.timeout(5)
+
+
+StallFeatureGroup = make_fg("StallFeatureGroup")
+
+
+class ReiterablePlan:
+    """A planner stub that yields the same steps on every pass, like a real ExecutionPlan."""
+
+    def __init__(self, *steps: Any) -> None:
+        self._steps = steps
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._steps)
+
+
+class InFlightStep:
+    """A step dispatched to a worker: it reports done only on the second poll."""
+
+    def __init__(self) -> None:
+        self.uuid = uuid4()
+        self.required_uuids: set[UUID] = set()
+        self.step_is_done = False
+        self.polls = 0
+
+    def get_uuids(self) -> set[UUID]:
+        return {self.uuid}
+
+    def poll(self) -> None:
+        """Stands in for WorkerManager.poll_result_queues draining the worker's result queue."""
+        self.polls += 1
+        if self.polls >= 2:
+            self.step_is_done = True
+
+
+def _orchestrator(*steps: Any) -> ExecutionOrchestrator:
+    """Wire a SYNC-mode orchestrator over the given steps; no compute framework is ever created."""
+    orchestrator = ExecutionOrchestrator(ReiterablePlan(*steps))
+    orchestrator.cfw_register = CfwManager({ParallelizationMode.SYNC})
+    return orchestrator
+
+
+def _feature_group_step(feature_name: str, required_uuids: set[UUID]) -> FeatureGroupStep:
+    """A real FeatureGroupStep; the plan stalls before anything ever executes it."""
+    return FeatureGroupStep(StallFeatureGroup, FeatureSet([Feature(feature_name)]), required_uuids, PythonDictFramework)
+
+
+def _unique_identifiers(step: FeatureGroupStep) -> tuple[str, ...]:
+    """Tokens that point at this step and no other: its feature names and its uuids."""
+    return (*step.features.get_all_names(), str(step.uuid), *(str(uuid) for uuid in step.get_uuids()))
+
+
+def test_compute_raises_when_a_required_uuid_is_never_produced() -> None:
+    dangling = uuid4()
+    step = _feature_group_step("stall_orphan_feature", {dangling})
+    orchestrator = _orchestrator(step)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        orchestrator.compute()
+
+    message = str(exc_info.value)
+    assert str(dangling) in message, f"the unsatisfied completion token must be named; got: {message}"
+    identifiers = ("FeatureGroupStep", StallFeatureGroup.get_class_name(), *_unique_identifiers(step))
+    assert any(token in message for token in identifiers), (
+        f"the waiting step must be identifiable via one of {identifiers}; got: {message}"
+    )
+
+
+def test_compute_stream_raises_when_a_required_uuid_is_never_produced() -> None:
+    dangling = uuid4()
+    step = _feature_group_step("stall_orphan_stream_feature", {dangling})
+    orchestrator = _orchestrator(step)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        list(orchestrator.compute_stream())
+
+    assert str(dangling) in str(exc_info.value), (
+        f"the unsatisfied completion token must be named; got: {exc_info.value}"
+    )
+
+
+def test_stall_message_describes_every_step_waiting_on_the_dropped_link_token() -> None:
+    """Both children of a dropped JoinStep wait on the same link uuid, so both must be described."""
+    link_token = uuid4()
+    left = _feature_group_step("stall_left_feature", {link_token})
+    right = _feature_group_step("stall_right_feature", {link_token})
+    orchestrator = _orchestrator(left, right)
+
+    with pytest.raises(MlodaRunError) as exc_info:
+        orchestrator.compute()
+
+    message = str(exc_info.value)
+    assert str(link_token) in message, f"the dropped link token must be named; got: {message}"
+    for step in (left, right):
+        identifiers = _unique_identifiers(step)
+        assert any(token in message for token in identifiers), (
+            f"every waiting step must be described via one of {identifiers}; got: {message}"
+        )
+
+
+def test_compute_does_not_raise_while_a_step_is_in_flight() -> None:
+    """A pass with no scheduling and no completion is progress while a step sits in flight."""
+    step = InFlightStep()
+    orchestrator = _orchestrator(step)
+    orchestrator.worker_manager.poll_result_queues = step.poll
+    orchestrator._execute_step = Mock()
+
+    orchestrator.compute()
+
+    assert step.polls >= 2, "the step must stay in flight for at least one full pass with no progress"
+    assert step.step_is_done is True
+    orchestrator._execute_step.assert_called_once_with(step)
+
+
+def test_compute_stream_does_not_raise_while_a_step_is_in_flight() -> None:
+    step = InFlightStep()
+    orchestrator = _orchestrator(step)
+    orchestrator.worker_manager.poll_result_queues = step.poll
+    orchestrator._execute_step = Mock()
+
+    list(orchestrator.compute_stream())
+
+    assert step.polls >= 2, "the step must stay in flight for at least one full pass with no progress"
+    assert step.step_is_done is True
+
+
+def test_compute_returns_on_empty_plan() -> None:
+    orchestrator = _orchestrator()
+
+    orchestrator.compute()
+
+
+def test_compute_stream_yields_nothing_on_empty_plan() -> None:
+    orchestrator = _orchestrator()
+
+    assert list(orchestrator.compute_stream()) == []


### PR DESCRIPTION
## Problem

`ExecutionOrchestrator` loops until every step uuid in the plan is finished. When a step requires a completion token that no step of the plan produces, nothing can ever be scheduled, no worker error is reported, and both `compute()` and `compute_stream()` spin with the CPU pinned until the process is killed.

The known trigger is a dropped join step. `JoinStep.get_uuids()` returns `{self.uuid, self.link.uuid}`, so a join step is the only producer of its link uuid, and child feature group steps still carry that uuid in their `required_uuids`.

An empty plan was a second, independent hang: `compute()` spun on it, while `compute_stream()` already returned.

## Change

A pass that schedules nothing, completes nothing and leaves nothing in flight is terminal. The plan is a fixed list, and every piece of state that gates scheduling changes only through a scheduled or a completed step, so the next pass would be identical. Such a pass now raises `MlodaRunError`.

A step dispatched to a thread or process sits in `currently_running_steps` while its `step_is_done` is still `False`, so a pass that only polls it counts as progress. Without that clause the check would fire on the gap between scheduling and completion on every threaded and multiprocessing run.

The message names the steps blocked on a token that no step of the plan produces, what each waits for, and the unsatisfied tokens themselves. Both listings are capped and report how many entries were left out, since real plans hold hundreds of steps. A cycle produces every token it waits for, so when that filter selects nothing, the unfinished steps are described instead.

`compute()` now returns on an empty plan, matching `compute_stream()`.

## Notes

- No behavior changes for a plan that can run to completion: every state this fires on is a guaranteed hang today.
- The step renderer used in the message tolerates a step missing the attributes it reads. An error renderer that raises hides the failure it was called to report.
- Deliberately not included: a post-merge data tripwire. There is no backend-independent predicate, since inner joins may legitimately return zero rows and engines differ on duplicate and column handling.