### PR TITLE
test: run the near-miss label guards in the default tox env

### DIFF
--- a/tests/test_docs_near_miss_labels.py
+++ b/tests/test_docs_near_miss_labels.py
@@ -3,6 +3,10 @@
 Renaming a ``_STAGE_LABELS`` value reddens the renderer's hardcoded label table, which names no doc page, so
 updating that table turns the suite green with the pages still quoting the old label. These guards read the
 label back off the page, check it against the live table, and name the file and line that went stale.
+
+String parsing over docs/docs plus a ``_STAGE_LABELS`` import and one backend-free render, so it lives
+outside tests/test_documentation, which the default tox env ignores. Same placement as test_docs_fences.py,
+and for the same reason: a rename that leaves a page stale has to redden a plain ``tox``, not only python314.
 """
 
 import gc
@@ -23,7 +27,7 @@ from mloda.core.prepare.resolution_types import Elimination, EliminationStage, E
 
 # Anchored to this file, not to the cwd: a relative glob run from anywhere but
 # the repo root yields nothing and these guards pass vacuously (issue #937).
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_ROOT = REPO_ROOT / "docs" / "docs"
 FENCE_PATTERN = re.compile(r"^\s*```")
 
@@ -76,7 +80,7 @@ def _near_miss_bullets(text: str) -> Iterator[tuple[int, re.Match[str]]]:
 def test_rendered_near_miss_bullets_carry_a_current_stage_label(fpath: Path) -> None:
     """Every label a page reproduces in a near-miss bullet is still a value of ``_STAGE_LABELS``."""
     stale = [
-        f"{fpath}:{number} renders near-miss label '{match.group('label')}'"
+        f"{fpath.relative_to(REPO_ROOT)}:{number} renders near-miss label '{match.group('label')}'"
         for number, match in _near_miss_bullets(fpath.read_text(encoding="utf-8"))
         if match.group("label") not in ALLOWED_LABELS
     ]


### PR DESCRIPTION
Closes #1082.

## The hole

The default `[testenv]` command passes `--ignore=tests/test_documentation`, and only `python314` clears `DEACTIVATE_NOTEBOOK_AND_DOC_TESTS`. So the near-miss label guards — the tests whose whole job is to redden when a stage label is renamed and a published page keeps quoting the old one — never run under a plain local `tox`. CI runs the 3.14 env, so the gate holds there, which is exactly what made the hole invisible.

## The change

Move `tests/test_documentation/test_near_miss_labels_in_docs.py` to `tests/test_docs_near_miss_labels.py`, next to `test_docs_fences.py` — the precedent named in the issue, which already sits outside `tests/test_documentation` for this reason and says so in its docstring.

Moved whole rather than split by dependency. All 46 cases are string parsing over `docs/docs/**.md` plus a `_STAGE_LABELS` import, and the one self-test that renders a real failure builds an `EvaluationResult` and calls `render_resolution_failure` directly, so it needs no backend and no flight server. The whole file runs in **0.21s**. Moving it whole also keeps one home for the label vocabulary (`ALLOWED_LABELS`, `NEAR_MISS_BULLET_PATTERN`, `DOC_BULLET_STAGES`, `PROSE_LABEL_PAGES`, `LABEL_TABLE_PAGE`), which a split would have had to duplicate or export.

The diff is the rename, the docstring paragraph explaining the placement, and `REPO_ROOT` moving from `parents[2]` to `parents[1]` because the file sits one level shallower. Nothing else changes.

## Verification

Label guards collected by the default env's own selection, `pytest --ignore=tests/test_documentation -m 'not notebooks'`:

| | main | this branch |
| --- | --- | --- |
| label guard cases collected | **0** | **46** |

Then the rename the guard exists to catch — `_STAGE_LABELS["input_data"]` from `"input data"` to `"input source"`, under that same selection:

```
FAILED test_rendered_near_miss_bullets_carry_a_current_stage_label[docs/docs/in_depth/data-access-patterns.md]
FAILED test_a_registered_page_still_renders_the_bullet_of_its_own_stage[in_depth/data-access-patterns.md]
FAILED TestProseLabelMentions::test_the_page_still_spells_the_current_label[in_depth/data-access-patterns.md-input_data]
FAILED test_the_label_table_rows_are_exactly_the_distinct_stage_labels
4 failed, 42 passed in 0.45s
```

The stale page and the troubleshooting label table are both named. On main the same rename is green under that selection. Source file restored afterwards — `git diff main -- mloda/` is empty on this branch.

Gates on the moved file: `ruff format --check --line-length 120`, `ruff check`, `mypy --strict --ignore-missing-imports` all clean. No remaining references to the old path anywhere in the repo.

## One note on the issue text

The issue mentions "the two self-tests that render a real failure and drive `GlobalFilter.warn_on_unmatched_filters`". In this file there is one such self-test (`test_the_scanner_pattern_matches_a_rendered_near_miss_bullet`); nothing here touches `warn_on_unmatched_filters`. It made no difference to the outcome, since the render is backend-free either way and the file moved whole — flagging it in case a second guard was meant to exist and is missing.

Rebased onto current `main` (`9caea51d`), which picked up the `parents[2]` anchoring and the relative parametrize ids from #937 in the meantime; this branch keeps those as they are.
