### PR TITLE
ci: give the tox matrix step headroom over its actual runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,9 @@ jobs:
       env:
         PYTEST_WORKERS: 2
       run: tox ${{ matrix.toxenv }}
-      timeout-minutes: 3
+      # The slowest envs run ~185s, so a 3-minute cap failed steps whose tox
+      # reported OK. Kept well above that, and still short enough to kill a hang.
+      timeout-minutes: 10
 
   notebooks:
     # Runs the marimo example notebooks; slower than the unit-test matrix.

--- a/tests/test_ci_step_timeouts.py
+++ b/tests/test_ci_step_timeouts.py
@@ -1,0 +1,42 @@
+"""The tox matrix step must allow more time than the envs actually take.
+
+`build (3.10, -e python310)` failed on `main` while its own gate passed: tox
+reported `python310: OK (183.96 ... seconds)` and the step was then killed by a
+3-minute cap. A green gate reading as a red PR hides real failures, so the cap
+needs headroom over the observed runtime.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CI_YAML = PROJECT_ROOT / ".github" / "workflows" / "ci.yaml"
+
+# The slowest env observed in CI, rounded up from the 183.96s in the report.
+SLOWEST_OBSERVED_MINUTES = 4
+
+
+def _tox_matrix_step() -> dict[str, Any]:
+    config: dict[Any, Any] = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+    steps = config["jobs"]["build"]["steps"]
+    matching = [step for step in steps if str(step.get("run", "")).startswith("tox ${{ matrix.toxenv }}")]
+    assert len(matching) == 1, f"expected exactly one tox matrix step, found {len(matching)}"
+    return dict(matching[0])
+
+
+def test_tox_matrix_step_timeout_has_headroom() -> None:
+    timeout = _tox_matrix_step()["timeout-minutes"]
+    assert timeout > SLOWEST_OBSERVED_MINUTES, (
+        f"timeout-minutes={timeout} leaves no headroom over the ~{SLOWEST_OBSERVED_MINUTES}min "
+        "the slowest tox env takes; a passing gate would fail the step"
+    )
+
+
+def test_tox_matrix_step_still_has_a_timeout() -> None:
+    """Headroom, not removal: a hung step must still be killed rather than run to the job limit."""
+    step = _tox_matrix_step()
+    assert "timeout-minutes" in step
+    assert step["timeout-minutes"] <= 15


### PR DESCRIPTION
Closes #1098.

## Problem

`build (3.10, -e python310)` fails on `main` even though the gate it runs passes:

```
python310: OK (183.96=setup[3.62]+cmd[140.58,...] seconds)
congratulations :) (184.05 seconds)
##[error]The action 'Run tox -e python310' has timed out after 3 minutes.
```

The env needs about 184 seconds and the step allows 180. python312 has been seen at 185 seconds and passed only on a re-run at a lower number, so this shows up intermittently across envs rather than as a stable 3.10 failure. A green gate reading as a red PR means every PR needs re-running or hand-triage, and a real failure in these envs is indistinguishable from the timeout at a glance.

## Change

`timeout-minutes: 3` → `10` on the tox matrix step.

I went for headroom rather than splitting the envs, since the envs are already close to each other and a split would just move the edge. 10 matches the `notebooks` job in the same file, which keeps the two step caps consistent, and it is roughly 3x the observed runtime — enough that ordinary runner variance cannot reach it, while still killing a hung step well before the 6-hour job limit rather than removing the cap.

## Test

`tests/test_ci_step_timeouts.py` reads the step out of `ci.yaml` and pins both halves: the cap has headroom over the ~4 minutes the slowest env takes, and the cap still exists and stays bounded, so a future "fix" that deletes it or sets it back under the runtime fails the suite. It follows the parsing approach in `tests/test_ci_paths_ignore.py`.

`ruff format --check`, `ruff check` and `mypy --strict` are clean on the new file; it passes alongside the existing CI-config tests.