### PR TITLE
test: make test_stream_run.py resolve its feature group standalone

### DIFF
--- a/tests/test_core/test_api/test_stream_run.py
+++ b/tests/test_core/test_api/test_stream_run.py
@@ -3,9 +3,6 @@
 These tests verify:
 1. mlodaAPI has a stream_run method that is callable
 2. stream_run returns a generator (types.GeneratorType), not a list
-
-All tests are expected to FAIL because:
-- mlodaAPI does not have a stream_run method yet
 """
 
 import types
@@ -13,6 +10,10 @@ import types
 
 from mloda.user import Feature, Features, ParallelizationMode, mlodaAPI
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+# stream_run plans eagerly, so ``EngineRunnerTest1`` must be a loaded FeatureGroup subclass at call
+# time. Import its defining module here rather than relying on another test package's conftest.
+import tests.test_core.test_integration.test_core.test_runner_one_compute_framework  # noqa: F401
 
 
 class TestStreamRunImport:


### PR DESCRIPTION
Closes #1084.

## The dependency

`test_stream_run.py` requests the feature `EngineRunnerTest1`. Its FeatureGroup is defined in `tests/test_core/test_integration/test_core/test_runner_one_compute_framework.py`. Resolution walks live `FeatureGroup` subclasses, so that module has to be imported before `stream_run` plans.

Nothing in `test_stream_run.py` imported it. The tests passed only because `tests/test_core/test_runtime/conftest.py` imports that module for `test_stream_all.py`, and a full run collects the sibling package first.

## Reproduction, on a clean tree

```
pytest tests/test_core/test_api/test_stream_run.py -q
```

```
FAILED TestStreamRunReturnsGenerator::test_stream_run_returns_generator_type
FAILED TestStreamRunReturnsGenerator::test_stream_run_is_not_a_list
mloda.core.prepare.identify_feature_group.FeatureResolutionError:
No feature groups found for feature name: 'EngineRunnerTest1'.
```

`2 failed, 1 passed`. A full `tox` run is green, which is what kept this invisible at the gate.

## The change

Import the defining module from the test module itself — the same one-line registration `tests/test_core/test_runtime/conftest.py` already relies on, with the same reasoning in a comment.

`tests/test_core/test_runtime/conftest.py` is left in place: `test_stream_all.py` still needs it, and it is that package's own registration.

## Verification

| command | before | after |
| --- | --- | --- |
| `pytest tests/test_core/test_api/test_stream_run.py` | 2 failed, 1 passed | **3 passed** |
| `pytest .../test_stream_run.py .../test_runtime/test_stream_all.py` | 8 passed | 8 passed |

Gates on the changed file: `ruff format --check --line-length 120`, `ruff check`, `mypy --strict --ignore-missing-imports` all clean.

## One unrelated line in the same file

The module docstring still claimed:

> All tests are expected to FAIL because:
> - mlodaAPI does not have a stream_run method yet

`stream_run` exists and the file has been green in full runs for a while, so that paragraph is dropped. Happy to pull it back out if you would rather keep this diff to the import alone.
