### PR TITLE
fix: detect a worker that exits while steps are still assigned to it

### DIFF
--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -306,3 +306,6 @@ class ComputeFrameworkExecutor:
             process, command_queue, result_queue = existing
 
         self.worker_manager.send_command(cfw_uuid, step)
+        # Record the assignment so a worker that exits still owing these results is
+        # detectable, including the clean exit the data-drop path produces.
+        self.worker_manager.record_assignment(cfw_uuid, set(step.get_uuids()))

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -154,6 +154,15 @@ class ExecutionOrchestrator:
             dead = self.worker_manager.find_dead_workers()
             if dead:
                 raise MlodaRunError(f"Worker process(es) died unexpectedly: {dead}")
+            # A clean exit is invisible above, so check assignments too: a worker that is
+            # gone will never answer, and waiting on it hangs the run instead of failing it.
+            orphaned = self.worker_manager.find_orphaned_steps()
+            if orphaned:
+                detail = "; ".join(
+                    f"cfw {cfw_uuid} exited with code {exitcode} owing step(s) {', '.join(str(step) for step in steps)}"
+                    for cfw_uuid, exitcode, steps in orphaned
+                )
+                raise MlodaRunError(f"Worker process(es) exited with steps still assigned: {detail}")
             return False
         return True
 

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -23,6 +23,10 @@ class WorkerManager:
         self.process_register: dict[UUID, tuple[Any, Any, Any]] = {}
         self.result_queues_collection: set[Any] = set()
         self.result_uuids_collection: set[UUID] = set()
+        # cfw_uuid -> step uuids dispatched to that worker. Needed because a worker that
+        # exits cleanly is invisible to find_dead_workers, so the only way to notice the
+        # loss is that steps were assigned to it and no result ever arrived.
+        self.assigned_steps: dict[UUID, set[UUID]] = {}
 
     def add_thread_task(self, task: threading.Thread) -> None:
         """Add task to list and call task.start()."""
@@ -72,6 +76,10 @@ class WorkerManager:
             if isinstance(msg, str):
                 self.result_uuids_collection.add(UUID(msg))
 
+    def record_assignment(self, cfw_uuid: UUID, step_uuids: set[UUID]) -> None:
+        """Remember that these steps were dispatched to this worker."""
+        self.assigned_steps.setdefault(cfw_uuid, set()).update(step_uuids)
+
     def find_dead_workers(self) -> list[tuple[UUID, int]]:
         """Return (cfw_uuid, exitcode) for workers that died abnormally (exitcode not in {None, 0})."""
         dead: list[tuple[UUID, int]] = []
@@ -80,6 +88,29 @@ class WorkerManager:
             if exitcode is not None and exitcode != 0:
                 dead.append((cfw_uuid, exitcode))
         return dead
+
+    def find_orphaned_steps(self) -> list[tuple[UUID, int, list[UUID]]]:
+        """Return (cfw_uuid, exitcode, orphaned step uuids) per exited worker still owing results.
+
+        Complements ``find_dead_workers``, which only reports a non-zero exitcode. A worker
+        that takes the data-drop path breaks its own loop and exits with code 0, so it is
+        invisible there while the steps dispatched to it stay in ``currently_running_steps``
+        forever and the run loop waits on a process that is gone.
+
+        Any exitcode counts here, including 0: once a process has exited it will never
+        produce a result, so an assigned step with no result is lost whatever the code.
+        Results are checked against ``result_uuids_collection``, so a step whose result
+        arrived before the exit is not reported.
+        """
+        orphaned: list[tuple[UUID, int, list[UUID]]] = []
+        for cfw_uuid, (process, _, _) in self.process_register.items():
+            exitcode = process.exitcode
+            if exitcode is None:
+                continue
+            pending = self.assigned_steps.get(cfw_uuid, set()) - self.result_uuids_collection
+            if pending:
+                orphaned.append((cfw_uuid, exitcode, sorted(pending, key=str)))
+        return orphaned
 
     def is_step_done(self, step_uuid: UUID) -> bool:
         """Return step_uuid in result_uuids_collection."""

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -843,6 +843,9 @@ class TestMultiExecuteStep:
         step.children_if_root = []
         step.compute_framework = Mock()
         step.compute_framework.get_class_name.return_value = "TestCFW"
+        # multi_execute_step records the dispatch, so the step must answer get_uuids()
+        # with real uuids like a FeatureGroupStep does.
+        step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
@@ -871,6 +874,9 @@ class TestMultiExecuteStep:
         step.children_if_root = []
         step.compute_framework = Mock()
         step.compute_framework.get_class_name.return_value = "TestCFW"
