### PR TITLE
fix(ci): give the tox step a budget the suite can grow into

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       env:
         PYTEST_WORKERS: 2
       run: tox ${{ matrix.toxenv }}
-      timeout-minutes: 3
+      timeout-minutes: 6
 
   notebooks:
     # Runs the marimo example notebooks; slower than the unit-test matrix.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,10 @@ jobs:
       env:
         PYTEST_WORKERS: 2
       run: tox ${{ matrix.toxenv }}
-      timeout-minutes: 3
+      # Catches a wedged job, not a slow one. A green full env already spends ~3.5 minutes here (uv sync, ~9000
+      # tests over 2 workers, then mypy and bandit), so a budget that close to the runtime turns every test the
+      # suite gains into a red gate. Per-test hangs stay covered by pytest's own --timeout=10.
+      timeout-minutes: 6
 
   notebooks:
     # Runs the marimo example notebooks; slower than the unit-test matrix.

--- a/tests/helpers/probe_runner.py
+++ b/tests/helpers/probe_runner.py
@@ -9,21 +9,38 @@ _PROBE_TIMEOUT = 30.0
 
 
 def run_probes(probe: Path, count: int) -> list[dict[str, str]]:
-    """Run ``probe`` ``count`` times, each in its own interpreter, and parse the one json line it prints."""
+    """Run ``probe`` ``count`` times, each in its own interpreter, and parse the one json line it prints.
+
+    The interpreters start together rather than one after the other. Each one is cold, so starting them in
+    sequence costs the sum of every import, which is what the callers pay for on the gate. Isolation is
+    unchanged: a probe still decides alone, in a process that shares no state with the others.
+    """
     assert probe.is_file(), f"{probe} does not exist"
 
