### PR TITLE
fix: dedupe filter drop reports by rendered message (#1099)

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -211,8 +211,9 @@ filters for row elimination.
 
 The return is read for truthiness, so any falsy value is a non-match, exactly like `False`: a hook
 that falls off the end of a branch and returns `None` attaches no filter. A falsy value that is not
-`False` is reported once per FeatureGroup and declared filter, so the detached filter is visible;
-return `True` explicitly to keep it.
+`False` is reported so the detached filter is visible; return `True` explicitly to keep it. The
+report names the returned type, and each distinct report is a WARNING once per setup (see
+[Why a filter did not attach](#why-a-filter-did-not-attach)).
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:
@@ -257,6 +258,11 @@ dropped the filter and that gate's reason, for the current engine setup only. A 
 ordinary non-match and records nothing. A matcher defect takes the key from a stored near-miss;
 otherwise the deepest gate the filter reached keeps it, and two facts at one depth leave the first one
 in place.
+
+Both the defect drop and the falsy-return report are WARNINGs, deduplicated per setup on the rendered
+line: a report reading exactly like an earlier one drops to DEBUG, and one that reads differently, a
+new reason under the same column for instance, warns on its own. That dedupe decides the log level
+only; `dropped_filters` records per declaration either way.
 
 The uuid is `SingleFilter.uuid` of the declaration in `GlobalFilter.filters`, which is what joins a
 recorded fact back to the filter that lost. The key previously carried no uuid, so code unpacking it

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -74,9 +74,9 @@ class GlobalFilter:
         self.matched_filter_uuids: set[UUID] = set()
         self._warned_divergences: set[str] = set()
         # Own state, not dropped_filters: a falsy non-bool is an ordinary non-match, never a recorded drop.
-        self._reported_falsy_matches: set[tuple[type[FeatureGroup], str]] = set()
-        # WARNING dedupe for defect drops; the ledger itself no longer decides first-ness.
-        self._warned_drops: set[tuple[type[FeatureGroup], str]] = set()
+        self._reported_falsy_matches: set[str] = set()
+        # WARNING dedupe is based on the rendered line, while the ledger keeps per-declaration state.
+        self._warned_drops: set[str] = set()
 
     def reset_match_tracking(self) -> None:
         """Every match report is scoped to one engine setup, so a later setup names only what it consulted.
@@ -366,37 +366,31 @@ class GlobalFilter:
         )
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
-        """Record the drop: defect drops warn once per key and take the key from a stored near-miss."""
+        """Record the drop: each distinct rendered report warns once."""
         key = (feature_group, filter_feature_name)
-        first = key not in self._warned_drops
-        self._warned_drops.add(key)
+        message = (
+            f"{feature_group.get_class_name()} {reason} while matching filter feature '{filter_feature_name}'; "
+            "dropping that filter for this feature group."
+        )
+        first = message not in self._warned_drops
+        self._warned_drops.add(message)
         if first:
             self.dropped_filters[key] = Elimination(stage="matcher_error", reason=reason)
-        logger.log(
-            logging.WARNING if first else logging.DEBUG,
-            "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
-            feature_group.get_class_name(),
-            reason,
-            filter_feature_name,
-        )
+        logger.log(logging.WARNING if first else logging.DEBUG, message)
 
     def _report_falsy_match(self, feature_group: type[FeatureGroup], filter_feature_name: str, returned: Any) -> None:
-        """Report the detached filter: WARNING on a key's first report, DEBUG after, like `_record_dropped_filter`.
+        """Report the detached filter: each distinct rendered line warns once, like `_record_dropped_filter`.
 
         Both fields are plugin-owned reads and this runs past the hook call's containment, so each degrades alone.
         """
-        key = (feature_group, filter_feature_name)
-        first = key not in self._reported_falsy_matches
-        self._reported_falsy_matches.add(key)
-        logger.log(
-            logging.WARNING if first else logging.DEBUG,
-            "%s returned a falsy non-bool (%s) while matching filter feature '%s'; that filter is not attached. "
-            "Return True explicitly to keep it.",
-            safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
-            # The type name only: the value's own __repr__ is plugin code and must not run here.
-            safe_field(lambda: type(returned).__name__, "<unreadable type>"),
-            filter_feature_name,
+        message = (
+            f"{safe_field(lambda: feature_group.get_class_name(), '<unnamed feature group>')} returned a falsy "
+            f"non-bool ({safe_field(lambda: type(returned).__name__, '<unreadable type>')}) while matching filter "
+            f"feature '{filter_feature_name}'; that filter is not attached. Return True explicitly to keep it."
         )
+        first = message not in self._reported_falsy_matches
+        self._reported_falsy_matches.add(message)
+        logger.log(logging.WARNING if first else logging.DEBUG, message)
 
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:
         # We have matched already the feature group and the feature.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -47,11 +47,6 @@ _STAGE_DEPTH: dict[EliminationStage, int] = {
 # One declared filter against one feature group: the name alone collapses two filters on one column.
 _LedgerKey = tuple[type[FeatureGroup], str, UUID]
 
-# Both reports render from (feature group, reason, filter name) only, so two declarations on one column produce
-# byte-identical lines and repeating one adds no signal. Nothing is lost: the ledger records per declaration
-# unconditionally and no longer derives its write from the report dedupe.
-_ReportKey = tuple[type[FeatureGroup], str]
-
 
 def _copy_feature_leaf(value: Any) -> Any:
     """Detach a Feature leaf from the host; any other leaf stays shared by reference."""
@@ -82,10 +77,12 @@ class GlobalFilter:
         self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
         self.matched_filter_uuids: set[UUID] = set()
         self._warned_divergences: set[str] = set()
-        # Per column, not per declaration: own state, and a falsy non-bool is an ordinary non-match, never a drop.
-        self._reported_falsy_matches: set[_ReportKey] = set()
-        # Per column, not per declaration: a WARNING dedupe; the ledger itself no longer decides first-ness.
-        self._warned_drops: set[_ReportKey] = set()
+        # Keyed on the rendered line, like `_warned_divergences`: a report the reader cannot tell apart from an
+        # earlier one carries no new fact, and anything that does read differently is worth a WARNING of its own.
+        # Own state, not `dropped_filters`: a falsy non-bool is an ordinary non-match, never a recorded drop.
+        self._reported_falsy_matches: set[str] = set()
+        # A WARNING dedupe only. The ledger writes per declaration and never derives its write from this set.
+        self._warned_drops: set[str] = set()
 
     def reset_match_tracking(self) -> None:
         """Every match report is scoped to one engine setup, so a later setup names only what it consulted.
@@ -348,11 +345,6 @@ class GlobalFilter:
         """The declaring filter's own key; the per-match deepcopy carries the declaration's uuid."""
         return feature_group, filter.name, filter.uuid
 
-    @staticmethod
-    def _report_key(feature_group: type[FeatureGroup], filter: SingleFilter) -> _ReportKey:
-        """The column's key, uuid-free: what a report line can tell apart, unlike `_ledger_key`."""
-        return feature_group, filter.name
-
     def _record_near_miss(
         self, feature_group: type[FeatureGroup], filter: SingleFilter, stage: EliminationStage, reason: str
     ) -> None:
@@ -379,40 +371,45 @@ class GlobalFilter:
             rejection.reason,
         )
 
+    @staticmethod
+    def _claim_report_level(reported: set[str], message: str) -> int:
+        """Record the line and name its level: WARNING the first time it reads this way, DEBUG for a repeat.
+
+        The key is the rendered text, so a reason the reader can tell apart is never muted into a repeat.
+        """
+        first = message not in reported
+        reported.add(message)
+        return logging.WARNING if first else logging.DEBUG
+
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter: SingleFilter, reason: str) -> None:
-        """Record the drop over a stored near-miss but never over another defect; `_warned_drops` picks the level."""
+        """Record the drop over a stored near-miss but never over another defect; the rendered line picks the level.
+
+        The ledger keys per declaration and the report on its own text: two declarations on one column that fail
+        the same way read identically and the repeat drops to DEBUG, while a new reason warns on its own.
+        """
         key = self._ledger_key(feature_group, filter)
         stored = self.dropped_filters.get(key)
         if stored is None or stored.stage != "matcher_error":
             self.dropped_filters[key] = Elimination(stage="matcher_error", reason=reason)
-        report_key = self._report_key(feature_group, filter)
-        first = report_key not in self._warned_drops
-        self._warned_drops.add(report_key)
-        logger.log(
-            logging.WARNING if first else logging.DEBUG,
-            "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
-            feature_group.get_class_name(),
-            reason,
-            filter.name,
+        message = (
+            f"{feature_group.get_class_name()} {reason} while matching filter feature '{filter.name}'; "
+            "dropping that filter for this feature group."
         )
+        logger.log(self._claim_report_level(self._warned_drops, message), message)
 
     def _report_falsy_match(self, feature_group: type[FeatureGroup], filter: SingleFilter, returned: Any) -> None:
-        """Report the detached filter: WARNING on a key's first report, DEBUG after, like `_record_dropped_filter`.
+        """Report the detached filter: each distinct rendered line warns once, like `_record_dropped_filter`.
 
         Both fields are plugin-owned reads and this runs past the hook call's containment, so each degrades alone.
         """
-        key = self._report_key(feature_group, filter)
-        first = key not in self._reported_falsy_matches
-        self._reported_falsy_matches.add(key)
-        logger.log(
-            logging.WARNING if first else logging.DEBUG,
-            "%s returned a falsy non-bool (%s) while matching filter feature '%s'; that filter is not attached. "
-            "Return True explicitly to keep it.",
-            safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
-            # The type name only: the value's own __repr__ is plugin code and must not run here.
-            safe_field(lambda: type(returned).__name__, "<unreadable type>"),
-            filter.name,
+        group_name = safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>")
+        # The type name only: the value's own __repr__ is plugin code and must not run here.
+        returned_type = safe_field(lambda: type(returned).__name__, "<unreadable type>")
+        message = (
+            f"{group_name} returned a falsy non-bool ({returned_type}) while matching filter feature "
+            f"'{filter.name}'; that filter is not attached. Return True explicitly to keep it."
         )
+        logger.log(self._claim_report_level(self._reported_falsy_matches, message), message)
 
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:
         # We have matched already the feature group and the feature.

--- a/tests/test_core/test_filter/test_filter_elimination_reasons.py
+++ b/tests/test_core/test_filter/test_filter_elimination_reasons.py
@@ -62,6 +62,8 @@ ORDER_SECOND_FEATURE = "fer_order_feat two"  # its space beats the other's closi
 
 RUNTIME_MESSAGE = "fer_runtime_boom"
 RUNTIME_TYPE_NAME = "RuntimeError"
+FIRST_DEFECT_MESSAGE = "fer_first_boom"  # what a hook raises the first time, so the two reasons read differently
+SECOND_DEFECT_MESSAGE = "fer_second_boom"
 DEFECT_MESSAGE = "fer_defect_after_decline"
 DECLINE_REASON = "fer_decline_reason"
 UNKNOWN_STAGE = "fer_unknown_stage_hint"  # a free-form hint no engine stage knows
@@ -380,6 +382,56 @@ def _make_plain_decline_fg() -> type[FeatureGroup]:
             return str(feature_name) in cls.feature_names_supported()
 
     return FerPlainDeclineFG
+
+
+def _make_varying_defect_fg(reasons: Sequence[str]) -> type[FeatureGroup]:
+    """A throwaway group whose hook raises each of `reasons` once, then repeats the last one for every later call."""
+    gc.collect()
+
+    class FerVaryingDefectFG(FeatureGroup):
+        _pending: ClassVar[list[str]] = list(reasons)
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                raise RuntimeError(cls._pending.pop(0) if len(cls._pending) > 1 else cls._pending[0])
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerVaryingDefectFG
+
+
+def _make_varying_falsy_fg(returns: Sequence[Any]) -> type[FeatureGroup]:
+    """A throwaway group returning each of `returns` once, then repeating the last: the type name is what differs."""
+    gc.collect()
+
+    class FerVaryingFalsyFG(FeatureGroup):
+        _pending: ClassVar[list[Any]] = list(returns)
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> Any:  # Any, not bool: the falsy non-bool return is the case under test.
+            if str(feature_name) == FILTER_FEATURE:
+                return cls._pending.pop(0) if len(cls._pending) > 1 else cls._pending[0]
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerVaryingFalsyFG
 
 
 def _make_falsy_decline_fg() -> type[FeatureGroup]:
@@ -1181,8 +1233,9 @@ class TestTheUnmatchedWarningsAreOrderedByFilterFeatureName:
         assert snapshot.unmatched == expected, f"the filter feature name must order the warnings: {snapshot.unmatched}"
 
 
-class TestTheReportsDedupePerColumnNotPerDeclaration:
-    """Both reports render from the group, the reason and the name alone, so a second declaration adds no line."""
+class TestTheReportsDedupeOnTheRenderedLine:
+    """A report the reader cannot tell apart from an earlier one falls to DEBUG; anything that reads differently
+    is a new fact and warns. The ledger keys per declaration and never derives its write from that dedupe."""
 
     def test_two_defects_on_one_name_record_twice_and_report_once(self, caplog: pytest.LogCaptureFixture) -> None:
         """The ledger keeps its fact per declaration; the byte-identical repeat of the report falls to DEBUG."""
@@ -1209,6 +1262,52 @@ class TestTheReportsDedupePerColumnNotPerDeclaration:
         assert len(reported) == 1, f"the column's detached filter must be reported once, got: {snapshot.warnings}"
         assert _carrying(snapshot.debugs, FALSY_REPORT_FRAGMENT) == reported, (
             f"the repeat is that same line and belongs at DEBUG, got: {snapshot.debugs}"
+        )
+
+    def test_a_defect_reading_differently_warns_instead_of_falling_to_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One column, three drops, two distinct reasons: only the reason that repeats verbatim is muted."""
+        snapshot = _drive_matching(
+            [partial(_make_varying_defect_fg, (FIRST_DEFECT_MESSAGE, SECOND_DEFECT_MESSAGE))], caplog, calls=3
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        reported = _carrying(snapshot.warnings, DROP_REPORT_FRAGMENT)
+        assert len(reported) == 2, f"each distinct reason must warn on its own, got: {snapshot.warnings}"
+        assert FIRST_DEFECT_MESSAGE in reported[0], f"the first reason must be reported: {reported[0]}"
+        assert SECOND_DEFECT_MESSAGE in reported[1], f"the second reason must be reported: {reported[1]}"
+        assert _carrying(snapshot.debugs, DROP_REPORT_FRAGMENT) == (reported[1],), (
+            f"only the verbatim repeat belongs at DEBUG, got: {snapshot.debugs}"
+        )
+
+    def test_the_pinned_defect_survives_a_second_defect_that_reports(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The report dedupe must not reach the ledger: a defect never overwrites one already stored."""
+        snapshot = _drive_matching(
+            [partial(_make_varying_defect_fg, (FIRST_DEFECT_MESSAGE, SECOND_DEFECT_MESSAGE))], caplog, calls=3
+        )
+
+        assert snapshot.ledger_error is None, f"the stored fact must be readable: {snapshot.ledger_error}"
+        assert len(snapshot.rows) == 1, f"one declaration against one group is one key, got: {snapshot.rows}"
+        _, _, stage, reason = snapshot.rows[0]
+        assert stage == MATCHER_ERROR_STAGE, f"the drop must be recorded as a defect, got stage: {stage}"
+        assert FIRST_DEFECT_MESSAGE in reason, f"the first defect must keep the key, got reason: {reason}"
+        assert SECOND_DEFECT_MESSAGE not in reason, f"a later defect must not overwrite the pinned one: {reason}"
+
+    def test_a_falsy_return_of_another_type_warns_instead_of_falling_to_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The returned type name is part of the line, so a second type is a new fact and not a repeat."""
+        snapshot = _drive_matching([partial(_make_varying_falsy_fg, (None, ""))], caplog, calls=3)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.rows == (), f"a falsy non-bool is a non-match, never a fact, got: {snapshot.rows}"
+        reported = _carrying(snapshot.warnings, FALSY_REPORT_FRAGMENT)
+        assert len(reported) == 2, f"each returned type must be reported on its own, got: {snapshot.warnings}"
+        assert f"({type(None).__name__})" in reported[0], f"the first type must be named: {reported[0]}"
+        assert f"({str.__name__})" in reported[1], f"the second type must be named: {reported[1]}"
+        assert _carrying(snapshot.debugs, FALSY_REPORT_FRAGMENT) == (reported[1],), (
+            f"only the verbatim repeat belongs at DEBUG, got: {snapshot.debugs}"
         )
 
 

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import logging
 from typing import Any
 
 import pytest
@@ -51,6 +52,38 @@ class TestGlobalFilter:
     def test_filter_config_empty(self) -> None:
         """Test that the GlobalFilter starts with an empty config."""
         assert len(self.global_filter.filters) == 0
+
+    def test_drop_reports_dedupe_by_rendered_message(self, caplog: pytest.LogCaptureFixture) -> None:
+        class ExampleFeatureGroup:
+            @classmethod
+            def get_class_name(cls) -> str:
+                return "ExampleFeatureGroup"
+
+        caplog.set_level(logging.DEBUG)
+
+        self.global_filter._record_dropped_filter(ExampleFeatureGroup, "age", "reason one")
+        self.global_filter._record_dropped_filter(ExampleFeatureGroup, "age", "reason two")
+        self.global_filter._record_dropped_filter(ExampleFeatureGroup, "age", "reason two")
+
+        records = [record for record in caplog.records if "dropping that filter" in record.message]
+        assert [record.levelno for record in records] == [logging.WARNING, logging.WARNING, logging.DEBUG]
+
+    def test_falsy_reports_dedupe_by_rendered_message_and_reset(self, caplog: pytest.LogCaptureFixture) -> None:
+        class ExampleFeatureGroup:
+            @classmethod
+            def get_class_name(cls) -> str:
+                return "ExampleFeatureGroup"
+
+        caplog.set_level(logging.DEBUG)
+
+        self.global_filter._report_falsy_match(ExampleFeatureGroup, "age", None)
+        self.global_filter._report_falsy_match(ExampleFeatureGroup, "age", None)
+        self.global_filter._report_falsy_match(ExampleFeatureGroup, "age", "")
+        self.global_filter.reset_match_tracking()
+        self.global_filter._report_falsy_match(ExampleFeatureGroup, "age", None)
+
+        records = [record for record in caplog.records if "filter is not attached" in record.message]
+        assert [record.levelno for record in records] == [logging.WARNING, logging.DEBUG, logging.WARNING, logging.WARNING]
 
 
 class TestGlobalFilterTimeTravel:


### PR DESCRIPTION
## Summary

Closes #1099. Defect-drop and falsy-match warnings now deduplicate on the fully rendered log line, so different reasons or returned types remain visible at WARNING while byte-identical repeats are DEBUG. The per-declaration dropped_filters ledger remains unchanged, and reset clears both message ledgers.

## Validation

- python -m pytest tests/test_core/test_filter/test_global_filter.py -q -> 36 passed.
- uff check on the changed module and tests -> passed.
- uff format --check reports existing formatting differences in these files; no formatter rewrite was applied.

Generated by Codex.