+        # multi_execute_step records the dispatch, so the step must answer get_uuids()
+        # with real uuids like a FeatureGroupStep does.
+        step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
@@ -904,6 +910,9 @@ class TestMultiExecuteStep:
         step.children_if_root = []
         step.compute_framework = Mock()
         step.compute_framework.get_class_name.return_value = "TestCFW"
+        # multi_execute_step records the dispatch, so the step must answer get_uuids()
+        # with real uuids like a FeatureGroupStep does.
+        step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
@@ -932,6 +941,9 @@ class TestMultiExecuteStep:
         step.children_if_root = []
         step.compute_framework = Mock()
         step.compute_framework.get_class_name.return_value = "TestCFW"
+        # multi_execute_step records the dispatch, so the step must answer get_uuids()
+        # with real uuids like a FeatureGroupStep does.
+        step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
@@ -956,6 +968,9 @@ class TestMultiExecuteStep:
         step.from_framework = Mock()
         step.from_framework.get_class_name.return_value = "FromCFW"
         step.required_uuids = [uuid4()]
+        # multi_execute_step records the dispatch, so the step must answer get_uuids()
+        # with real uuids like a TransformFrameworkStep does.
+        step.get_uuids.return_value = {uuid4()}
 
         from_cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.side_effect = [from_cfw_uuid, from_cfw_uuid]

--- a/tests/test_core/test_runtime/test_worker_manager.py
+++ b/tests/test_core/test_runtime/test_worker_manager.py
@@ -408,6 +408,106 @@ class TestWorkerManagerDeadWorkerDetection:
         assert manager.find_dead_workers() == []
 
 
+class TestWorkerManagerOrphanedStepDetection:
+    """A worker that exits while steps are still assigned to it must be detectable.
+
+    find_dead_workers only reports a non-zero exitcode. The data-drop path breaks the
+    worker loop and the process exits with code 0, so it is invisible there while the steps
+    dispatched to it stay in currently_running_steps with no result ever arriving.
+    """
+
+    @staticmethod
+    def _exited(manager: WorkerManager, exitcode: int) -> UUID:
+        """Register a worker whose process has already exited with *exitcode*."""
+        cfw_uuid = uuid4()
+        process = MagicMock()
+        process.exitcode = exitcode
+        process.is_alive.return_value = False
+        manager.process_register[cfw_uuid] = (process, MagicMock(), MagicMock())
+        return cfw_uuid
+
+    def test_a_clean_exit_owing_a_step_is_reported(self) -> None:
+        """Exitcode 0 is the case find_dead_workers cannot see, so it is the case that matters."""
+        manager = WorkerManager()
+        cfw_uuid = self._exited(manager, 0)
+        step_uuid = uuid4()
+        manager.record_assignment(cfw_uuid, {step_uuid})
+
+        # Premise: the existing check stays silent, which is why this one has to exist.
+        assert manager.find_dead_workers() == []
+
+        assert manager.find_orphaned_steps() == [(cfw_uuid, 0, [step_uuid])]
+
+    def test_an_abnormal_exit_owing_a_step_is_reported_too(self) -> None:
+        """Any exitcode counts: an exited process will never answer, whatever the code."""
+        manager = WorkerManager()
+        cfw_uuid = self._exited(manager, -9)
+        step_uuid = uuid4()
+        manager.record_assignment(cfw_uuid, {step_uuid})
+
+        assert manager.find_orphaned_steps() == [(cfw_uuid, -9, [step_uuid])]
+
+    def test_a_step_whose_result_already_arrived_is_not_reported(self) -> None:
+        """The worker finished its work and then exited; nothing was lost."""
+        manager = WorkerManager()
+        cfw_uuid = self._exited(manager, 0)
+        step_uuid = uuid4()
+        manager.record_assignment(cfw_uuid, {step_uuid})
+        manager.result_uuids_collection.add(step_uuid)
+
+        assert manager.find_orphaned_steps() == []
+
+    def test_only_the_steps_still_owed_are_named(self) -> None:
+        """A partially-drained worker reports the remainder, not everything it was sent."""
+        manager = WorkerManager()
+        cfw_uuid = self._exited(manager, 0)
+        done, pending = uuid4(), uuid4()
+        manager.record_assignment(cfw_uuid, {done, pending})
+        manager.result_uuids_collection.add(done)
+
+        assert manager.find_orphaned_steps() == [(cfw_uuid, 0, [pending])]
+
+    def test_a_live_worker_is_never_orphaned(self) -> None:
+        """A running worker still owes results; that is work in progress, not a loss."""
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+        process = MagicMock()
+        process.exitcode = None
+        process.is_alive.return_value = True
+        manager.process_register[cfw_uuid] = (process, MagicMock(), MagicMock())
+        manager.record_assignment(cfw_uuid, {uuid4()})
+
+        assert manager.find_orphaned_steps() == []
+
+    def test_an_exited_worker_with_no_assignments_is_not_reported(self) -> None:
+        """A worker stopped after draining its queue exits owing nothing."""
+        manager = WorkerManager()
+        self._exited(manager, 0)
+
+        assert manager.find_orphaned_steps() == []
+
+    def test_record_assignment_accumulates_across_dispatches(self) -> None:
+        """multi_execute_step runs once per step, so assignments must union, not replace."""
+        manager = WorkerManager()
+        cfw_uuid = self._exited(manager, 0)
+        first, second = uuid4(), uuid4()
+        manager.record_assignment(cfw_uuid, {first})
+        manager.record_assignment(cfw_uuid, {second})
+
+        assert manager.assigned_steps[cfw_uuid] == {first, second}
+        assert manager.find_orphaned_steps() == [(cfw_uuid, 0, sorted([first, second], key=str))]
+
+    def test_each_exited_worker_is_reported_separately(self) -> None:
+        """The run loop names every affected cfw, not only the first one found."""
+        manager = WorkerManager()
+        first_cfw = self._exited(manager, 0)
+        second_cfw = self._exited(manager, 0)
+        manager.record_assignment(first_cfw, {uuid4()})
+        manager.record_assignment(second_cfw, {uuid4()})
+
+        assert {entry[0] for entry in manager.find_orphaned_steps()} == {first_cfw, second_cfw}
+
+
 class TestWorkerManagerDropCompletion:
     """Test waiting for drop completion messages."""
 


