### PR TITLE
fix: stop asking a candidate its name where the answer cannot be contained

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -31,7 +31,7 @@ Filter matching contains the same way: a raise is a non-match for that probe, li
 
 The probe runs per feature, but a matched filter attaches to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset).
 
-Every caller reads the return by truthiness: any falsy value is a non-match, any truthy value a match. Filter matching additionally reports a falsy value that is not `False` once per FeatureGroup and declared filter.
+Every caller reads the return by truthiness: any falsy value is a non-match, any truthy value a match. Filter matching additionally reports a falsy value that is not `False`, and each distinct report is a WARNING once per setup.
 
 The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -459,7 +459,7 @@ class GlobalFilter:
             compared = safe_field(
                 lambda: as_str(feature_group.get_domain().name),
                 "<unreadable domain>",
-                field=f"{feature_group.get_class_name()}.get_domain",
+                field=f"{feature_group.__name__}.get_domain",
             )
         return f"the filter feature's domain '{declared.name}' does not match '{compared}'"
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -391,8 +391,10 @@ class GlobalFilter:
         stored = self.dropped_filters.get(key)
         if stored is None or stored.stage != "matcher_error":
             self.dropped_filters[key] = Elimination(stage="matcher_error", reason=reason)
+        # A plugin-owned read past the hook call's containment, so it degrades instead of escaping the seam.
+        group_name = safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>")
         message = (
-            f"{feature_group.get_class_name()} {reason} while matching filter feature '{filter.name}'; "
+            f"{group_name} {reason} while matching filter feature '{filter.name}'; "
             "dropping that filter for this feature group."
         )
         logger.log(self._claim_report_level(self._warned_drops, message), message)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -84,7 +84,7 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
     """
     if isinstance(scope, type):
         return issubclass(feature_group, scope)
-    # Name first: get_class_name() is @final and just returns __name__, while issubclass() on an ABCMeta
+    # Name first: __name__ is an attribute read no plugin can raise out of, while issubclass() on an ABCMeta
     # class is the expensive check, so the name gate keeps it off nearly every MRO entry.
     return any(
         ancestor.__name__ == scope and ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup)
@@ -203,7 +203,8 @@ class IdentifyFeatureGroupClass:
         'Did you mean' suggestion that merely echoes a candidate its near-miss block already names."""
         hints: set[str] = set()
         for feature_group in result.eliminations:
-            hints.add(feature_group.get_class_name())
+            # __name__, unlike the catalog: this suppresses what the near-miss block renders, which is __name__.
+            hints.add(feature_group.__name__)
             prefix = self._prefix_of(feature_group)
             if prefix:
                 hints.add(prefix)
@@ -228,7 +229,7 @@ class IdentifyFeatureGroupClass:
 
     def _domain_name(self, feature_group: type[FeatureGroup]) -> str | None:
         """Best-effort domain name. None when get_domain() raised or returned no Domain: renders without a suffix."""
-        field = f"{feature_group.get_class_name()}.get_domain"
+        field = f"{feature_group.__name__}.get_domain"
         domain, error = self._domain_outcome(feature_group)
         # error, not domain, is what tells a raise apart from a malformed return: both leave domain unusable.
         if error is not None:
@@ -249,7 +250,7 @@ class IdentifyFeatureGroupClass:
             self._declared_frameworks[feature_group] = safe_field(
                 lambda: frozenset(feature_group.compute_framework_definition()),
                 frozenset(),
-                field=f"{feature_group.get_class_name()}.compute_framework_definition",
+                field=f"{feature_group.__name__}.compute_framework_definition",
             )
         return self._declared_frameworks[feature_group]
 
@@ -262,7 +263,7 @@ class IdentifyFeatureGroupClass:
         return safe_field(
             lambda: {as_str(cfw.get_class_name()) for cfw in self._declared_frameworks_of(feature_group)},
             set(),
-            field=f"{feature_group.get_class_name()}.compute_framework_definition",
+            field=f"{feature_group.__name__}.compute_framework_definition",
         )
 
     def _capture_domains(self, result: EvaluationResult) -> dict[type[FeatureGroup], str]:
@@ -304,8 +305,16 @@ class IdentifyFeatureGroupClass:
 
     def _catalog_names_of(self, feature_group: type[FeatureGroup]) -> list[str]:
         """One candidate's whole contribution to the name catalog, in capture order."""
-        # get_class_name() is @final, so it cannot raise on a provider's behalf and needs no guard.
-        names = [feature_group.get_class_name(), *self._supported_names_of(feature_group)]
+        # get_class_name(), because that is the name the default matcher accepts, so a renaming override stays
+        # reachable. Guarded, and falling back to __name__: a placeholder would seed a name no candidate carries.
+        names = [
+            safe_field(
+                lambda: as_str(feature_group.get_class_name()),
+                feature_group.__name__,
+                field=f"{feature_group.__name__}.get_class_name",
+            ),
+            *self._supported_names_of(feature_group),
+        ]
         prefix = self._prefix_of(feature_group)
         if prefix:
             names.append(prefix)
