### PR TITLE
fix: attribute dropped-filter facts per declaration, not per column name

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -252,10 +252,12 @@ value whose truthiness test raises, that filter is a non-match for that probe, l
 return, and the drop is recorded in `GlobalFilter.dropped_filters`. A typed decline the matcher
 records lands in the same ledger, at DEBUG. A framework-owned raise still aborts.
 
-`GlobalFilter.dropped_filters` maps (FeatureGroup, filter feature name) to the gate that dropped the
-filter and that gate's reason, for the current engine setup only. A plain `False` is an ordinary
-non-match and records nothing. A matcher defect takes the key from a stored near-miss; otherwise the
-deepest gate the filter reached keeps it, and two facts at one depth leave the first one in place.
+`GlobalFilter.dropped_filters` maps (FeatureGroup, filter feature name, filter uuid) to the gate that
+dropped the filter and that gate's reason, for the current engine setup only. The uuid is the filter's
+identity, so two filters declared over one column each keep their own entry. A plain `False` is an
+ordinary non-match and records nothing. A matcher defect takes the key from a stored near-miss;
+otherwise the deepest gate the filter reached keeps it, and two facts at one depth leave the first one
+in place.
 
 A filter that matches no FeatureGroup at all is reported once after setup, with its nearest miss
 appended when one was recorded: across FeatureGroups the deepest gate wins, and a matcher defect
