### PR TITLE
fix: reject a link resolution the feature does not declare

### DIFF
--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -123,6 +123,7 @@ class ResolveComputeFrameworks:
                 )
             if len(new_cfws) > 1:
                 self.raise_on_link_disagreement(f, resolved, feature_trekkers[f.uuid])
+            self.raise_on_unsupported_resolution(f, new_cfws)
             f.compute_frameworks = new_cfws
             any_rewritten = True
 
@@ -166,6 +167,34 @@ class ResolveComputeFrameworks:
         )
         raise ValueError(
             f"Feature {feature.name} resolves to more than one compute framework {names}. Disagreeing links: {links}"
+        )
+
+    @staticmethod
+    def raise_on_unsupported_resolution(feature: Any, new_cfws: set[type[ComputeFramework]]) -> None:
+        """Reject a link resolution the feature does not declare, instead of rewriting it onto one.
+
+        The sibling branch for a feature with no trekker already refuses to move a feature onto a
+        framework outside its declared set. Without this the trekker branch disagreed: it overwrote
+        compute_frameworks with whatever the links resolved to, so a feature group could run in a
+        framework its own compute_framework_rule excludes, with no error and no warning.
+
+        ``compute_frameworks is None`` means the feature declared no restriction, so anything resolves.
+        """
+        if feature.compute_frameworks is None:
+            return
+
+        declared = set(feature.compute_frameworks)
+        unsupported = new_cfws - declared
+        if not unsupported:
+            return
+
+        resolved_names = sorted(cfw.get_class_name() for cfw in unsupported)
+        declared_names = sorted(cfw.get_class_name() for cfw in declared)
+        raise ValueError(
+            f"Feature {feature.name} declares the compute framework(s) {declared_names}, "
+            f"but its links resolve to {resolved_names}. "
+            "Give the feature group a compute_framework_rule that includes the resolved framework, "
+            "or bring the linked parents onto a framework it declares."
         )
 
     def order_queue_by_trekker_order(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -336,15 +336,19 @@ def test_left_join_inverted_orientation_keeps_every_left_row(
 
 
 @MODES_SYNC_THREADING
-def test_right_join_keeps_every_right_row_for_a_child_declaring_the_left_framework(
+def test_right_join_rejects_a_child_declaring_only_the_left_framework(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
-    results = _run_pair_results(PAIR_B, "right", OrientCharArrowChild, modes, flight_server)
-    frame = _packed_frame(results, OrientCharArrowChild.get_class_name())
+    """The planner used to rewrite the child off its declared PyArrowTable without asking whether it
+    supported the resolved one, so it came back as a pandas DataFrame with no error and no warning.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        _run_pair_results(PAIR_B, "right", OrientCharArrowChild, modes, flight_server)
 
-    # The planner rewrote the child off its declared PyArrowTable, without asking whether it supports the new one.
-    assert type(frame) is PandasDataFrame.expected_data_framework()
-    assert _packed_rows(results, OrientCharArrowChild.get_class_name()) == RIGHT_JOIN_ROWS
+    message = str(excinfo.value)
+    assert OrientCharArrowChild.get_class_name() in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
 
 
 @MODES_SYNC_THREADING


### PR DESCRIPTION
Closes #1078.

## The disagreement

`rewrite_group_frameworks` has two branches, and they disagreed about whether a feature may be moved onto a framework it does not declare.

The branch for a feature with **no trekker** already refuses (`resolve_compute_frameworks.py:105-111`):

```python
unsupported = group_cfws - supported
if unsupported:
    raise ValueError(f"Feature {f.name} does not support the compute framework(s) {names} chosen for its group.")
```

The branch for a feature **with** a trekker just assigned (`:126`):

```python
f.compute_frameworks = new_cfws
```

So a child declaring `{PyArrowTable}` that consumes both sides of a RIGHT link between a PyArrow parent and a Pandas parent came back as a pandas DataFrame — running in a framework its own `compute_framework_rule()` excludes, with no error and no warning.

## The change

`raise_on_unsupported_resolution` applies the sibling branch's check to the trekker branch, after the existing link-disagreement check. It names the feature, its declared frameworks and the resolved one, and points at the two ways out:

```
ValueError: Feature OrientCharArrowChild declares the compute framework(s) ['PyArrowTable'],
but its links resolve to ['PandasDataFrame']. Give the feature group a compute_framework_rule
that includes the resolved framework, or bring the linked parents onto a framework it declares.
```

`compute_frameworks is None` still means "no restriction declared", so anything resolves — same convention as the sibling branch and as `reject_self_merging_links`.

## The characterization test

`test_right_join_keeps_every_right_row_for_a_child_declaring_the_left_framework` pinned the rewrite as current behaviour, asserting the result frame type with the comment *"The planner rewrote the child off its declared PyArrowTable, without asking whether it supports the new one."* Per the DoD it now asserts the error and is renamed `test_right_join_rejects_a_child_declaring_only_the_left_framework`. It checks the message names the feature, `PyArrowTable` and `PandasDataFrame`, rather than pinning the exact wording.

The neighbouring `test_right_join_raises_for_a_child_on_the_right_framework` and the two `xfail(strict=True)` right-side-binding cases are unaffected.

## Verification

| suite | result |
| --- | --- |
| `tests/test_core` | **5193 passed, 4 xfailed** |
| `tests/test_plugins` + `test_docs_fences.py` | 3549 passed, 170 skipped, **4 failed — all pre-existing** |
| `test_link_planner_orientation_characterization.py` | 16 passed, 2 xfailed |

The 4 plugin failures reproduce on a clean tree (verified by stashing both changed files and re-running exactly those node ids): `test_read_context_files_file_paths_filtering::…[interior]`, `test_read_context_files_option_declarations::test_an_explicit_empty_file_type_raises_the_no_files_found_error`, `test_docs_fences::test_illustrative_py_blocks_match_allowlist`, `test_sqlite::test_is_valid_credentials_nonexistent`. None touch the planner.

Intermediate check worth recording: with the fix in place but the **old** assertions, exactly the 2 right-join characterization cases failed on the new error and the other 14 stayed green — so the guard fires on the case the issue describes and nothing else.

Gates on the changed files: `ruff format --check --line-length 120`, `ruff check`, `mypy --strict --ignore-missing-imports` all clean.

## One thing for you to decide

This turns a silent rewrite into a raise, so a configuration that quietly worked before now stops with an error. That is what the DoD asks for, and the sibling branch already behaves this way, but it is a behaviour change rather than a pure bug fix — flagging in case you want a different conventional-commit prefix than `fix:` for the semver bump.