@@ -339,7 +348,7 @@ class IdentifyFeatureGroupClass:
         return not safe_field(
             lambda: self._filter_feature_group_by_links(feature_group, links),
             True,
-            field=f"{feature_group.get_class_name()}.index_columns/supports_index",
+            field=f"{feature_group.__name__}.index_columns/supports_index",
         )
 
     def _fails_domain_gate(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
@@ -608,7 +617,8 @@ class IdentifyFeatureGroupClass:
             # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
             logger.debug(
                 "%s rejected an option value while matching '%s': %s",
-                feature_group.get_class_name(),
+                # A plugin-owned read past the hook call's containment, so it degrades instead of escaping the seam.
+                safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
                 feature.name,
                 safe_field(functools.partial(str, exc), type(exc).__name__),
             )
@@ -617,7 +627,7 @@ class IdentifyFeatureGroupClass:
             logger.log(
                 contained_raise_log_level(probe.matcher_error),
                 "%s %s while matching '%s'; treating it as a non-match.",
-                feature_group.get_class_name(),
+                safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
                 reason,
                 feature.name,
             )

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -21,7 +21,8 @@ def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
     """Render the shared scope callout, or None when the scope is unset."""
     if scope is None:
         return None
-    scope_name = scope.get_class_name() if isinstance(scope, type) else scope
+    # __name__, not get_class_name(): the scope is user-supplied and this projection calls no overridable hook.
+    scope_name = scope.__name__ if isinstance(scope, type) else scope
     return f"Scoped to feature group: '{scope_name}'."
 
 
@@ -42,13 +43,13 @@ def _supported_feature_names(feature_group: type[FeatureGroup]) -> set[str]:
     return safe_field(
         lambda: {as_str(name) for name in feature_group.feature_names_supported()},
         set(),
-        field=f"{feature_group.get_class_name()}.feature_names_supported",
+        field=f"{feature_group.__name__}.feature_names_supported",
     )
 
 
 def _prefix_name(feature_group: type[FeatureGroup]) -> str:
     """Best-effort prefix of one candidate."""
-    return safe_field(lambda: as_str(feature_group.prefix()), "", field=f"{feature_group.get_class_name()}.prefix")
+    return safe_field(lambda: as_str(feature_group.prefix()), "", field=f"{feature_group.__name__}.prefix")
 
 
 _STAGE_LABELS: dict[EliminationStage, str] = {

--- a/tests/test_core/test_filter/test_filter_elimination_reasons.py
+++ b/tests/test_core/test_filter/test_filter_elimination_reasons.py
@@ -67,6 +67,15 @@ SECOND_DEFECT_MESSAGE = "fer_second_boom"
 DEFECT_MESSAGE = "fer_defect_after_decline"
 DECLINE_REASON = "fer_decline_reason"
 UNKNOWN_STAGE = "fer_unknown_stage_hint"  # a free-form hint no engine stage knows
+PERCENT_DEFECT_MESSAGE = "fer_percent_%s_%d_boom"  # a raise message whose % must not be read as a format directive
+
+REPORT_OPTION_KEY = "fer_report_option_key"  # the option the host carries and the option-keyed probe reads back
+REPORT_VALUE_A = "fer_report_val_a"
+REPORT_VALUE_B = "fer_report_val_b"
+OPTION_KEYED_DEFECT = "fer_option_keyed_defect"  # prefix of the option-keyed raise message
+
+CLASS_NAME_RAISE_MESSAGE = "fer_class_name_boom"  # raised by the group that cannot say what it is called
+UNNAMED_GROUP_FALLBACK = "<unnamed feature group>"  # what a guarded read of a group's class name degrades to
 
 GROUP_DOMAIN = "fer_group_domain"  # declared by the group-domain probe
 FEATURE_DOMAIN = "fer_feature_domain"  # carried by the resolved host feature
@@ -152,6 +161,11 @@ def _stage_reason(stage: str) -> str:
     return f"fer_stage_reason_{stage}"
 
 
+def _defect_message(value: str) -> str:
+    """The raise message the option-keyed defect probe makes for one probed option value."""
+    return f"{OPTION_KEYED_DEFECT}_{value}"
+
+
 def _fact_of(recorded: Any) -> tuple[str, str]:
     """(stage, reason) of one recorded fact. Any, because the ledger's value type is what this suite pins."""
     return str(recorded.stage), str(recorded.reason)
@@ -199,6 +213,11 @@ def _host_feature(domain: str | None = None, pin: type[ComputeFramework] | None 
 def _plain_host() -> Feature:
     """The host carrying neither a domain nor a pin."""
     return _host_feature()
+
+
+def _keyed_host_feature(value: str) -> Feature:
+    """A host carrying the option value unify_options merges onto a filter feature that omits it."""
+    return Feature(HOST_FEATURE, Options(group={REPORT_OPTION_KEY: value}))
 
 
 def _domain_losing_host() -> Feature:
@@ -457,6 +476,57 @@ def _make_falsy_decline_fg() -> type[FeatureGroup]:
     return FerFalsyDeclineFG
 
 
+def _make_option_keyed_defect_fg() -> type[FeatureGroup]:
+    """A throwaway group whose raise message is keyed off the probed options, so what it reads decides the reason."""
+    gc.collect()
+
+    class FerOptionKeyedDefectFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                raise RuntimeError(_defect_message(str(options.get(REPORT_OPTION_KEY))))
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerOptionKeyedDefectFG
+
+
+def _make_unnameable_defect_fg() -> type[FeatureGroup]:
+    """A throwaway group that raises for the filter feature and cannot say what it is called either."""
+    gc.collect()
+
+    class FerUnnameableDefectFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        # The @final on get_class_name is a mypy pin; a plugin can still install this override at runtime.
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            raise RuntimeError(CLASS_NAME_RAISE_MESSAGE)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                raise RuntimeError(RUNTIME_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerUnnameableDefectFG
+
+
 def _make_decline_then_defect_fg() -> type[FeatureGroup]:
     """A throwaway group whose hook declines with a recorded reason once, then raises on the next ask."""
     gc.collect()
@@ -697,6 +767,37 @@ def _losing_pair_messages() -> tuple[str, ...]:
             for stage, reason in ((SCOPE_STAGE, SCOPE_REASON), (FRAMEWORK_PIN_STAGE, PIN_REASON))
         )
     )
+
+
+@dataclass(frozen=True)
+class _DegradedDropSnapshot:
+    """Plain-data readout of a drop whose group cannot name itself. Holds no class and reads no ledger key."""
+
+    escaped: str | None
+    names: tuple[str, ...]
+    drops: int
+    warnings: tuple[str, ...]
+
+
+def _drive_unnameable_drop(make: _Factory, caplog: pytest.LogCaptureFixture) -> _DegradedDropSnapshot:
+    """Match one declared filter against a group whose class name raises; the ledger is counted, never keyed."""
+    caplog.clear()
+    fg = make()
+    global_filter = _new_global_filter((FILTER_FEATURE,))
+    matched: set[SingleFilter] | None = None
+    try:
+        with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
+            matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, _plain_host(), None))
+        return _DegradedDropSnapshot(
+            escaped=escaped,
+            names=tuple(sorted(single.name for single in matched or ())),
+            # A count, not the keys: reading a key back would call the unreadable class name again.
+            drops=len(global_filter.dropped_filters),
+            warnings=_messages(caplog, logging.WARNING),
+        )
+    finally:
+        del fg, global_filter, matched
+        gc.collect()
 
 
 @dataclass(frozen=True)
