### PR TITLE
test: make CompatibleDtypeFeatureGroup test a distinct dtype path

### DIFF
--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -689,3 +689,29 @@ class TestFeatureGroupFinalFilters:
                 flight_server=flight_server,
                 global_filter=global_filter,
             )
+
+    def test_compatible_dtype_passes_validation(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+        """FG=True with compatible numeric dtypes. No error should be raised.
+
+        CompatibleDtypeFeatureGroup returns final_filters()=True and the
+        "rank" column is integer (int64), matching the integer filter value
+        type (rank == 1). Row elimination should proceed normally.
+        """
+        feature_name = "CompatibleDtypeFeatureGroup"
+
+        features = Features([Feature(name=feature_name, initial_requested_data=True)])
+
+        global_filter = GlobalFilter()
+        global_filter.add_filter("rank", "equal", {"value": 1})
+
+        result = MlodaTestRunner.run_api(
+            features,
+            compute_frameworks={PyArrowTable},
+            parallelization_modes=modes,
+            flight_server=flight_server,
+            global_filter=global_filter,
+        )
+
+        for res in result.results:
+            data = res.to_pydict()
+            assert data[feature_name] == [10, 30]


### PR DESCRIPTION
## Summary

Fix #1085

CompatibleDtypeFeatureGroup was byte-identical to ForceFinalOnFinalEngine, both testing a string filter on a string column. This change replaces the string column with an integer rank column and uses an integer equal filter, making it test a genuinely distinct compatible-dtype scenario (int-vs-int instead of string-vs-string).

## Changes

- `CompatibleDtypeFeatureGroup`: changed from `status` (string) column to `rank` (int64) column
- `test_compatible_dtype_passes_validation`: changed from `status == active` filter to `rank == 1` integer equal filter
- Expected result: `[10, 30]` (rows with rank=1, matching ForceFinalOnFinalEngine's pair pattern)

## Verification

- All 26 tests in `tests/test_core/test_filter/test_feature_group_final_filters.py` pass
- All 513 tests in the filter test suite pass
- Ruff format and check pass clean