-    outputs: list[dict[str, str]] = []
-    for _ in range(count):
+    processes = [
         # Safe: fixed argv, no shell, no user input.
-        completed = subprocess.run(  # nosec B603
+        subprocess.Popen(  # nosec B603
             [sys.executable, str(probe)],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=_PROBE_TIMEOUT,
         )
-        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
-        lines = [line for line in completed.stdout.splitlines() if line.strip()]
-        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
-        parsed: dict[str, str] = json.loads(lines[0])
-        outputs.append(parsed)
+        for _ in range(count)
+    ]
+
+    outputs: list[dict[str, str]] = []
+    try:
+        for process in processes:
+            stdout, stderr = process.communicate(timeout=_PROBE_TIMEOUT)
+            assert process.returncode == 0, f"probe interpreter failed:\n{stderr}"
+            lines = [line for line in stdout.splitlines() if line.strip()]
+            assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {stdout!r}"
+            parsed: dict[str, str] = json.loads(lines[0])
+            outputs.append(parsed)
+    finally:
+        # A raise above leaves the later probes running; subprocess.run reaped its child on every exit, and a
+        # leaked interpreter would outlive the xdist worker that started it.
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
     return outputs

--- a/tests/helpers/probe_runner.py
+++ b/tests/helpers/probe_runner.py
@@ -12,18 +12,28 @@ def run_probes(probe: Path, count: int) -> list[dict[str, str]]:
     """Run ``probe`` ``count`` times, each in its own interpreter, and parse the one json line it prints."""
     assert probe.is_file(), f"{probe} does not exist"
 
-    outputs: list[dict[str, str]] = []
-    for _ in range(count):
+    processes = [
         # Safe: fixed argv, no shell, no user input.
-        completed = subprocess.run(  # nosec B603
+        subprocess.Popen(  # nosec B603
             [sys.executable, str(probe)],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=_PROBE_TIMEOUT,
         )
-        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
-        lines = [line for line in completed.stdout.splitlines() if line.strip()]
-        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
-        parsed: dict[str, str] = json.loads(lines[0])
-        outputs.append(parsed)
+        for _ in range(count)
+    ]
+
+    outputs: list[dict[str, str]] = []
+    try:
+        for process in processes:
+            stdout, stderr = process.communicate(timeout=_PROBE_TIMEOUT)
+            assert process.returncode == 0, f"probe interpreter failed:\n{stderr}"
+            lines = [line for line in stdout.splitlines() if line.strip()]
+            assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {stdout!r}"
+            parsed: dict[str, str] = json.loads(lines[0])
+            outputs.append(parsed)
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
     return outputs

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -40,6 +40,10 @@ MODES_SYNC_THREADING = pytest.mark.parametrize(
     [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}],
 )
 
+# Carried by the left join alone. Each run spawns one cold interpreter per step, which makes a run here the most
+# expensive shape in the suite, and what the mode adds is the flight hop, not the join semantics the other two
+# modes already pin per join type. The left join is the shape that proves the most over that hop: its expectation
+# is the inner one plus the unmatched rows, so a padded cell has to survive the round trip as well as the order.
 MODES_WITH_MULTIPROCESSING = pytest.mark.parametrize(
     "modes",
     [
@@ -299,7 +303,7 @@ RIGHT_SIDE_BINDING_REASON = (
 )
 
 
-@MODES_WITH_MULTIPROCESSING
+@MODES_SYNC_THREADING
 def test_inner_join_declared_orientation_keeps_left_group_first(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -299,7 +299,7 @@ RIGHT_SIDE_BINDING_REASON = (
 )
 
 
-@MODES_WITH_MULTIPROCESSING
+@MODES_SYNC_THREADING
 def test_inner_join_declared_orientation_keeps_left_group_first(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:


### PR DESCRIPTION
The full envs (`python310`, `python311`, `python312`) are timing out on `main`. Nothing is broken: pytest, ruff and mypy all pass, and the step is killed partway through bandit by `timeout-minutes: 3`.

## What actually happened

The step budget was set when the suite was a fraction of its size and never revisited. Its non-pytest content is fixed cost:

| segment | time |
| --- | --- |
| `uv sync` + freeze | ~28s |
| pytest | see below |
| ruff, pip-licenses | ~1s |
| mypy `--strict` | ~21s |
| bandit | ~14s |

That leaves pytest about 116s of the 180s. The last green run on `main` spent **107.7s** there, so the gate was already 93% full. This week the suite went from 8815 to 8970 tests and pytest from **107.7s to 150s**, which puts the step at ~3m25s.

Most of the new pytest time sits in a handful of tests that start processes, not in the ~150 new assertions. Total work under `-n 8`:

| test | work | origin |
| --- | --- | --- |
| `test_inner_join_declared_orientation_keeps_left_group_first[MULTIPROCESSING]` | 13.2s | new in `badffc57` |
| `test_left_join_declared_orientation_keeps_every_left_row[MULTIPROCESSING]` | 13.0s | new in `badffc57` |
| `test_fresh_interpreters_reduce_to_the_same_frameworks` | 11.5s | pre-existing |
| `test_fresh_interpreters_plan_the_same_link_orientation` | 5.2s | new in `badffc57` |

## The changes

**`timeout-minutes: 3` -> `6`.** This is the part that makes the gate green. A step timeout catches a wedged job, not a slow one, and a budget within 10% of the real runtime turns every test the suite gains into a red gate. Per-test hangs stay covered by pytest's own `--timeout=10`.

**`run_probes` starts its interpreters together.** It spawned one cold interpreter at a time and paid for every import in sequence. Isolation is unchanged: a probe still decides alone, in a process that shares no state with the others. The `finally` reaps any probe still running when an assertion fires, which `subprocess.run` used to do on its own.

**The link orientation characterization runs MULTIPROCESSING on one join instead of two.** Each such run spawns a cold interpreter per step, three of them, each importing pandas and pyarrow before it can work; that is what made these the two most expensive tests in the suite. What the mode adds over SYNC and THREADING is the flight hop, not the join semantics, which both other modes already pin per join type. The left join carries it alone because it proves the most over that hop: its expectation is the inner one plus the unmatched rows, so a padded cell has to survive the round trip as well as the row order. Test count goes 8970 -> 8969; skips are unchanged at 170.

## Measurements

The three files `badffc57` touched, alternating old and new on the same machine to cancel drift:

```
before  51 passed, 4 xfailed in 19.77s      after   50 passed, 4 xfailed in 10.89s
before  51 passed, 4 xfailed in 19.71s      after   50 passed, 4 xfailed in 10.87s
before  51 passed, 4 xfailed in 19.34s      after   50 passed, 4 xfailed in 10.86s
```

**Worth knowing before reviewing:** neither speedup is visible in CI wall time. Across the three full envs, pytest measures 150.2/141.5/137.3s on `main` and 158.4/136.9/154.0s here. The runner varies by ±15s between identical runs, which is more than the ~9s these changes remove, and the runner's 2 vCPUs give the concurrent probe spawns nothing to overlap into. The reduction is real and reproducible locally; it is not what makes CI pass. The timeout is.

`tox -e python310` green in a clean worktree: 8969 passed, 170 skipped, 4 xfailed, plus ruff, licenses, `mypy --strict` and bandit.
