### PR TITLE
fix: dedupe the filter drop reports on the rendered message

### DIFF
--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -74,9 +74,13 @@ class GlobalFilter:
         self.matched_filter_uuids: set[UUID] = set()
         self._warned_divergences: set[str] = set()
         # Own state, not dropped_filters: a falsy non-bool is an ordinary non-match, never a recorded drop.
-        self._reported_falsy_matches: set[tuple[type[FeatureGroup], str]] = set()
-        # WARNING dedupe for defect drops; the ledger itself no longer decides first-ness.
-        self._warned_drops: set[tuple[type[FeatureGroup], str]] = set()
+        # Keyed by the rendered line, like _warned_divergences: two reports under one column can differ.
+        self._reported_falsy_matches: set[str] = set()
+        # WARNING dedupe for defect drops, also keyed by the rendered line.
+        self._warned_drops: set[str] = set()
+        # Which keys the ledger has already taken a defect for; separate from the log dedupe above,
+        # because the ledger is per declaration while the log is per distinct message.
+        self._recorded_drops: set[tuple[type[FeatureGroup], str]] = set()
 
     def reset_match_tracking(self) -> None:
         """Every match report is scoped to one engine setup, so a later setup names only what it consulted.
@@ -85,6 +89,7 @@ class GlobalFilter:
         self.dropped_filters.clear()
         self._warned_divergences.clear()
         self._warned_drops.clear()
+        self._recorded_drops.clear()
         self._reported_falsy_matches.clear()
 
     def rehash_stored_filters(self) -> None:
@@ -366,37 +371,35 @@ class GlobalFilter:
         )
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
-        """Record the drop: defect drops warn once per key and take the key from a stored near-miss."""
+        """Record the drop: the ledger takes the first defect per key and outranks a stored near-miss,
+        while the log dedupes on the rendered line, so a second drop with a new reason is still reported."""
         key = (feature_group, filter_feature_name)
-        first = key not in self._warned_drops
-        self._warned_drops.add(key)
-        if first:
+        if key not in self._recorded_drops:
+            self._recorded_drops.add(key)
             self.dropped_filters[key] = Elimination(stage="matcher_error", reason=reason)
-        logger.log(
-            logging.WARNING if first else logging.DEBUG,
-            "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
-            feature_group.get_class_name(),
-            reason,
-            filter_feature_name,
+        message = (
+            f"{feature_group.get_class_name()} {reason} while matching filter feature "
+            f"'{filter_feature_name}'; dropping that filter for this feature group."
         )
+        first = message not in self._warned_drops
+        self._warned_drops.add(message)
+        logger.log(logging.WARNING if first else logging.DEBUG, "%s", message)
 
     def _report_falsy_match(self, feature_group: type[FeatureGroup], filter_feature_name: str, returned: Any) -> None:
-        """Report the detached filter: WARNING on a key's first report, DEBUG after, like `_record_dropped_filter`.
+        """Report the detached filter: WARNING on a line's first report, DEBUG after, like `_record_dropped_filter`.
 
         Both fields are plugin-owned reads and this runs past the hook call's containment, so each degrades alone.
         """