@@ -1311,6 +1412,40 @@ class TestTheReportsDedupeOnTheRenderedLine:
         )
 
 
+class TestTheHostFeaturesOptionsReachTheReport:
+    """unify_options merges the host's options onto the per-match filter copy, so one declaration renders per host."""
+
+    def test_one_declaration_probed_against_two_hosts_warns_per_host(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The probed value comes from the host, not from the declaration, and each rendered reason is its own."""
+        snapshot = _drive(
+            [_make_option_keyed_defect_fg],
+            caplog,
+            make_hosts=(partial(_keyed_host_feature, REPORT_VALUE_A), partial(_keyed_host_feature, REPORT_VALUE_B)),
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        reported = _carrying(snapshot.warnings, DROP_REPORT_FRAGMENT)
+        assert len(reported) == 2, f"each host's reason must warn, got: {reported}, at DEBUG: {snapshot.debugs}"
+        assert len(_carrying(reported, _defect_message(REPORT_VALUE_A))) == 1, f"the first host's reason: {reported}"
+        assert len(_carrying(reported, _defect_message(REPORT_VALUE_B))) == 1, f"the second host's reason: {reported}"
+        assert _carrying(snapshot.debugs, DROP_REPORT_FRAGMENT) == (), (
+            f"neither line repeats the other, so nothing belongs at DEBUG, got: {snapshot.debugs}"
+        )
+
+
+class TestAReasonCarryingAPercentIsLoggedVerbatim:
+    """The line is logged pre-rendered, so logging must not re-format it against args it does not have."""
+
+    def test_a_percent_in_the_reason_reaches_the_warning_unchanged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A re-formatted line fails inside logging's own handler, where nothing would fail a test."""
+        snapshot = _drive_matching([partial(_make_varying_defect_fg, (PERCENT_DEFECT_MESSAGE,))], caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        reported = _carrying(snapshot.warnings, DROP_REPORT_FRAGMENT)
+        assert len(reported) == 1, f"the drop must warn once, got: {snapshot.warnings}"
+        assert PERCENT_DEFECT_MESSAGE in reported[0], f"the reason must survive byte for byte: {reported[0]}"
+
+
 class TestFilterIdentitySurvivesThePerMatchDeepcopy:
     """Every gate records against a per-match deepcopy, so the copy must carry the declaration's uuid."""
 
@@ -1407,3 +1542,20 @@ class TestAnUnreadableGroupDomainDegrades:
         assert stage == DOMAIN_STAGE, f"the domain gate owns this drop, got stage: {stage}"
         assert OTHER_DOMAIN in reason, f"the reason must name the filter feature's declared domain: {reason}"
         assert UNREADABLE_DOMAIN_FALLBACK in reason, f"an unreadable domain name must degrade: {reason}"
+
+
+class TestAnUnreadableGroupNameOnTheDropPathDegrades:
+    """get_class_name is plugin-overridable, so the drop report's read of it degrades like its siblings' do."""
+
+    def test_a_drop_whose_group_cannot_name_itself_still_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The report runs past the hook call's containment, so its own read must not end the matching pass."""
+        snapshot = _drive_unnameable_drop(_make_unnameable_defect_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"a raising hook must attach no filter, got: {snapshot.names}"
+        assert snapshot.drops == 1, f"the drop must still be recorded, got: {snapshot.drops}"
+        reported = _carrying(snapshot.warnings, DROP_REPORT_FRAGMENT)
+        assert len(reported) == 1, f"the drop must still be reported once, got: {snapshot.warnings}"
+        assert UNNAMED_GROUP_FALLBACK in reported[0], f"an unreadable group name must degrade: {reported[0]}"
+        assert RUNTIME_MESSAGE in reported[0], f"the fields that ARE readable must still be named: {reported[0]}"
+        assert FILTER_FEATURE in reported[0], f"the report must name the filter feature: {reported[0]}"

--- a/tests/test_core/test_filter/test_filter_elimination_reasons.py
+++ b/tests/test_core/test_filter/test_filter_elimination_reasons.py
@@ -527,6 +527,32 @@ def _make_unnameable_defect_fg() -> type[FeatureGroup]:
     return FerUnnameableDefectFG
 
 
+def _make_unnameable_domain_fg() -> type[FeatureGroup]:
+    """A throwaway group that matches the filter feature and cannot say what it is called."""
+    gc.collect()
+
+    class FerUnnameableDomainFG(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            raise RuntimeError(CLASS_NAME_RAISE_MESSAGE)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            # Spelled out because the default matcher reads the class name this group cannot answer.
+            return str(feature_name) in cls.feature_names_supported()
+
+    return FerUnnameableDomainFG
+
+
 def _make_decline_then_defect_fg() -> type[FeatureGroup]:
     """A throwaway group whose hook declines with a recorded reason once, then raises on the next ask."""
     gc.collect()
@@ -776,14 +802,17 @@ class _DegradedDropSnapshot:
     escaped: str | None
     names: tuple[str, ...]
     drops: int
+    facts: tuple[tuple[str, str], ...]
     warnings: tuple[str, ...]
 
 
-def _drive_unnameable_drop(make: _Factory, caplog: pytest.LogCaptureFixture) -> _DegradedDropSnapshot:
+def _drive_unnameable_drop(
+    make: _Factory, caplog: pytest.LogCaptureFixture, filter_feature: Feature | str = FILTER_FEATURE
+) -> _DegradedDropSnapshot:
     """Match one declared filter against a group whose class name raises; the ledger is counted, never keyed."""
     caplog.clear()
     fg = make()
-    global_filter = _new_global_filter((FILTER_FEATURE,))
+    global_filter = _new_global_filter((filter_feature,))
     matched: set[SingleFilter] | None = None
     try:
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
@@ -793,6 +822,8 @@ def _drive_unnameable_drop(make: _Factory, caplog: pytest.LogCaptureFixture) -> 
             names=tuple(sorted(single.name for single in matched or ())),
             # A count, not the keys: reading a key back would call the unreadable class name again.
             drops=len(global_filter.dropped_filters),
+            # The stored values only, for the same reason: a recorded fact names no class.
+            facts=tuple(sorted(_fact_of(recorded) for recorded in global_filter.dropped_filters.values())),
             warnings=_messages(caplog, logging.WARNING),
         )
     finally:
@@ -1559,3 +1590,24 @@ class TestAnUnreadableGroupNameOnTheDropPathDegrades:
         assert UNNAMED_GROUP_FALLBACK in reported[0], f"an unreadable group name must degrade: {reported[0]}"
         assert RUNTIME_MESSAGE in reported[0], f"the fields that ARE readable must still be named: {reported[0]}"
         assert FILTER_FEATURE in reported[0], f"the report must name the filter feature: {reported[0]}"
+
+
+class TestAnUnreadableGroupNameOnTheDomainDropPathDegrades:
+    """The domain drop's reason guards its plugin-owned read, then LABELS that guard with the class name."""
+
+    def test_a_domain_drop_whose_group_cannot_name_itself_still_records_its_reason(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The label is built before the guard runs, so it must degrade with the read it names."""
+        snapshot = _drive_unnameable_drop(
+            _make_unnameable_domain_fg, caplog, filter_feature=_filter_feature(domain=OTHER_DOMAIN)
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"a diverging domain must attach no filter, got: {snapshot.names}"
+        assert snapshot.drops == 1, f"the domain fact must still be recorded, got: {snapshot.drops}"
+        stage, reason = snapshot.facts[0]
+        assert stage == DOMAIN_STAGE, f"the domain gate owns this drop, got stage: {stage}"
+        assert OTHER_DOMAIN in reason, f"the reason must name the filter feature's declared domain: {reason}"
+        # Only the label degrades: the read it labels is a different hook, and this group answers it.
+        assert UNREADABLE_DOMAIN_FALLBACK not in reason, f"the group's own domain must still be read: {reason}"

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -17,7 +17,7 @@ from abc import abstractmethod
 from ast import literal_eval
 from collections.abc import Callable, Iterable, Iterator
 from difflib import get_close_matches
-from typing import Any, Optional, cast, get_args
+from typing import Any, ClassVar, Optional, cast, get_args
 
 import pytest
 
@@ -47,7 +47,7 @@ from mloda.core.prepare.resolution_types import (
     EvaluationResult,
     RenderFacts,
 )
-from tests.helpers.plugin_stubs import CountingStubFeatureGroup, HookCounter, StubFeatureGroup, make_fg
+from tests.helpers.plugin_stubs import CountingStubFeatureGroup, HookCounter, StubFeatureGroup, StubHookError, make_fg
 
 
 SUCCESS_FEATURE_791 = "renderer_success_791"
@@ -203,6 +203,19 @@ MAX_RENDERED_SUGGESTIONS_791 = 5
 HEALTHY_DOMAIN_791 = "renderer_healthy_domain_791"
 BOOM_SUPPORTED_NAME_791 = "renderer_boom_supported_name_791"
 
+# The candidate that cannot say what it is called: the capture path reads get_class_name() to LABEL guarded reads.
+UNNAMEABLE_FEATURE_791 = "renderer_unnameable_791"  # requested name, matched by nothing
+UNNAMEABLE_SPARE_791 = "renderer_unnameable_spare_791"  # the one name it declares and can still report
+UNNAMEABLE_ABSTRACT_FEATURE_791 = "renderer_unnameable_abstract_791"
+UNNAMEABLE_SCOPE_FEATURE_791 = "renderer_unnameable_scope_791"  # requested under a scope that cannot name itself
+CLASS_NAME_RAISE_MESSAGE_791 = "renderer_class_name_boom_791"
+# What a guarded name read degrades to: a placeholder names no candidate, so no catalog may carry one.
+UNNAMED_GROUP_FALLBACK_791 = "<unnamed feature group>"
+
+# The candidate whose readable name is not its Python class name; the default matcher owns the readable one.
+RENAMED_CLASS_NAME_791 = "RendererReadableNameFG791"  # what its get_class_name() answers, and what resolves to it
+RENAMED_TYPO_791 = "RendererRedableNameFG791"  # a typo of that name, matched by nothing
+
 # Same-named tie candidates get an explicit __module__ so only the module can break the sort tie.
 TIE_MODULE_A_791 = "tests.renderer_tie_module_a_791"
 TIE_MODULE_B_791 = "tests.renderer_tie_module_b_791"
@@ -254,7 +267,8 @@ TWO_FRAMEWORKS_791: set[type[ComputeFramework]] = {RendererFwOne791, RendererFwT
 class CountingFeatureGroup791(CountingStubFeatureGroup):
     """Feature group base that counts every provider-overridable hook the renderer must not call."""
 
-    COUNTER = HOOK_COUNTER_791
+    # Annotated as the base declares it, so a stub that cannot be tallied can unset it.
+    COUNTER: ClassVar[HookCounter | None] = HOOK_COUNTER_791
 
 
 def _counting_fg(
@@ -949,6 +963,110 @@ def _build_raising_framework_rule_groups() -> tuple[type[CountingFeatureGroup791
     return RendererRaisingAbstractBaseFG791, _armed(RendererRaisingConcreteSubFG791)
 
 
+def _build_unnameable_group() -> type[CountingFeatureGroup791]:
+    """Build an accessible declarer of a sibling name whose get_class_name() raises, matching nothing."""
+
+    class RendererUnnameableFG791(CountingFeatureGroup791):
+        """Declarer that can never say what it is called."""
+
+        # Unset: the tally keys on the very name this group cannot answer.
+        COUNTER = None
+        SUPPORTED_NAMES = frozenset({UNNAMEABLE_SPARE_791})
+        # The requested domain, so the name-blind retest's domain gate decides nothing and the links gate is reached.
+        DOMAIN_NAME = REQUESTED_DOMAIN_791
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        # The @final on get_class_name is a mypy pin; a plugin can still install this override at runtime.
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            if cls.ARMED:
+                raise StubHookError(CLASS_NAME_RAISE_MESSAGE_791)
+            return cls.__name__
+
+    return _armed(RendererUnnameableFG791)
+
+
+def _build_unnameable_abstract_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
+    """Build an abstract base plus a concrete subclass that cannot say what it is called."""
+
+    class RendererUnnameableAbstractBaseFG791(CountingFeatureGroup791):
+        """Abstract base that matches the name but can never be instantiated."""
+
+        MATCHED_NAMES = frozenset({UNNAMEABLE_ABSTRACT_FEATURE_791})
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        @abstractmethod
+        def _renderer_unnameable_abstract_hook_791(cls) -> str:
+            """Abstract hook that keeps this base uninstantiable."""
+
+    class RendererUnnameableConcreteSubFG791(RendererUnnameableAbstractBaseFG791):
+        """Concrete implementation whose declared frameworks are readable and whose own name is not."""
+
+        COUNTER = None
+        # Matches the name too, so a run that enables none of its frameworks eliminates it as a near-miss.
+        MATCHED_NAMES = frozenset({UNNAMEABLE_ABSTRACT_FEATURE_791})
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            if cls.ARMED:
+                raise StubHookError(CLASS_NAME_RAISE_MESSAGE_791)
+            return cls.__name__
+
+        @classmethod
+        def _renderer_unnameable_abstract_hook_791(cls) -> str:
+            return "concrete"
+
+    return RendererUnnameableAbstractBaseFG791, _armed(RendererUnnameableConcreteSubFG791)
+
+
+def _build_unnameable_scope_group() -> type[CountingFeatureGroup791]:
+    """Build the class a request names as its feature_group scope, which cannot say what it is called."""
+
+    class RendererUnnameableScopeFG791(CountingFeatureGroup791):
+        """Scope class that can never say what it is called, and that matches nothing."""
+
+        # Unset: the tally keys on the very name this group cannot answer.
+        COUNTER = None
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            if cls.ARMED:
+                raise StubHookError(CLASS_NAME_RAISE_MESSAGE_791)
+            return cls.__name__
+
+    return _armed(RendererUnnameableScopeFG791)
+
+
+def _build_renamed_group() -> type[CountingFeatureGroup791]:
+    """Build a candidate whose readable class name is not its Python one, matching by the default class rules."""
+
+    class RendererRenamedFG791(CountingFeatureGroup791):
+        """Declarer that answers a different, readable name and resolves under exactly that one."""
+
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            return RENAMED_CLASS_NAME_791 if cls.ARMED else cls.__name__
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            cls._enter_hook("match_feature_group_criteria")
+            # The two class-identity rules of the default matcher, both of which read get_class_name().
+            name = str(feature_name)
+            return cls.feature_name_equal_to_class_name(name) or cls.feature_name_contains_class_name_as_prefix(name)
+
+    return _armed(RendererRenamedFG791)
+
+
 def _make_tie_group(module: str, namespace: dict[str, Any]) -> type[CountingFeatureGroup791]:
     """Build a candidate named RendererTieFG791 in the given module, so only __module__ breaks the sort tie."""
     created: Any = type("RendererTieFG791", (CountingFeatureGroup791,), {"__module__": module, **namespace})
@@ -1439,6 +1557,32 @@ def raising_framework_rule_abstract_scenario() -> Scenario:
     return Feature(RAISING_ABSTRACT_FEATURE_791), {base: {RendererFwOne791}, concrete: set()}
 
 
+def unnameable_none_scenario() -> LinkedScenario:
+    """A domain-carrying, linked ordinary-none failure next to a candidate that cannot name itself."""
+    return (
+        Feature(UNNAMEABLE_FEATURE_791, domain=REQUESTED_DOMAIN_791),
+        {_build_unnameable_group(): {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}},
+        {LINKS_GATE_LINK_791},
+    )
+
+
+def unnameable_abstract_scenario() -> Scenario:
+    """An abstract-only failure whose concrete implementation cannot name itself."""
+    base, concrete = _build_unnameable_abstract_groups()
+    return Feature(UNNAMEABLE_ABSTRACT_FEATURE_791), {base: {RendererFwOne791}, concrete: set()}
+
+
+def unnameable_scope_scenario() -> Scenario:
+    """A scoped none failure whose scope is the very class that cannot say what it is called."""
+    scope = _build_unnameable_scope_group()
+    return Feature(UNNAMEABLE_SCOPE_FEATURE_791, feature_group=scope), {scope: {RendererFwOne791}}
+
+
+def renamed_catalog_scenario() -> Scenario:
+    """A none failure whose only candidate answers a readable class name that is not its Python one."""
+    return Feature(RENAMED_TYPO_791), {_build_renamed_group(): {RendererFwOne791}}
+
+
 FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "multiple": multiple_scenario,
     "capability": capability_scenario,
@@ -1472,6 +1616,7 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "raising_names_none": raising_names_none_scenario,
     "raising_rejection_none": raising_rejection_none_scenario,
     "raising_framework_rule_abstract": raising_framework_rule_abstract_scenario,
+    "unnameable_abstract": unnameable_abstract_scenario,
 }
 
 # Every (candidate, framework) pair the capability hook may be asked about during one evaluate(), and how
@@ -1918,6 +2063,124 @@ class TestFactCaptureNeverTakesEvaluateDown:
         assert result.feature_group is None
         assert set(result.candidates) == enabled
         assert result.error is not None
+
+
+class TestAnUnreadableCandidateNameNeverTakesTheCaptureDown:
+    """Each guarded read of the capture path LABELS its guard with the candidate's class name, before it runs."""
+
+    def test_an_unnameable_candidate_keeps_every_fact_it_can_still_report(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """evaluate() still returns, the message still renders, and each degraded label costs only itself."""
+        scenario = unnameable_none_scenario()
+        feature, _, _ = scenario
+
+        with caplog.at_level(logging.WARNING):
+            result = _evaluate_linked(scenario)
+
+        assert result.failure_kind == "none"
+        # Premise: the dead-name sweep ran to its end, so the name-blind gates were retested per candidate.
+        assert KNOWN_FEATURE_791 in result.facts.dead_only_names
+
+        # The degrade is scoped: the name it CAN report survives, and the healthy sibling's catalog is untouched.
+        assert UNNAMEABLE_SPARE_791 in result.facts.known_names
+        assert KNOWN_FEATURE_791 in result.facts.known_names
+        # Its prefix() reads the class name too, so that read degrades to "" and contributes no name.
+        assert _degrade_warnings(caplog, ".prefix"), "Expected a WARNING naming the degraded prefix read"
+
+        assert render_resolution_failure(result, feature) is not None
+
+    def test_an_unnameable_concrete_implementation_still_reports_its_frameworks(self) -> None:
+        """A readable framework declaration survives a label the same candidate cannot build."""
+        scenario = unnameable_abstract_scenario()
+        feature, accessible_plugins = scenario
+        # __name__, not get_class_name(): the readout must not ask the candidate the question it cannot answer.
+        _, concrete = [candidate.__name__ for candidate in accessible_plugins]
+
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "abstract_only"
+        assert result.facts.concrete_frameworks == (RendererFwOne791.__name__,)
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"require compute framework(s) ['{RendererFwOne791.__name__}']" in message
+        # The near-miss of the same candidate is captured from its elimination, which reads its name too.
+        assert f"  - {concrete} (compute framework): " in message
+
+
+class TestTheRendererNeverAsksTheScopeClassItsName:
+    """The scope is a user-supplied class, and the renderer's contract is to call no provider-overridable hook."""
+
+    def test_a_scope_that_cannot_name_itself_still_renders_its_callout(self) -> None:
+        """evaluate() decided the failure, so the projection of it must not fail on reading a name."""
+        scenario = unnameable_scope_scenario()
+        feature, accessible_plugins = scenario
+        # __name__, not get_class_name(): the callout must not ask the scope the question it cannot answer.
+        (scope_name,) = [candidate.__name__ for candidate in accessible_plugins]
+
+        result = _evaluate(scenario)
+
+        # Premise: evaluate() came back with an ordinary none, so nothing but the rendering is left to fail.
+        assert result.failure_kind == "none"
+        assert feature.feature_group_scope is not None
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message.startswith(
+            f"No feature groups found for feature name: '{UNNAMEABLE_SCOPE_FEATURE_791}'. "
+            f"Scoped to feature group: '{scope_name}'."
+        )
+        assert "Use resolve_feature(name, options=..., feature_group=...) to debug feature resolution." in message
+        assert message.endswith(TROUBLESHOOTING_LINE)
+
+
+class TestTheNameCatalogOffersTheNameTheMatcherAccepts:
+    """The catalog is what a user is told to type, and the default matcher owns a name by get_class_name().
+
+    Capturing the Python class name instead offers a name that resolves to nothing whenever a plugin renames
+    itself, and drops the only name that would have resolved. The fallback for a RAISING override is the other
+    half: the Python class name is a true name of that candidate, while a placeholder names no candidate at all.
+    """
+
+    def test_a_renamed_candidate_is_offered_under_the_name_that_resolves(self) -> None:
+        """An override renames what resolves to the candidate, so the catalog and the suggestion follow it."""
+        scenario = renamed_catalog_scenario()
+        feature, accessible_plugins = scenario
+        (renamed,) = accessible_plugins
+        python_name = renamed.__name__
+
+        result = _evaluate(scenario)
+
+        # Premise: the override's name is what the matcher accepts, and the Python class name resolves nothing.
+        accepted = _evaluate((Feature(RENAMED_CLASS_NAME_791), accessible_plugins))
+        assert set(accepted.identified) == {renamed}
+        assert _evaluate((Feature(python_name), accessible_plugins)).failure_kind == "none"
+
+        assert RENAMED_CLASS_NAME_791 in result.facts.known_names
+        assert python_name not in result.facts.known_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert RENAMED_CLASS_NAME_791 in suggestions
+        assert python_name not in suggestions
+
+    def test_an_unnameable_candidate_falls_back_to_a_name_it_really_carries(self) -> None:
+        """A raising override leaves the Python class name, which no request can reach through a placeholder."""
+        scenario = unnameable_none_scenario()
+        feature, accessible_plugins, _ = scenario
+        unnameable, _known = [candidate.__name__ for candidate in accessible_plugins]
+
+        result = _evaluate_linked(scenario)
+
+        assert result.failure_kind == "none"
+        assert unnameable in result.facts.known_names
+        assert UNNAMED_GROUP_FALLBACK_791 not in result.facts.known_names
+
+        assert render_resolution_failure(result, feature) is not None
 
 
 class TestCapabilityRenderingUniverse:

--- a/tests/test_core/test_prepare/test_unnameable_candidate_criteria_seam.py
+++ b/tests/test_core/test_prepare/test_unnameable_candidate_criteria_seam.py
@@ -1,0 +1,203 @@
+"""The criteria seam names its candidate in both reports it writes, and that name is plugin-overridable.
+
+Each report reads it BEFORE the containment it describes, so the read must degrade rather than end the
+resolution pass. Probe classes live inside factory functions and are dropped before any assert runs.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, TypeVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_types import EliminationStage
+
+
+IDENTIFY_LOGGER_NAME = IdentifyFeatureGroupClass.__module__
+
+UCS_FEATURE = "ucs_probe_feat"  # the name every probe here is asked about
+UCS_MATCHER_MESSAGE = "ucs_matcher_boom"  # what the defective matcher raises
+UCS_DECLINE_MESSAGE = "ucs_declined_value"  # what the declining matcher raises
+UCS_CLASS_NAME_MESSAGE = "ucs_class_name_boom"  # what the unreadable class name raises
+
+UNNAMED_GROUP_FALLBACK = "<unnamed feature group>"  # what a guarded read of a group's class name degrades to
+DECLINE_REPORT_FRAGMENT = "rejected an option value"  # the decline report's own wording
+
+MATCHER_ERROR_STAGE: EliminationStage = "matcher_error"
+VALUE_REJECTION_STAGE: EliminationStage = "value_rejection"
+
+T = TypeVar("T")
+
+_Factory = Callable[[], type[FeatureGroup]]
+
+
+class UcsFw(ComputeFramework):
+    """Dummy compute framework for the unnameable-candidate probes."""
+
+
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (red-phase probe: an escape is the fact under test)
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _fact_of(elimination: Any) -> tuple[str, str]:
+    """(stage, reason) of one elimination. Any, so the readout never depends on the record's declared shape."""
+    return str(elimination.stage), str(elimination.reason)
+
+
+def _reported(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
+    """Formatted messages the identify seam logged, whatever level it chose for each."""
+    return tuple(record.getMessage() for record in caplog.records if record.name == IDENTIFY_LOGGER_NAME)
+
+
+def _carrying(messages: Sequence[str], fragment: str) -> tuple[str, ...]:
+    """The messages carrying `fragment`."""
+    return tuple(message for message in messages if fragment in message)
+
+
+def _make_unnameable_matcher_defect_fg() -> type[FeatureGroup]:
+    """A throwaway candidate whose matcher raises and that cannot say what it is called either."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class UcsMatcherDefectFG(FeatureGroup):
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {UcsFw}
+
+        # The @final on get_class_name is a mypy pin; a plugin can still install this override at runtime.
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            raise RuntimeError(UCS_CLASS_NAME_MESSAGE)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            raise RuntimeError(UCS_MATCHER_MESSAGE)
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+            return None
+
+    return UcsMatcherDefectFG
+
+
+def _make_unnameable_value_decline_fg() -> type[FeatureGroup]:
+    """A throwaway candidate that declines the option value and cannot say what it is called either."""
+    gc.collect()
+
+    class UcsValueDeclineFG(FeatureGroup):
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {UcsFw}
+
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            raise RuntimeError(UCS_CLASS_NAME_MESSAGE)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            raise PropertyValueRejection(UCS_DECLINE_MESSAGE)
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+            return None
+
+    return UcsValueDeclineFG
+
+
+@dataclass(frozen=True)
+class _SeamSnapshot:
+    """Plain-data readout of one evaluation. Holds no class, no exception and no Elimination object."""
+
+    escaped: str | None
+    failure_kind: str | None
+    facts: tuple[tuple[str, str], ...]
+    reported: tuple[str, ...]
+
+
+def _drive(make: _Factory, caplog: pytest.LogCaptureFixture) -> _SeamSnapshot:
+    """Evaluate the probe alone, folding the outcome and the seam's own log records to plain data."""
+    caplog.clear()
+    fg = make()
+    plugins: FeatureGroupEnvironmentMapping = {fg: {UcsFw}}
+    result = None
+    try:
+        with caplog.at_level(logging.DEBUG, logger=IDENTIFY_LOGGER_NAME):
+            result, escaped = _capture(partial(IdentifyFeatureGroupClass.evaluate, Feature(UCS_FEATURE), plugins, None))
+        snapshot = _SeamSnapshot(
+            escaped=escaped,
+            failure_kind=None if result is None else result.failure_kind,
+            # The stored values only: reading a key back would ask the class the question it cannot answer.
+            facts=() if result is None else tuple(sorted(_fact_of(e) for e in result.eliminations.values())),
+            reported=_reported(caplog),
+        )
+        del result
+        result = None
+        return snapshot
+    finally:
+        del fg, plugins, result
+        gc.collect()
+
+
+class TestAnUnreadableCandidateNameOnTheCriteriaSeamDegrades:
+    """Both reports of the seam name their candidate as an eager argument, built before the guard they label."""
+
+    def test_a_contained_matcher_raise_whose_group_cannot_name_itself_still_evaluates(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The report runs past the hook call's containment, so its own read must not end the resolution pass."""
+        snapshot = _drive(_make_unnameable_matcher_defect_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross evaluate(): {snapshot.escaped}"
+        assert snapshot.failure_kind == "none", f"a contained raise is a non-match, got: {snapshot.failure_kind}"
+        assert len(snapshot.facts) == 1, f"the near-miss must still be recorded, got: {snapshot.facts}"
+        stage, reason = snapshot.facts[0]
+        assert stage == MATCHER_ERROR_STAGE, f"a contained raise is a matcher_error, got stage: {stage}"
+        assert UCS_MATCHER_MESSAGE in reason, f"the reason must name the contained raise: {reason}"
+        reported = _carrying(snapshot.reported, UCS_MATCHER_MESSAGE)
+        assert len(reported) == 1, f"the contained raise must still be reported once, got: {snapshot.reported}"
+        assert UNNAMED_GROUP_FALLBACK in reported[0], f"an unreadable group name must degrade: {reported[0]}"
+        assert UCS_FEATURE in reported[0], f"the report must name the feature it was matching: {reported[0]}"
+
+    def test_a_contained_value_decline_whose_group_cannot_name_itself_still_evaluates(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The other branch of the same seam: a declined value is reported by name too, and degrades the same."""
+        snapshot = _drive(_make_unnameable_value_decline_fg, caplog)
+
+        assert snapshot.escaped is None, f"nothing may cross evaluate(): {snapshot.escaped}"
+        assert snapshot.failure_kind == "none", f"a declined value is a non-match, got: {snapshot.failure_kind}"
+        assert len(snapshot.facts) == 1, f"the near-miss must still be recorded, got: {snapshot.facts}"
+        stage, reason = snapshot.facts[0]
+        assert stage == VALUE_REJECTION_STAGE, f"a declined value is a value_rejection, got stage: {stage}"
+        assert UCS_DECLINE_MESSAGE in reason, f"the reason must name the decline: {reason}"
+        reported = _carrying(snapshot.reported, DECLINE_REPORT_FRAGMENT)
+        assert len(reported) == 1, f"the decline must still be reported once, got: {snapshot.reported}"
+        assert UNNAMED_GROUP_FALLBACK in reported[0], f"an unreadable group name must degrade: {reported[0]}"
+        assert UCS_DECLINE_MESSAGE in reported[0], f"the fields that ARE readable must still be named: {reported[0]}"
+        assert UCS_FEATURE in reported[0], f"the report must name the feature it was matching: {reported[0]}"


### PR DESCRIPTION
Closes #1105.

`FeatureGroup.get_class_name` is `@final` and returns `cls.__name__`, but `@final` is a type pin rather than a runtime one, so a plugin can still install an override that raises. Reads of it sat outside every guard on the discovery path, and any of them took the whole call down instead of degrading one field:

- `safe_field` renders its `field=` label before it runs, so a label built from `get_class_name()` escaped the guard it was labelling. Seven sites across filter matching, candidate identification and failure rendering.
- The criteria seam logs the name after the hook call's containment has already closed, on both the value-decline and the matcher-raise branch. The filter seam guards its three counterparts; this one did not.
- The failure renderer asked a user-supplied scope class its name, while documenting that it calls no provider-overridable hook. The raise replaced the failure message the user was about to read.
- Two name catalogs read it unguarded to collect a candidate's name.

Each site now reads what it can answer for. A label or a rendered class name takes `__name__`, which is what `get_class_name` returns and what the candidate sort key, the near-miss block and the plugin docs already use. The criteria seam degrades to the placeholder its filter-seam counterparts use.

The name catalog is the exception and keeps asking `get_class_name`, guarded: that is the name the matcher accepts, so a renaming override has to stay reachable through a "Did you mean" suggestion. Its fallback is `__name__` rather than a placeholder, which would offer a name no candidate carries. The eliminated-candidate hints stay on `__name__`, because they suppress what the near-miss block renders.

Also in this PR, from the same seam: the filter drop report rendered `get_class_name()` unguarded while its two siblings did not, a reason carrying a `%` is pinned as logged verbatim (the line is passed with no format args, and a regression would be swallowed by logging rather than fail a test), and one declaration probed against two host features reports both lines, since the matcher sees the host's options merged onto the filter feature's.

Docs: `feature-group-matching.md` still promised a falsy-return report per FeatureGroup and declared filter.