@@ -269,8 +271,8 @@ The parenthesized label, `(scope)` here, names the gate in the vocabulary of the
 found" error's
 [near-miss bullets](troubleshooting/feature-group-resolution-errors.md#the-eliminated-candidates-block).
 
-Two filters declared on one column name share the ledger key, so neither report can quote a fact and
-both stay the bare sentence.
+Two filters declared on one column name are explained independently, each quoting the gate its own
+declaration reached.
 
 ### Filter scope is the `FeatureSet`
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -59,8 +59,10 @@ class GlobalFilter:
            names and the uuid to the used single filter. This is used to track which features are associated with which filters for a specific feature group.
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
-        3. `dropped_filters`: maps (feature group, filter feature name) to the `Elimination` naming the gate that
-           dropped it and why; a matcher defect outranks a stored near-miss, otherwise the deepest gate reached wins.
+        3. `dropped_filters`: maps (feature group, filter feature name, filter uuid) to the `Elimination` naming
+           the gate that dropped it and why; a matcher defect outranks a stored near-miss, otherwise the deepest
+           gate reached wins. The uuid is the filter's identity, so two filters declared over one column each keep
+           their own entry; the name stays in the key because the ledger is read by humans.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
         5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once this setup.
 
@@ -69,13 +71,15 @@ class GlobalFilter:
         """
         self.filters: set[SingleFilter] = set()
         self.collection: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
-        self.dropped_filters: dict[tuple[type[FeatureGroup], str], Elimination] = {}
+        self.dropped_filters: dict[tuple[type[FeatureGroup], str, UUID], Elimination] = {}
         self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
         self.matched_filter_uuids: set[UUID] = set()
         self._warned_divergences: set[str] = set()
         # Own state, not dropped_filters: a falsy non-bool is an ordinary non-match, never a recorded drop.
+        # Keyed on the name, not the filter: the report is documented as once per group and filter feature,
+        # so two filters over one column share one log line even though they get their own ledger entries.
         self._reported_falsy_matches: set[tuple[type[FeatureGroup], str]] = set()
-        # WARNING dedupe for defect drops; the ledger itself no longer decides first-ness.
+        # WARNING dedupe for defect drops, name-keyed for the same reason; the ledger decides its own writes.
         self._warned_drops: set[tuple[type[FeatureGroup], str]] = set()
 
     def reset_match_tracking(self) -> None:
@@ -171,26 +175,25 @@ class GlobalFilter:
             # We are making a deepcopy so that, we do not change the original filter.
             _filter = deepcopy(filter)
             _filter.filter_feature.options = self.unify_options(feat.options, _filter.filter_feature.options)
-            filter_name = str(_filter.filter_feature.name)
 
             # criteria records its own drops: only it can tell a defect from a decline from a plain non-match.
             if not self.criteria(feature_group, _filter, data_access_collection):
                 continue
             if self.domain(_filter, feat.domain, feature_group) is False:
                 self._record_near_miss(
-                    feature_group, filter_name, "domain", self._domain_reason(_filter, feat, feature_group)
+                    feature_group, _filter, "domain", self._domain_reason(_filter, feat, feature_group)
                 )
                 continue
             if self.feature_group_scope(_filter, feature_group) is False:
-                self._record_near_miss(feature_group, filter_name, "scope", "outside the requested feature group scope")
+                self._record_near_miss(feature_group, _filter, "scope", "outside the requested feature group scope")
                 continue
             supported = self.capability(_filter, feat, feature_group)
             if supported is not None and not supported:
-                self._record_near_miss(feature_group, filter_name, "capability", self._capability_reason(_filter, feat))
+                self._record_near_miss(feature_group, _filter, "capability", self._capability_reason(_filter, feat))
                 continue
             if self.compute_framework(_filter, feat, supported) is False:
                 self._record_near_miss(
-                    feature_group, filter_name, "framework_pin", self._framework_pin_reason(_filter, feat)
+                    feature_group, _filter, "framework_pin", self._framework_pin_reason(_filter, feat)
                 )
                 continue
             # we don't check links, because this is not necessary as this is covered by the feature and feature group before
@@ -207,22 +210,19 @@ class GlobalFilter:
             if filter.uuid in self.matched_filter_uuids:
                 continue
             message = f"Filter feature '{filter.name}' matched no feature group."
-            # SingleFilter.name reads through to filter_feature.name, which is what the recorders key on.
-            nearest = self._nearest_miss(filter.name)
+            nearest = self._nearest_miss(filter)
             if nearest is not None:
                 message += f" Nearest miss: {nearest}"
             logger.warning(message)
 
-    def _nearest_miss(self, filter_feature_name: str) -> str | None:
+    def _nearest_miss(self, filter: SingleFilter) -> str | None:
         """The captured fact of the deepest gate this filter reached, as the shared near-miss bullet."""
-        # The ledger keys on the name, so a name two declared filters share makes every fact under it
-        # unattributable to either of them.
-        if sum(1 for filter in self.filters if filter.name == filter_feature_name) > 1:
-            return None
+        # Keyed on the filter's uuid, so a column two filters share no longer makes either one's facts
+        # unattributable; each declaration is explained on its own.
         captured = [
             (feature_group, elimination)
-            for (feature_group, name), elimination in self.dropped_filters.items()
-            if name == filter_feature_name
+            for (feature_group, _name, filter_uuid), elimination in self.dropped_filters.items()
+            if filter_uuid == filter.uuid
         ]
         if not captured:
             return None
@@ -327,22 +327,31 @@ class GlobalFilter:
         )
         if probe.matcher_error is not None:
             reason = contained_raise_reason(probe.matcher_error)
-            self._record_dropped_filter(feature_group, str(filter.filter_feature.name), reason)
+            self._record_dropped_filter(feature_group, filter, reason)
             return False
         # value_rejection is excluded: its returned is the containment's synthetic None, not the hook's.
         if probe.value_rejection is None and not probe.matched and not isinstance(probe.returned, bool):
-            self._report_falsy_match(feature_group, str(filter.filter_feature.name), probe.returned)
+            self._report_falsy_match(feature_group, filter, probe.returned)
         if probe.rejection is not None:
-            self._record_rejected_filter(feature_group, str(filter.filter_feature.name), probe.rejection)
+            self._record_rejected_filter(feature_group, filter, probe.rejection)
             return False
         return probe.matched
 
+    @staticmethod
+    def _ledger_key(feature_group: type[FeatureGroup], filter: SingleFilter) -> tuple[type[FeatureGroup], str, UUID]:
+        """One key per declaration against one feature group.
+
+        The uuid carries the identity, so two filters over one column no longer collapse into a single
+        entry. The name rides along because the ledger is read by humans and named in the docs.
+        """
+        return (feature_group, str(filter.filter_feature.name), filter.uuid)
+
     def _record_near_miss(
-        self, feature_group: type[FeatureGroup], filter_feature_name: str, stage: EliminationStage, reason: str
+        self, feature_group: type[FeatureGroup], filter: SingleFilter, stage: EliminationStage, reason: str
     ) -> None:
         """Record the gate one filter lost at against one feature group; the deepest gate reached keeps the key,
         matching how `_nearest_miss` reads the ledger back."""
-        key = (feature_group, filter_feature_name)
+        key = self._ledger_key(feature_group, filter)
         stored = self.dropped_filters.get(key)
         # A stored defect stays pinned to its key, and equal depth keeps the first fact recorded.
         if stored is None or (
@@ -351,41 +360,49 @@ class GlobalFilter:
             self.dropped_filters[key] = Elimination(stage=stage, reason=reason)
 
     def _record_rejected_filter(
-        self, feature_group: type[FeatureGroup], filter_feature_name: str, rejection: MatchRejection
+        self, feature_group: type[FeatureGroup], filter: SingleFilter, rejection: MatchRejection
     ) -> None:
         """Record a typed decline in the same ledger at DEBUG: a deliberate rejection is a near-miss, not a defect."""
-        self._record_near_miss(
-            feature_group, filter_feature_name, rejection_elimination_stage(rejection.stage), rejection.reason
-        )
+        self._record_near_miss(feature_group, filter, rejection_elimination_stage(rejection.stage), rejection.reason)
         logger.debug(
             "%s rejected filter feature '%s': %s; dropping that filter for this feature group.",
             # A plugin-owned read past the hook call's containment, so it degrades instead of escaping the seam.
             safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
-            filter_feature_name,
+            str(filter.filter_feature.name),
             rejection.reason,
         )
 
-    def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
-        """Record the drop: defect drops warn once per key and take the key from a stored near-miss."""
-        key = (feature_group, filter_feature_name)
-        first = key not in self._warned_drops
-        self._warned_drops.add(key)
-        if first:
+    def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter: SingleFilter, reason: str) -> None:
+        """Record the drop: defect drops warn once per group and filter feature, and take the ledger key
+        from a stored near-miss.
+
+        The two decisions are separate. The WARNING dedupes on the name, as documented. The ledger write
+        dedupes on this filter's own entry, so a second filter over the same column still records its
+        defect; a repeat defect for the same filter must not rewrite the reason already stored.
+        """
+        filter_name = str(filter.filter_feature.name)
+        warn_key = (feature_group, filter_name)
+        first = warn_key not in self._warned_drops
+        self._warned_drops.add(warn_key)
+
+        key = self._ledger_key(feature_group, filter)
+        stored = self.dropped_filters.get(key)
+        if stored is None or stored.stage != "matcher_error":
             self.dropped_filters[key] = Elimination(stage="matcher_error", reason=reason)
         logger.log(
             logging.WARNING if first else logging.DEBUG,
             "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
             feature_group.get_class_name(),
             reason,
-            filter_feature_name,
+            str(filter.filter_feature.name),
         )
 
-    def _report_falsy_match(self, feature_group: type[FeatureGroup], filter_feature_name: str, returned: Any) -> None:
+    def _report_falsy_match(self, feature_group: type[FeatureGroup], filter: SingleFilter, returned: Any) -> None:
         """Report the detached filter: WARNING on a key's first report, DEBUG after, like `_record_dropped_filter`.
 
         Both fields are plugin-owned reads and this runs past the hook call's containment, so each degrades alone.
         """
-        key = (feature_group, filter_feature_name)
+        key = (feature_group, str(filter.filter_feature.name))
         first = key not in self._reported_falsy_matches
         self._reported_falsy_matches.add(key)
         logger.log(
@@ -395,7 +412,7 @@ class GlobalFilter:
             safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
             # The type name only: the value's own __repr__ is plugin code and must not run here.
             safe_field(lambda: type(returned).__name__, "<unreadable type>"),
-            filter_feature_name,
+            str(filter.filter_feature.name),
         )
 
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:

--- a/tests/test_core/test_filter/test_filter_elimination_reasons.py
+++ b/tests/test_core/test_filter/test_filter_elimination_reasons.py
@@ -1062,21 +1062,37 @@ class TestEveryMatchReportIsScopedToOneSetup:
         )
 
 
-class TestTwoFiltersOnOneNameAttributeNothing:
-    """The ledger keys on the filter feature NAME, so a shared name cannot attribute a fact to one filter."""
+class TestTwoFiltersOnOneNameAreExplainedIndependently:
+    """The ledger keys on the filter's uuid, so a shared name still attributes each fact to its own filter."""
 
-    def test_both_warnings_are_the_bare_sentence(self, caplog: pytest.LogCaptureFixture) -> None:
-        """One filter loses at scope and the other at the pin; neither message may quote the other's fact."""
+    def test_each_warning_quotes_its_own_fact(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One filter loses at scope and the other at the pin; each message quotes its own gate."""
+        from mloda.core.prepare.resolution_failure_renderer import near_miss_text
+
         snapshot = _drive_shared_name(caplog, _losing_pair())
 
         assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
         assert snapshot.names == (), f"neither filter may attach, got: {snapshot.names}"
-        assert snapshot.unmatched == (BARE_MESSAGE, BARE_MESSAGE), (
-            f"an unattributable fact must not be quoted, got: {snapshot.unmatched}"
+
+        scope_expected = (
+            f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{near_miss_text(PLAIN_CLASS_NAME, SCOPE_STAGE, SCOPE_REASON)}"
+        )
+        pin_prefix = f"{BARE_MESSAGE} {NEAREST_MISS_PHRASE}{PLAIN_CLASS_NAME} ({_STAGE_LABELS[FRAMEWORK_PIN_STAGE]}):"
+
+        # Both filters carry one name, so warn_on_unmatched_filters' sort key cannot order them: assert unordered.
+        assert len(snapshot.unmatched) == 2, f"one warning per declared filter, got: {snapshot.unmatched}"
+        assert scope_expected in snapshot.unmatched, (
+            f"the scope-losing filter must quote its own scope fact, got: {snapshot.unmatched}"
+        )
+        assert any(message.startswith(pin_prefix) for message in snapshot.unmatched), (
+            f"the pinned filter must quote its own framework-pin fact, got: {snapshot.unmatched}"
+        )
+        assert BARE_MESSAGE not in snapshot.unmatched, (
+            f"no filter may be left without a reason now that facts are attributable, got: {snapshot.unmatched}"
         )
 
     def test_one_filter_on_that_name_still_names_its_nearest_miss(self, caplog: pytest.LogCaptureFixture) -> None:
-        """The guard covers the ambiguous case only: a single filter still gets its suffix."""
+        """The single-filter case is unchanged by the re-keying."""
         from mloda.core.prepare.resolution_failure_renderer import near_miss_text
 
         snapshot = _drive_shared_name(caplog, (_filter_feature(scope=MISSING_SCOPE),))
@@ -1085,10 +1101,11 @@ class TestTwoFiltersOnOneNameAttributeNothing:
         assert snapshot.unmatched == (expected,), f"one filter on the name keeps its suffix, got: {snapshot.unmatched}"
 
     def test_the_pair_renders_the_same_way_on_every_run(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Which of the two facts the ledger keeps rides set iteration order; the messages must not."""
-        runs = tuple(_drive_shared_name(caplog, _losing_pair()).unmatched for _ in range(REPEAT_RUNS))
+        """Both facts are stored now, so set iteration order can no longer decide which one survives."""
+        runs = tuple(frozenset(_drive_shared_name(caplog, _losing_pair()).unmatched) for _ in range(REPEAT_RUNS))
 
-        assert set(runs) == {(BARE_MESSAGE, BARE_MESSAGE)}, f"the runs diverged: {sorted(set(runs))}"
+        assert len(set(runs)) == 1, f"the runs diverged: {[sorted(run) for run in sorted(set(runs), key=sorted)]}"
+        assert len(runs[0]) == 2, f"each run must report both filters, got: {sorted(runs[0])}"
 
 
 class TestTheDeepestFactKeepsTheKey:

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -276,14 +276,16 @@ def _drive_criteria(
     global_filter = GlobalFilter()
     ledger: Optional[dict[Any, Any]] = None
     items: list[tuple[Any, Any]] = []
+    # ONE filter across every call: the ledger keys on the filter's uuid, so a fresh SingleFilter per call
+    # would be a fresh declaration rather than a repeat. identify_matched_filters likewise deepcopies the
+    # stored filter, which carries its uuid, so this is the shape a real repeat has.
+    single = _single(filter_feature_name, options)
     try:
         results: list[Optional[bool]] = []
         escaped: Optional[str] = None
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
             for _ in range(calls):
-                value, failure = _capture_type_name(
-                    partial(global_filter.criteria, fg, _single(filter_feature_name, options), None)
-                )
+                value, failure = _capture_type_name(partial(global_filter.criteria, fg, single, None))
                 results.append(value)
                 if failure is not None:
                     escaped = failure
@@ -294,7 +296,7 @@ def _drive_criteria(
             results=tuple(results),
             escaped=escaped,
             has_ledger=ledger is not None,
-            keyed_by_group_and_filter=ledger is not None and (fg, filter_feature_name) in ledger,
+            keyed_by_group_and_filter=ledger is not None and (fg, filter_feature_name, single.uuid) in ledger,
             entries=tuple((str(key[0].get_class_name()), str(key[1])) for key, _ in items),
             reasons=tuple(str(_reason_of(recorded)) for _, recorded in items),
             reason_types=tuple(type(_reason_of(recorded)).__name__ for _, recorded in items),

--- a/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
+++ b/tests/test_core/test_filter/test_filter_matcher_rejection_taxonomy.py
@@ -494,12 +494,15 @@ def _drive_criteria(make: _RtxFactory, caplog: pytest.LogCaptureFixture, calls: 
     fg, read_window = make()
     global_filter = GlobalFilter()
     items: list[tuple[Any, Any]] = []
+    # ONE filter across every call: the ledger keys on the filter's uuid, so a fresh SingleFilter per call
+    # would be a fresh declaration rather than a repeat against the same key.
+    single = _single(FILTER_FEATURE)
     try:
         value: Any = None
         escaped: str | None = None
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
             for _ in range(calls):
-                value, call_escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+                value, call_escaped = _capture(partial(global_filter.criteria, fg, single, None))
                 escaped = escaped or call_escaped
         items = sorted(global_filter.dropped_filters.items(), key=lambda item: str(item[0]))
         return _RtxCriteriaSnapshot(


### PR DESCRIPTION
Closes #1074.

## Reproduced first

Two filters on `price`, one losing at the scope gate and one at the framework pin gate:

**Before**

```
declared filters: 2
  max   name='price' uuid=2b97882f-…
  min   name='price' uuid=de2b0bf2-…

dropped_filters entries: 1        <- one of the two facts is simply gone
  key=(PriceScope, 'price')
    stage='framework_pin' …

nearest miss per declared filter:
  max   -> None
  min   -> None                   <- the shared-name guard withholds both
```

**After**

```
dropped_filters entries: 2
  key=(PriceScope, 'price', UUID('2b97882f-…'))  stage='framework_pin' …
  key=(PriceScope, 'price', UUID('de2b0bf2-…'))  stage='scope' …

nearest miss per declared filter:
  max   -> "PriceScope (compute framework pin): pinned compute framework 'PyArrowTable' is not the feature's resolved 'PandasDataFrame'"
  min   -> 'PriceScope (scope): outside the requested feature group scope'
```

## The key

`(FeatureGroup, filter feature name, filter uuid)`.

The uuid carries the identity. The name stays in the key on purpose: the ledger is user-facing, exported through `mloda.user` and named in the docs, and keeping it means existing readers of `key[1]` keep working. `_nearest_miss` selects by uuid, and the shared-name guard is gone.

`identify_matched_filters` deepcopies the stored filter before running the gates, so the fix depends on `deepcopy` preserving the uuid. Verified explicitly rather than assumed:

```
original uuid : f78b282d-c41d-4917-bcd3-b2a142aa6767
deepcopy uuid : f78b282d-c41d-4917-bcd3-b2a142aa6767
equal / hash / key identical : True True True
```

## Deliberately *not* re-keyed

`_warned_drops` and `_reported_falsy_matches` dedupe **log lines**, and `filter_data.md` documents that as "once per FeatureGroup and filter feature". I re-keyed them at first and it broke four tests for the right reason — so they stay name-keyed.

That leaves a coupling to break: `_record_dropped_filter` used one `first` flag for both the WARNING level *and* whether to write the ledger. Name-keyed dedupe would have suppressed the second filter's ledger entry. The two decisions are now separate — the WARNING dedupes on the name, the ledger write dedupes on this filter's own stored entry (`stored is None or stored.stage != "matcher_error"`), so a repeat defect still cannot rewrite a stored reason.

## Tests

| test | change |
| --- | --- |
| `TestTwoFiltersOnOneNameAttributeNothing` | pinned the withheld reason — the behaviour the DoD removes. Renamed `TestTwoFiltersOnOneNameAreExplainedIndependently`; each filter now must quote its own fact, and none may be left bare. |
| `test_the_pair_renders_the_same_way_on_every_run` | both facts are stored now, so it compares frozensets over 8 runs instead of pinning one bare-message tuple. |
| `_drive_criteria` (containment + rejection taxonomy) | built a **fresh** `SingleFilter` per call, which under uuid keying is a fresh declaration rather than a repeat. Both now reuse one filter across the calls loop — what "repeat drops of one key" means, and what `identify_matched_filters` actually does. |
| containment key-shape helper | checks the 3-tuple. |

Both filters in the pair share a name, so `warn_on_unmatched_filters`' sort key cannot order them and the two warnings arrive in set-iteration order; the assertions are unordered for that reason.

## Verification

| suite | result |
| --- | --- |
| `tests/test_core/test_filter` | **513 passed** |
| `tests/test_core` + `test_docs_fences.py` | 5204 passed, 4 xfailed, **1 failed — pre-existing** |

The one failure is `test_docs_fences::test_illustrative_py_blocks_match_allowlist`. It fails on a clean tree too. Since this branch edits a doc page, I diffed that test's per-file ` ```py ` counts with and without the `filter_data.md` edit — **identical**, so the edit is not implicated.

`ruff format --check --line-length 120` (993 files), `ruff check`, `mypy --strict --ignore-missing-imports mloda/` (140 files) all clean.

## Docs

`filter_data.md` records the new key shape and the per-declaration attribution, and drops the paragraph stating that two filters on one column leave both reports bare.