-        key = (feature_group, filter_feature_name)
-        first = key not in self._reported_falsy_matches
-        self._reported_falsy_matches.add(key)
-        logger.log(
-            logging.WARNING if first else logging.DEBUG,
-            "%s returned a falsy non-bool (%s) while matching filter feature '%s'; that filter is not attached. "
-            "Return True explicitly to keep it.",
-            safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
+        message = (
+            f"{safe_field(lambda: feature_group.get_class_name(), '<unnamed feature group>')} "
             # The type name only: the value's own __repr__ is plugin code and must not run here.
-            safe_field(lambda: type(returned).__name__, "<unreadable type>"),
-            filter_feature_name,
+            f"returned a falsy non-bool ({safe_field(lambda: type(returned).__name__, '<unreadable type>')}) "
+            f"while matching filter feature '{filter_feature_name}'; that filter is not attached. "
+            "Return True explicitly to keep it."
         )
+        first = message not in self._reported_falsy_matches
+        self._reported_falsy_matches.add(message)
+        logger.log(logging.WARNING if first else logging.DEBUG, "%s", message)
 
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:
         # We have matched already the feature group and the feature.

--- a/tests/test_core/test_filter/test_filter_drop_report_dedupe.py
+++ b/tests/test_core/test_filter/test_filter_drop_report_dedupe.py
@@ -1,0 +1,112 @@
+"""The drop and falsy-match reports dedupe on the rendered line, not on the column key.
+
+Two filters declared on one column can be dropped by one feature group for different
+reasons, and one declaration can be probed against different host features. Keying the
+dedupe on ``(feature group, filter feature name)`` muted every report after the first to
+DEBUG, even when its text was new. ``_warn_on_diverging_options`` already dedupes on the
+message; these two now match it.
+"""
+
+import logging
+
+import pytest
+
+from mloda.core.filter.global_filter import GlobalFilter
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+class DropReportingFeatureGroup(FeatureGroup):
+    """Only used as a ledger key; nothing is computed."""
+
+
+def _lines(caplog: pytest.LogCaptureFixture, level: int) -> list[str]:
+    return [record.getMessage() for record in caplog.records if record.levelno == level]
+
+
+def test_distinct_drop_reasons_each_warn(caplog: pytest.LogCaptureFixture) -> None:
+    global_filter = GlobalFilter()
+
+    with caplog.at_level(logging.DEBUG):
+        global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+        global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised B")
+
+    warnings = _lines(caplog, logging.WARNING)
+    assert len(warnings) == 2
+    assert any("raised A" in line for line in warnings)
+    assert any("raised B" in line for line in warnings)
+
+
+def test_repeated_drop_reason_is_demoted_to_debug(caplog: pytest.LogCaptureFixture) -> None:
+    global_filter = GlobalFilter()
+
+    with caplog.at_level(logging.DEBUG):
+        global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+        global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+
+    assert len(_lines(caplog, logging.WARNING)) == 1
+    assert len(_lines(caplog, logging.DEBUG)) == 1
+
+
+def test_ledger_keeps_the_first_defect_per_key() -> None:
+    """The ledger stays per declaration: a second reason does not overwrite the recorded one."""
+    global_filter = GlobalFilter()
+
+    global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+    global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised B")
+
+    recorded = global_filter.dropped_filters[(DropReportingFeatureGroup, "amount")]
+    assert recorded.stage == "matcher_error"
+    assert recorded.reason == "raised A"
+
+
+def test_defect_still_outranks_a_stored_near_miss() -> None:
+    """A near-miss recorded first must not stop the defect from claiming the key."""
+    global_filter = GlobalFilter()
+
+    global_filter._record_near_miss(DropReportingFeatureGroup, "amount", "domain", "lost at the domain gate")
+    global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+
+    recorded = global_filter.dropped_filters[(DropReportingFeatureGroup, "amount")]
+    assert recorded.stage == "matcher_error"
+    assert recorded.reason == "raised A"
+
+
+def test_distinct_falsy_match_reports_each_warn(caplog: pytest.LogCaptureFixture) -> None:
+    global_filter = GlobalFilter()
+
+    with caplog.at_level(logging.DEBUG):
+        global_filter._report_falsy_match(DropReportingFeatureGroup, "amount", 0)
+        global_filter._report_falsy_match(DropReportingFeatureGroup, "amount", "")
+
+    warnings = _lines(caplog, logging.WARNING)
+    assert len(warnings) == 2
+    assert any("(int)" in line for line in warnings)
+    assert any("(str)" in line for line in warnings)
+
+
+def test_repeated_falsy_match_report_is_demoted_to_debug(caplog: pytest.LogCaptureFixture) -> None:
+    global_filter = GlobalFilter()
+
+    with caplog.at_level(logging.DEBUG):
+        global_filter._report_falsy_match(DropReportingFeatureGroup, "amount", 0)
+        global_filter._report_falsy_match(DropReportingFeatureGroup, "amount", 0)
+
+    assert len(_lines(caplog, logging.WARNING)) == 1
+    assert len(_lines(caplog, logging.DEBUG)) == 1
+
+
+def test_reset_match_tracking_clears_both_ledgers(caplog: pytest.LogCaptureFixture) -> None:
+    global_filter = GlobalFilter()
+
+    global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+    global_filter._report_falsy_match(DropReportingFeatureGroup, "amount", 0)
+    global_filter.reset_match_tracking()
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG):
+        global_filter._record_dropped_filter(DropReportingFeatureGroup, "amount", "raised A")
+        global_filter._report_falsy_match(DropReportingFeatureGroup, "amount", 0)
+
+    # Both report at WARNING again, and the ledger takes the drop again.
+    assert len(_lines(caplog, logging.WARNING)) == 2
+    assert (DropReportingFeatureGroup, "amount") in global_filter.dropped_filters


### PR DESCRIPTION
Closes #1099.

## Problem

`_warned_drops` and `_reported_falsy_matches` dedupe on `(feature group, filter feature name)`, so the second report under that key logs at DEBUG even when its reason text differs from the first. Two filters declared on one column can be dropped by one FeatureGroup for different reasons — the matcher sees the filter feature's options merged onto the host's, so an option-derived message differs per declaration — and the same holds for one declaration probed against different host features. Only the first is reported at WARNING; the rest are muted despite being new information.

## Change

Both sets are now keyed on the rendered message, which is what `_warn_on_diverging_options` already does with `_warned_divergences`. Every distinct line reports once at WARNING, and byte-identical repeats still collapse to DEBUG, which is what the column key was there to suppress.

Building the message eagerly rather than passing `%s` args is the same trade `_warn_on_diverging_options` makes: the text has to exist to be the dedupe key.

## Keeping the ledger per declaration

`dropped_filters` keeps its `(feature group, filter feature name)` key, as the issue asks. It previously took its first-ness from `_warned_drops`, which no longer means "first for this key", so it gets its own `_recorded_drops` set. That preserves both existing guarantees:

- a matcher defect still outranks a stored near-miss (it writes unconditionally on the key's first defect, rather than being blocked by an entry a near-miss already put there), and
- the first reason recorded for a key still wins over a later one.

`reset_match_tracking` clears the new set alongside the others.

## Tests

`tests/test_core/test_filter/test_filter_drop_report_dedupe.py`, seven cases:

- distinct drop reasons under one key each warn; a repeated reason is demoted to DEBUG
- the same pair for the falsy-match report, distinguished by the reported type name
- the ledger keeps the first defect per key when a second reason arrives
- a defect still claims the key over a near-miss recorded first
- `reset_match_tracking` clears both, so the next setup reports at WARNING again and the ledger takes the drop again

## Verification

`tests/test_core/test_filter/` goes 513 → 520 passed, the seven added. `ruff format --check`, `ruff check` and `mypy --strict --ignore-missing-imports` are clean on both touched files.

I could not get a clean full `tox` run on this machine: `tests/.../test_read_dbs/test_read_db_multiprocessing.py` fails to collect during `PluginLoader().all()`, and the same failure reproduces on an unmodified `main`, so it is a local environment problem rather than something from this change. The `-n 8` run also hits a pytest-xdist `INTERNALERROR` on Windows. CI should give the real gate.