### PR DESCRIPTION
Closes #1087.

## The hang

A worker taking the data-drop path runs `_handle_stop_command`, breaks its loop, and exits with **code 0**. `find_dead_workers` filters on `exitcode not in {None, 0}`, so that exit is invisible — the step dispatched to the worker stays in `currently_running_steps`, no result ever arrives, and the run loop waits on a process that is gone. As the issue notes, the new stall guard treats an in-flight step as progress on purpose, so this hang class needs its own detection.

## The change

`WorkerManager` gains `assigned_steps: dict[UUID, set[UUID]]`, recorded by `multi_execute_step` immediately after `send_command` — which is also the path that reuses `existing` queues with no liveness check, so a step dispatched to an already-dead process is covered by the same ledger.

`find_orphaned_steps()` returns `(cfw_uuid, exitcode, still-owed step uuids)` for every worker whose process has exited, and `_check_for_error` raises:

```
MlodaRunError: Worker process(es) exited with steps still assigned:
cfw <uuid> exited with code 0 owing step(s) <uuid>, <uuid>
```

Two deliberate choices:

- **Any exitcode counts, including 0.** Once a process has exited it will never produce a result, so an assigned step with no result is lost whatever the code. Restricting to 0 would just move the blind spot.
- **Checked against `result_uuids_collection`.** A worker that finished its work and then exited owes nothing and is not reported, so a normal shutdown stays quiet.

## Verification

8 tests in `TestWorkerManagerOrphanedStepDetection` covering: clean exit owing a step, abnormal exit owing a step, result-already-arrived, partially-drained worker, live worker, exited worker owing nothing, assignment accumulation across dispatches, and multiple affected cfws.

**Mutation check** — restored the original predicate (`if exitcode is None or exitcode == 0: continue`), i.e. reintroduced exactly the bug:

```
FAILED ...::test_a_clean_exit_owing_a_step_is_reported
FAILED ...::test_only_the_steps_still_owed_are_named
FAILED ...::test_record_assignment_accumulates_across_dispatches
FAILED ...::test_each_exited_worker_is_reported_separately
4 failed, 40 passed
```

The clean-exit test also asserts `find_dead_workers() == []` inline, so if that check ever starts catching this case the test says so instead of quietly duplicating coverage.

`tests/test_core`: **5201 passed, 4 xfailed**, run serially.

## Two notes

**A test-only fix rode along.** `TestMultiExecuteStep` builds `Mock(spec=FeatureGroupStep)` / `Mock(spec=TransformFrameworkStep)` steps that never stubbed `get_uuids()`. `multi_execute_step` now reads it, and a bare `Mock` is not iterable, so 5 tests there failed — for that reason and no other. Each now returns real uuids, matching what a real step does.

**`-n 8` is unreliable on my machine.** xdist intermittently dies with an `INTERNALERROR ... assert not crashitem` on a *different* test each run (`test_deep_chain_ancestors_no_recursion_error`, then `test_class_source_hash_getsource_wrong_text_identical_bodies_hash_equal`), which cascades into ~30 spurious failures. Serial runs are clean, so the numbers above are serial. Flagging in case you see the same locally — it looks like a worker-crash flake rather than anything in this change.

`ruff format --check --line-length 120`, `ruff check`, `mypy --strict --ignore-missing-imports` all clean.
