### PR TITLE
refactor: share the column-wise framework hooks across feature group families

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -259,57 +259,51 @@ class PythonDictMergeEngine(BaseMergeEngine):
 
         return self._to_columnar(result, out_columns)
 
-    def _left_join(
-        self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
+    def _directional_join(
+        self,
+        primary_data: Any,
+        secondary_data: Any,
+        primary_cols: tuple[str, ...],
+        secondary_cols: tuple[str, ...],
+        primary_is_left: bool,
     ) -> Any:
-        """Performs left join, fanning out matches and null-filling unmatched left rows."""
-        left_rows = self._to_rows(left_data)
-        right_rows = self._to_rows(right_data)
-        right_groups = self._group_by_key(right_rows, right_cols)
+        """Drives one side of an outer join, fanning out matches and null-filling unmatched primary rows."""
+        primary_rows = self._to_rows(primary_data)
+        secondary_rows = self._to_rows(secondary_data)
+        secondary_groups = self._group_by_key(secondary_rows, secondary_cols)
 
-        out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
-        right_columns = [col for col in right_data.keys() if col not in set(right_cols) and col not in left_data]
+        out_columns = self._ordered_columns(primary_data.keys(), secondary_data.keys())
+        fill_columns = [
+            col for col in secondary_data.keys() if col not in set(secondary_cols) and col not in primary_data
+        ]
 
         result = []
-        for left in left_rows:
-            key = tuple(left.get(col) for col in left_cols)
-            matches = right_groups.get(key)
+        for primary in primary_rows:
+            key = tuple(primary.get(col) for col in primary_cols)
+            matches = secondary_groups.get(key)
             if matches:
-                for right in matches:
-                    result.append({**left, **right})
+                # Merge order stays left-then-right, so the right side wins overlapping columns either way.
+                for secondary in matches:
+                    result.append({**primary, **secondary} if primary_is_left else {**secondary, **primary})
             else:
-                merged = {**left}
-                for col in right_columns:
+                merged = {**primary}
+                for col in fill_columns:
                     merged[col] = None
                 result.append(merged)
 
         return self._to_columnar(result, out_columns)
+
+    def _left_join(
+        self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
+    ) -> Any:
+        """Performs left join, fanning out matches and null-filling unmatched left rows."""
+        return self._directional_join(left_data, right_data, left_cols, right_cols, primary_is_left=True)
 
     def _right_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
         """Performs right join, fanning out matches and null-filling unmatched right rows."""
-        left_rows = self._to_rows(left_data)
-        right_rows = self._to_rows(right_data)
-        left_groups = self._group_by_key(left_rows, left_cols)
-
-        out_columns = self._ordered_columns(right_data.keys(), left_data.keys())
-        left_columns = [col for col in left_data.keys() if col not in set(left_cols) and col not in right_data]
-
-        result = []
-        for right in right_rows:
-            key = tuple(right.get(col) for col in right_cols)
-            matches = left_groups.get(key)
-            if matches:
-                for left in matches:
-                    result.append({**left, **right})
-            else:
-                merged = {**right}
-                for col in left_columns:
-                    merged[col] = None
-                result.append(merged)
-
-        return self._to_columnar(result, out_columns)
+        return self._directional_join(right_data, left_data, right_cols, left_cols, primary_is_left=False)
 
     def _outer_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -273,8 +273,9 @@ class PythonDictMergeEngine(BaseMergeEngine):
         secondary_groups = self._group_by_key(secondary_rows, secondary_cols)
 
         out_columns = self._ordered_columns(primary_data.keys(), secondary_data.keys())
+        secondary_key_columns = set(secondary_cols)
         fill_columns = [
-            col for col in secondary_data.keys() if col not in set(secondary_cols) and col not in primary_data
+            col for col in secondary_data.keys() if col not in secondary_key_columns and col not in primary_data
         ]
 
         result = []

--- a/mloda_plugins/feature_group/columnwise_hooks.py
+++ b/mloda_plugins/feature_group/columnwise_hooks.py
@@ -1,0 +1,131 @@
+"""Per-framework implementations of the three column-wise hooks, shared by every family.
+
+This module sits outside ``experimental/`` on purpose: the hook sweep binds every hook-calling
+module under that tree to a family base directory, and a framework adapter belongs to no family.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from mloda.provider import FeatureGroup
+from mloda.user.python_dict import row_count
+
+
+class ColumnwiseHooks:
+    """Framework-neutral source-feature check, branching on the family's presence policy."""
+
+    # True: raise as soon as ANY source name is missing. False: raise only when NONE of them exists.
+    STRICT_SOURCE_FEATURES: bool = True
+
+    @classmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """Get the set of available column names from the data."""
+        raise NotImplementedError(f"{cls.__name__} must implement _get_available_columns")
+
+    @classmethod
+    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
+        """Check that the resolved source features exist, as strictly as the family declares."""
+        available = cls._get_available_columns(data)
+        missing = [name for name in feature_names if name not in available]
+        if cls.STRICT_SOURCE_FEATURES:
+            if missing:
+                raise ValueError(
+                    f"Source features not found in data: {missing}. Available columns: {sorted(available)}"
+                )
+        elif len(missing) == len(feature_names):
+            raise ValueError(
+                f"None of the source features {feature_names} found in data. Available columns: {sorted(available)}"
+            )
+
+
+class PandasColumnwiseHooks(ColumnwiseHooks):
+    """Column-wise hooks for a pandas DataFrame."""
+
+    @classmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """Get the set of available column names from the DataFrame."""
+        return set(data.columns)
+
+    @classmethod
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+        """Add the result to the DataFrame."""
+        data[feature_name] = result
+        return data
+
+
+class SklearnPandasColumnwiseHooks(PandasColumnwiseHooks):
+    """Writer for a scikit-learn result, spreading a multi-column array over the ~N naming convention."""
+
+    @classmethod
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+        """Add the result to the DataFrame, one column per result dimension."""
+        if hasattr(result, "shape") and len(result.shape) == 2:
+            if result.shape[1] == 1:
+                data[feature_name] = result.flatten()
+            else:
+                # cls is always a FeatureGroup subclass at call time; this class alone is not one.
+                named_columns = cast("type[FeatureGroup]", cls).apply_naming_convention(result, feature_name)
+                for col_name, col_data in named_columns.items():
+                    data[col_name] = col_data
+        elif hasattr(result, "shape") and len(result.shape) == 1:
+            data[feature_name] = result
+        else:
+            data[feature_name] = result
+
+        return data
+
+
+class PyArrowColumnwiseHooks(ColumnwiseHooks):
+    """Column-wise hooks for a PyArrow Table, duck-typed so this module needs no pyarrow import."""
+
+    @classmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """Get the set of available column names from the Table schema."""
+        return set(data.schema.names)
+
+    @classmethod
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+        """Add the result to the Table, replacing the column when it already exists."""
+        if feature_name in data.schema.names:
+            column_index = data.schema.names.index(feature_name)
+            data = data.remove_column(column_index)
+            return data.append_column(feature_name, result)
+        return data.append_column(feature_name, result)
+
+
+class PythonDictColumnwiseHooks(ColumnwiseHooks):
+    """Column-wise hooks for a columnar ``dict[str, list[Any]]``."""
+
+    @classmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """Get the set of available column names from the data."""
+        return set(data.keys())
+
+    @classmethod
+    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
+        """Reject empty data before the presence policy runs."""
+        if not data:
+            raise ValueError("Data cannot be empty")
+        super()._check_source_features_exist(data, feature_names)
+
+    @classmethod
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+        """Add the row-aligned result to the data."""
+        if len(result) != row_count(data):
+            raise ValueError(f"Result length {len(result)} does not match data length {row_count(data)}")
+
+        data[feature_name] = list(result)
+
+        return data
+
+
+class PolarsLazyColumnwiseHooks(ColumnwiseHooks):
+    """Column-wise hooks for a Polars LazyFrame."""
+
+    @classmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """Get the set of available column names from the LazyFrame schema."""
+        if not hasattr(data, "collect_schema"):
+            raise ValueError("Data does not have a collect_schema method, cannot get available columns.")
+        return set(data.collect_schema().names())

--- a/mloda_plugins/feature_group/columnwise_hooks.py
+++ b/mloda_plugins/feature_group/columnwise_hooks.py
@@ -1,7 +1,7 @@
-"""Per-framework implementations of the three column-wise hooks, shared by every family.
+"""Per-framework implementations of the column-wise hooks, shared by every family.
 
-This module sits outside ``experimental/`` on purpose: the hook sweep binds every hook-calling
-module under that tree to a family base directory, and a framework adapter belongs to no family.
+Outside ``experimental/`` on purpose: the hook sweep binds every hook-calling module under that
+tree to a family base directory, and a framework adapter belongs to no family.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ class ColumnwiseHooks:
 
     @classmethod
     def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the data."""
         raise NotImplementedError(f"{cls.__name__} must implement _get_available_columns")
 
     @classmethod
@@ -44,12 +43,10 @@ class PandasColumnwiseHooks(ColumnwiseHooks):
 
     @classmethod
     def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the DataFrame."""
         return set(data.columns)
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the DataFrame."""
         data[feature_name] = result
         return data
 
@@ -59,7 +56,6 @@ class SklearnPandasColumnwiseHooks(PandasColumnwiseHooks):
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the DataFrame, one column per result dimension."""
         if hasattr(result, "shape") and len(result.shape) == 2:
             if result.shape[1] == 1:
                 data[feature_name] = result.flatten()
@@ -81,12 +77,10 @@ class PyArrowColumnwiseHooks(ColumnwiseHooks):
 
     @classmethod
     def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the Table schema."""
         return set(data.schema.names)
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the Table, replacing the column when it already exists."""
         if feature_name in data.schema.names:
             column_index = data.schema.names.index(feature_name)
             data = data.remove_column(column_index)
@@ -99,19 +93,16 @@ class PythonDictColumnwiseHooks(ColumnwiseHooks):
 
     @classmethod
     def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the data."""
         return set(data.keys())
 
     @classmethod
     def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """Reject empty data before the presence policy runs."""
         if not data:
             raise ValueError("Data cannot be empty")
         super()._check_source_features_exist(data, feature_names)
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the row-aligned result to the data."""
         if len(result) != row_count(data):
             raise ValueError(f"Result length {len(result)} does not match data length {row_count(data)}")
 
@@ -125,7 +116,6 @@ class PolarsLazyColumnwiseHooks(ColumnwiseHooks):
 
     @classmethod
     def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the LazyFrame schema."""
         if not hasattr(data, "collect_schema"):
             raise ValueError("Data does not have a collect_schema method, cannot get available columns.")
         return set(data.collect_schema().names())

--- a/mloda_plugins/feature_group/columnwise_hooks.py
+++ b/mloda_plugins/feature_group/columnwise_hooks.py
@@ -6,10 +6,10 @@ tree to a family base directory, and a framework adapter belongs to no family.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from mloda.provider import FeatureGroup
-from mloda.user.python_dict import row_count
+from mloda.provider import COLUMN_DISCOVERY_HOOKS, FeatureGroup
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
 
 
 class ColumnwiseHooks:
@@ -18,23 +18,31 @@ class ColumnwiseHooks:
     # True: raise as soon as ANY source name is missing. False: raise only when NONE of them exists.
     STRICT_SOURCE_FEATURES: bool = True
 
-    @classmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        raise NotImplementedError(f"{cls.__name__} must implement _get_available_columns")
+    # The check below routes through the discovery hook, so every class mixing this in owes all three.
+    REQUIRED_COLUMNWISE_HOOKS = COLUMN_DISCOVERY_HOOKS
+
+    if TYPE_CHECKING:
+        # Declaration only: a runtime body here would shadow the raising default on
+        # FeatureChainParserMixin, which missing_columnwise_hooks compares against by identity.
+        @classmethod
+        def _get_available_columns(cls, data: Any) -> set[str]: ...
 
     @classmethod
     def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
         """Check that the resolved source features exist, as strictly as the family declares."""
         available = cls._get_available_columns(data)
         missing = [name for name in feature_names if name not in available]
+        # Sorted by str so the message is deterministic for every framework and survives mixed-type
+        # column labels, at the cost of a pandas frame's natural column order.
         if cls.STRICT_SOURCE_FEATURES:
             if missing:
                 raise ValueError(
-                    f"Source features not found in data: {missing}. Available columns: {sorted(available)}"
+                    f"Source features not found in data: {missing}. Available columns: {sorted(available, key=str)}"
                 )
         elif len(missing) == len(feature_names):
             raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {sorted(available)}"
+                f"None of the source features {feature_names} found in data."
+                f" Available columns: {sorted(available, key=str)}"
             )
 
 
@@ -64,8 +72,6 @@ class SklearnPandasColumnwiseHooks(PandasColumnwiseHooks):
                 named_columns = cast("type[FeatureGroup]", cls).apply_naming_convention(result, feature_name)
                 for col_name, col_data in named_columns.items():
                     data[col_name] = col_data
-        elif hasattr(result, "shape") and len(result.shape) == 1:
-            data[feature_name] = result
         else:
             data[feature_name] = result
 
@@ -82,9 +88,7 @@ class PyArrowColumnwiseHooks(ColumnwiseHooks):
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
         if feature_name in data.schema.names:
-            column_index = data.schema.names.index(feature_name)
-            data = data.remove_column(column_index)
-            return data.append_column(feature_name, result)
+            data = data.remove_column(data.schema.names.index(feature_name))
         return data.append_column(feature_name, result)
 
 

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pandas.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pandas.py
@@ -9,43 +9,17 @@ from typing import Any
 from mloda.provider import ComputeFramework
 
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 
 
-class PandasAggregatedFeatureGroup(AggregatedFeatureGroup):
+class PandasAggregatedFeatureGroup(PandasColumnwiseHooks, AggregatedFeatureGroup):
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with Pandas."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the DataFrame."""
-        return set(data.columns)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the DataFrame.
-
-        Args:
-            data: The Pandas DataFrame
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        missing_features = [name for name in feature_names if name not in data.columns]
-        if len(missing_features) == len(feature_names):
-            raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the DataFrame."""
-        data[feature_name] = result
-        return data
 
     @classmethod
     def _perform_aggregation(cls, data: Any, aggregation_type: str, in_features: list[str]) -> Any:

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
@@ -9,6 +9,7 @@ from typing import Any
 from mloda.provider import ComputeFramework
 
 from mloda.user.polars import PolarsLazyDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PolarsLazyColumnwiseHooks
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 
 try:
@@ -17,7 +18,7 @@ except ImportError:
     pl = None  # type: ignore[assignment]
 
 
-class PolarsLazyAggregatedFeatureGroup(AggregatedFeatureGroup):
+class PolarsLazyAggregatedFeatureGroup(PolarsLazyColumnwiseHooks, AggregatedFeatureGroup):
     """
     Polars Lazy implementation of aggregated feature group.
 
@@ -25,41 +26,12 @@ class PolarsLazyAggregatedFeatureGroup(AggregatedFeatureGroup):
     aggregation operations through query planning and deferred execution.
     """
 
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with Polars Lazy DataFrames."""
         return {PolarsLazyDataFrame}
-
-    @classmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """Get the set of available column names from the LazyFrame schema."""
-        if hasattr(data, "collect_schema"):
-            return set(data.collect_schema().names())
-        else:
-            raise ValueError("Data does not have a collect_schema method, cannot get available columns.")
-
-    @classmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the LazyFrame schema.
-
-        Args:
-            data: The Polars LazyFrame
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        if hasattr(data, "collect_schema"):
-            schema_names = set(data.collect_schema().names())
-            missing_features = [name for name in feature_names if name not in schema_names]
-            if len(missing_features) == len(feature_names):
-                raise ValueError(
-                    f"None of the source features {feature_names} found in data. "
-                    f"Available columns: {list(schema_names)}"
-                )
-        else:
-            raise ValueError("Data does not have a collect_schema method, cannot check feature existence.")
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -12,44 +12,23 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 
 from mloda.user.pyarrow import PyArrowTable
+from mloda_plugins.feature_group.columnwise_hooks import PyArrowColumnwiseHooks
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 
 
-class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
+class PyArrowAggregatedFeatureGroup(PyArrowColumnwiseHooks, AggregatedFeatureGroup):
     """
     PyArrow implementation of aggregated feature group.
 
     Supports multiple aggregation types in a single class.
     """
 
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with PyArrow."""
         return {PyArrowTable}
-
-    @classmethod
-    def _get_available_columns(cls, data: pa.Table) -> set[str]:
-        """Get the set of available column names from the Table schema."""
-        return set(data.schema.names)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pa.Table, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the Table.
-
-        Args:
-            data: The PyArrow Table
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        schema_names = set(data.schema.names)
-        missing_features = [name for name in feature_names if name not in schema_names]
-        if len(missing_features) == len(feature_names):
-            raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {list(schema_names)}"
-            )
 
     @classmethod
     def _add_result_to_data(cls, data: pa.Table, feature_name: str, result: Any) -> pa.Table:

--- a/mloda_plugins/feature_group/experimental/clustering/pandas.py
+++ b/mloda_plugins/feature_group/experimental/clustering/pandas.py
@@ -29,53 +29,17 @@ except ImportError:
 
 from mloda.provider import ComputeFramework
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
 
 
-class PandasClusteringFeatureGroup(ClusteringFeatureGroup):
+class PandasClusteringFeatureGroup(PandasColumnwiseHooks, ClusteringFeatureGroup):
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Define the compute framework for this feature group."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _get_available_columns(cls, data: pd.DataFrame) -> set[str]:
-        """Get the set of available column names from the DataFrame."""
-        return set(data.columns)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the DataFrame.
-
-        Args:
-            data: The Pandas DataFrame
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        missing_features = [name for name in feature_names if name not in data.columns]
-        if len(missing_features) == len(feature_names):
-            raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: "pd.DataFrame", feature_name: str, result: "NDArray[Any]") -> "pd.DataFrame":
-        """
-        Add the clustering result to the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_name: The name of the feature to add
-            result: The clustering result (cluster assignments)
-
-        Returns:
-            The updated DataFrame with the clustering result added
-        """
-        data[feature_name] = result
-        return data
 
     @classmethod
     def _perform_clustering(

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pandas.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pandas.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from mloda.provider import ComputeFramework
 
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 try:
@@ -18,30 +19,10 @@ except ImportError:
     pd = None
 
 
-class PandasMissingValueFeatureGroup(MissingValueFeatureGroup):
+class PandasMissingValueFeatureGroup(PandasColumnwiseHooks, MissingValueFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PandasDataFrame}
-
-    @classmethod
-    def _get_available_columns(cls, data: pd.DataFrame) -> set[str]:
-        """Get the set of available column names from the DataFrame."""
-        return set(data.columns)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """Check if the resolved source features exist in the DataFrame."""
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: Any) -> pd.DataFrame:
-        """Add the result to the DataFrame."""
-        data[feature_name] = result
-        return data
 
     @classmethod
     def _perform_imputation(

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -12,40 +12,14 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 
 from mloda.user.pyarrow import PyArrowTable
+from mloda_plugins.feature_group.columnwise_hooks import PyArrowColumnwiseHooks
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 
-class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
+class PyArrowMissingValueFeatureGroup(PyArrowColumnwiseHooks, MissingValueFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PyArrowTable}
-
-    @classmethod
-    def _get_available_columns(cls, data: pa.Table) -> set[str]:
-        """Get the set of available column names from the Table."""
-        return set(data.schema.names)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pa.Table, feature_names: list[str]) -> None:
-        """Check if the resolved source features exist in the Table."""
-        missing_features = [f for f in feature_names if f not in data.schema.names]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.schema.names)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: pa.Table, feature_name: str, result: Any) -> pa.Table:
-        """Add the result to the Table."""
-        if feature_name in data.schema.names:
-            # Column exists - replace it
-            # Remove the existing column and add the new one
-            column_index = data.schema.names.index(feature_name)
-            data = data.remove_column(column_index)
-            return data.append_column(feature_name, result)
-        else:
-            # Column doesn't exist - add it
-            return data.append_column(feature_name, result)
 
     @classmethod
     def _perform_imputation(

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
@@ -11,10 +11,11 @@ from typing import Any, Optional
 from mloda.provider import ComputeFramework
 
 from mloda.user.python_dict import PythonDictFramework, row_count
+from mloda_plugins.feature_group.columnwise_hooks import PythonDictColumnwiseHooks
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 
-class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
+class PythonDictMissingValueFeatureGroup(PythonDictColumnwiseHooks, MissingValueFeatureGroup):
     """
     PythonDict implementation for missing value imputation feature groups.
 
@@ -25,39 +26,6 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PythonDictFramework}
-
-    @classmethod
-    def _get_available_columns(cls, data: dict[str, list[Any]]) -> set[str]:
-        """Get the set of available column names from the data."""
-        return set(data.keys())
-
-    @classmethod
-    def _check_source_features_exist(cls, data: dict[str, list[Any]], feature_names: list[str]) -> None:
-        """Check if the resolved source features exist in the data."""
-        if not data:
-            raise ValueError("Data cannot be empty")
-
-        # Get all available features
-        available_features = cls._get_available_columns(data)
-
-        # Check which features are missing
-        missing_features = [f for f in feature_names if f not in available_features]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(available_features)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(
-        cls, data: dict[str, list[Any]], feature_name: str, result: list[Any]
-    ) -> dict[str, list[Any]]:
-        """Add the result to the data."""
-        if len(result) != row_count(data):
-            raise ValueError(f"Result length {len(result)} does not match data length {row_count(data)}")
-
-        data[feature_name] = list(result)
-
-        return data
 
     @classmethod
     def _perform_imputation(

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -8,6 +8,7 @@ from typing import Any, TYPE_CHECKING, cast
 
 from mloda.provider import ComputeFramework
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 
 if TYPE_CHECKING:
@@ -31,29 +32,11 @@ except ImportError:
     SKLEARN_AVAILABLE = False
 
 
-class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGroup):
+class PandasDimensionalityReductionFeatureGroup(PandasColumnwiseHooks, DimensionalityReductionFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Define the compute framework for this feature group."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If a feature does not exist in the DataFrame
-        """
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
 
     @classmethod
     def _add_result_to_data(cls, data: "pd.DataFrame", feature_name: str, result: "NDArray[Any]") -> "pd.DataFrame":

--- a/mloda_plugins/feature_group/experimental/forecasting/pandas.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/pandas.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas import pandas_type_semantics
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
 
 # Check if required packages are available
@@ -32,16 +33,13 @@ except ImportError:
     np = None  # type: ignore
 
 
-class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
+class PandasForecastingFeatureGroup(PandasColumnwiseHooks, ForecastingFeatureGroup):
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Define the compute framework for this feature group."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _get_available_columns(cls, data: pd.DataFrame) -> set[str]:
-        """Get the set of available column names from the DataFrame."""
-        return set(data.columns)
 
     @classmethod
     def _check_reference_time_column_exists(cls, data: pd.DataFrame, reference_time_column: str) -> None:
@@ -75,24 +73,6 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
         """
         semantics = pandas_type_semantics.column_semantics(data, reference_time_column)
         cls._validate_reference_time_column(semantics, reference_time_column)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        missing_features = [name for name in feature_names if name not in data.columns]
-        if len(missing_features) == len(feature_names):
-            raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {list(data.columns)}"
-            )
 
     @classmethod
     def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: pd.Series) -> pd.DataFrame:

--- a/mloda_plugins/feature_group/experimental/geo_distance/pandas.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/pandas.py
@@ -11,29 +11,15 @@ import numpy as np
 from mloda.provider import ComputeFramework
 
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
 
 
-class PandasGeoDistanceFeatureGroup(GeoDistanceFeatureGroup):
+class PandasGeoDistanceFeatureGroup(PandasColumnwiseHooks, GeoDistanceFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with Pandas."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """Check if the source features exist in the DataFrame."""
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the DataFrame."""
-        data[feature_name] = result
-        return data
 
     @classmethod
     def _calculate_distance(cls, data: Any, distance_type: str, point1_feature: str, point2_feature: str) -> Any:

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -16,32 +16,15 @@ except ImportError:
 
 from mloda.provider import CHAIN_SEPARATOR, ComputeFramework
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
 
 
-class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
+class PandasNodeCentralityFeatureGroup(PandasColumnwiseHooks, NodeCentralityFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Define the compute framework for this feature group."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If a feature does not exist in the DataFrame
-        """
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
 
     @classmethod
     def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: pd.Series) -> pd.DataFrame:

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -9,10 +9,11 @@ from typing import Any
 from mloda.provider import ComputeFramework
 
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
 
 
-class PandasEncodingFeatureGroup(EncodingFeatureGroup):
+class PandasEncodingFeatureGroup(PandasColumnwiseHooks, EncodingFeatureGroup):
     """
     Pandas implementation for scikit-learn encoding feature groups.
 
@@ -24,15 +25,6 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with Pandas."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """Check if the features exist in the DataFrame."""
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/pandas.py
@@ -9,10 +9,11 @@ from typing import Any
 from mloda.provider import ComputeFramework
 
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import SklearnPandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 
 
-class PandasSklearnPipelineFeatureGroup(SklearnPipelineFeatureGroup):
+class PandasSklearnPipelineFeatureGroup(SklearnPandasColumnwiseHooks, SklearnPipelineFeatureGroup):
     """
     Pandas implementation for scikit-learn pipeline feature groups.
 
@@ -24,38 +25,6 @@ class PandasSklearnPipelineFeatureGroup(SklearnPipelineFeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with Pandas."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """Check if the features exist in the DataFrame."""
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the DataFrame."""
-        # Handle different result types from sklearn pipelines
-        if hasattr(result, "shape") and len(result.shape) == 2:
-            # Multi-dimensional result (e.g., from PCA, multiple features)
-            if result.shape[1] == 1:
-                # Single column result
-                data[feature_name] = result.flatten()
-            else:
-                # Multiple columns - use naming convention with ~ separator
-                named_columns = cls.apply_naming_convention(result, feature_name)
-                for col_name, col_data in named_columns.items():
-                    data[col_name] = col_data
-        elif hasattr(result, "shape") and len(result.shape) == 1:
-            # Single dimensional result
-            data[feature_name] = result
-        else:
-            # Scalar or other result type
-            data[feature_name] = result
-
-        return data
 
     @classmethod
     def _extract_training_data(cls, data: Any, source_features: list[Any]) -> Any:

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/pandas.py
@@ -9,10 +9,11 @@ from typing import Any
 from mloda.provider import ComputeFramework
 
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import SklearnPandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
 
 
-class PandasScalingFeatureGroup(ScalingFeatureGroup):
+class PandasScalingFeatureGroup(SklearnPandasColumnwiseHooks, ScalingFeatureGroup):
     """
     Pandas implementation for scikit-learn scaling feature groups.
 
@@ -24,38 +25,6 @@ class PandasScalingFeatureGroup(ScalingFeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Specify that this feature group works with Pandas."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """Check if the features exist in the DataFrame."""
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """Add the result to the DataFrame."""
-        # Handle different result types from sklearn scalers
-        if hasattr(result, "shape") and len(result.shape) == 2:
-            # Multi-dimensional result (e.g., from Normalizer with multiple features)
-            if result.shape[1] == 1:
-                # Single column result
-                data[feature_name] = result.flatten()
-            else:
-                # Multiple columns - use naming convention with ~ separator
-                named_columns = cls.apply_naming_convention(result, feature_name)
-                for col_name, col_data in named_columns.items():
-                    data[col_name] = col_data
-        elif hasattr(result, "shape") and len(result.shape) == 1:
-            # Single dimensional result
-            data[feature_name] = result
-        else:
-            # Scalar or other result type
-            data[feature_name] = result
-
-        return data
 
     @classmethod
     def _extract_training_data(cls, data: Any, source_feature: str) -> Any:

--- a/mloda_plugins/feature_group/experimental/text_cleaning/pandas.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/pandas.py
@@ -27,10 +27,11 @@ except ImportError:
 
 from mloda.provider import ComputeFramework
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
 
 
-class PandasTextCleaningFeatureGroup(TextCleaningFeatureGroup):
+class PandasTextCleaningFeatureGroup(PandasColumnwiseHooks, TextCleaningFeatureGroup):
     """
     Pandas implementation of the TextCleaningFeatureGroup.
 
@@ -43,24 +44,6 @@ class PandasTextCleaningFeatureGroup(TextCleaningFeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         """Define the compute framework for this feature group."""
         return {PandasDataFrame}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If a feature does not exist in the DataFrame
-        """
-        missing_features = [f for f in feature_names if f not in data.columns]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. Available columns: {list(data.columns)}"
-            )
 
     @classmethod
     def _get_source_text(cls, data: pd.DataFrame, feature_name: str) -> pd.Series:
@@ -76,22 +59,6 @@ class PandasTextCleaningFeatureGroup(TextCleaningFeatureGroup):
         """
         # Convert to string if not already
         return data[feature_name].astype(str)
-
-    @classmethod
-    def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: pd.Series) -> pd.DataFrame:
-        """
-        Add the cleaning result to the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_name: The name of the feature to add
-            result: The cleaning result as a pandas Series
-
-        Returns:
-            The updated DataFrame with the cleaning result added
-        """
-        data[feature_name] = result
-        return data
 
     @classmethod
     def _apply_operation(cls, data: pd.DataFrame, text: pd.Series, operation: str) -> pd.Series:

--- a/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda.user.python_dict import PythonDictFramework, row_count
+from mloda.user.python_dict import PythonDictFramework
+from mloda_plugins.feature_group.columnwise_hooks import PythonDictColumnwiseHooks
 from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
 
 # Optional NLTK support - gracefully handle if not available
@@ -26,7 +27,7 @@ except ImportError:
     nltk_available = False
 
 
-class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
+class PythonDictTextCleaningFeatureGroup(PythonDictColumnwiseHooks, TextCleaningFeatureGroup):
     """
     PythonDict implementation for text cleaning feature groups.
 
@@ -38,19 +39,6 @@ class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PythonDictFramework}
-
-    @classmethod
-    def _check_source_features_exist(cls, data: dict[str, list[Any]], feature_names: list[str]) -> None:
-        if not data:
-            raise ValueError("Data cannot be empty")
-
-        available_features = set(data.keys())
-        missing_features = [f for f in feature_names if f not in available_features]
-        if missing_features:
-            raise ValueError(
-                f"Source features not found in data: {missing_features}. "
-                f"Available columns: {sorted(available_features)}"
-            )
 
     @classmethod
     def _get_source_text(cls, data: dict[str, list[Any]], feature_name: str) -> list[str]:
@@ -66,28 +54,6 @@ class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
         """
         # Convert to string if not already and handle None values
         return [str(value) if value is not None else "" for value in data.get(feature_name, [])]
-
-    @classmethod
-    def _add_result_to_data(
-        cls, data: dict[str, list[Any]], feature_name: str, result: list[str]
-    ) -> dict[str, list[Any]]:
-        """
-        Add the cleaning result to the data.
-
-        Args:
-            data: The columnar dict data structure
-            feature_name: The name of the feature to add
-            result: The cleaning result as a list of strings
-
-        Returns:
-            The updated data with the cleaning result added
-        """
-        if len(result) != row_count(data):
-            raise ValueError(f"Result length {len(result)} does not match data length {row_count(data)}")
-
-        data[feature_name] = list(result)
-
-        return data
 
     @classmethod
     def _apply_operation(cls, data: dict[str, list[Any]], text: list[str], operation: str) -> list[str]:

--- a/mloda_plugins/feature_group/experimental/time_window/pandas.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pandas.py
@@ -11,6 +11,7 @@ import numpy as np
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas import pandas_type_semantics
 from mloda.user.pandas import PandasDataFrame
+from mloda_plugins.feature_group.columnwise_hooks import PandasColumnwiseHooks
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
 
 
@@ -20,7 +21,9 @@ except ImportError:
     pd = None
 
 
-class PandasTimeWindowFeatureGroup(TimeWindowFeatureGroup):
+class PandasTimeWindowFeatureGroup(PandasColumnwiseHooks, TimeWindowFeatureGroup):
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PandasDataFrame}
@@ -39,35 +42,6 @@ class PandasTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         """Check if the reference time column is a datetime column."""
         semantics = pandas_type_semantics.column_semantics(data, reference_time_column)
         cls._validate_reference_time_column(semantics, reference_time_column)
-
-    @classmethod
-    def _get_available_columns(cls, data: pd.DataFrame) -> set[str]:
-        """Get the set of available column names from the DataFrame."""
-        return set(data.columns)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the DataFrame.
-
-        Args:
-            data: The Pandas DataFrame
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        missing_features = [name for name in feature_names if name not in data.columns]
-        if len(missing_features) == len(feature_names):
-            raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {list(data.columns)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: Any) -> pd.DataFrame:
-        """Add the result to the DataFrame."""
-        data[feature_name] = result
-        return data
 
     @classmethod
     def _perform_window_operation(

--- a/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
@@ -14,10 +14,13 @@ from mloda.provider import ComputeFramework
 
 from mloda_plugins.compute_framework.base_implementations.pyarrow import pyarrow_type_semantics
 from mloda.user.pyarrow import PyArrowTable
+from mloda_plugins.feature_group.columnwise_hooks import PyArrowColumnwiseHooks
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
 
 
-class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
+class PyArrowTimeWindowFeatureGroup(PyArrowColumnwiseHooks, TimeWindowFeatureGroup):
+    STRICT_SOURCE_FEATURES = False
+
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PyArrowTable}
@@ -36,45 +39,6 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         """Check if the reference time column is a datetime column."""
         semantics = pyarrow_type_semantics.column_semantics(data, reference_time_column)
         cls._validate_reference_time_column(semantics, reference_time_column)
-
-    @classmethod
-    def _get_available_columns(cls, data: pa.Table) -> set[str]:
-        """Get the set of available column names from the Table schema."""
-        return set(data.schema.names)
-
-    @classmethod
-    def _check_source_features_exist(cls, data: pa.Table, feature_names: list[str]) -> None:
-        """
-        Check if the resolved features exist in the Table.
-
-        Args:
-            data: The PyArrow Table
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the resolved features exist in the data
-        """
-        schema_names = set(data.schema.names)
-        missing_features = [name for name in feature_names if name not in schema_names]
-        if len(missing_features) == len(feature_names):
-            raise ValueError(
-                f"None of the source features {feature_names} found in data. Available columns: {list(schema_names)}"
-            )
-
-    @classmethod
-    def _add_result_to_data(cls, data: pa.Table, feature_name: str, result: Any) -> pa.Table:
-        """Add the result to the Table."""
-        # Check if column already exists
-        if feature_name in data.schema.names:
-            # Column exists, replace it by removing the old one and adding the new one
-            column_index = data.schema.names.index(feature_name)
-            # Remove the existing column
-            data = data.remove_column(column_index)
-            # Add the new column
-            return data.append_column(feature_name, result)
-        else:
-            # Column doesn't exist, add it normally
-            return data.append_column(feature_name, result)
 
     @classmethod
     def _perform_window_operation(

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
@@ -306,6 +306,68 @@ class TestPythonDictMergeEngineOneToMany:
         }
 
 
+class TestPythonDictDirectionalJoinShape:
+    """Column precedence and output column order of the left/right joins.
+
+    Both directions share one merge helper, so these pin the two axes that helper can
+    silently get wrong: which side wins an overlapping non-key column, and which side's
+    columns come first in the result.
+    """
+
+    @pytest.fixture
+    def overlap_left_data(self) -> Any:
+        """Left dataset whose payload column name collides with the right one."""
+        return {"idx": [1, 3], "v": ["a", "b"]}
+
+    @pytest.fixture
+    def overlap_right_data(self) -> Any:
+        """Right dataset whose payload column name collides with the left one."""
+        return {"idx": [1, 2], "v": ["x", "z"]}
+
+    @pytest.mark.parametrize(
+        ("jointype", "expected"),
+        [
+            (JoinType.LEFT, {"idx": [1, 3], "v": ["x", "b"]}),
+            (JoinType.RIGHT, {"idx": [1, 2], "v": ["x", "z"]}),
+        ],
+        ids=["left", "right"],
+    )
+    def test_directional_join_overlapping_column_takes_right_value(
+        self,
+        jointype: JoinType,
+        expected: dict[str, list[Any]],
+        overlap_left_data: Any,
+        overlap_right_data: Any,
+        index_obj: Any,
+    ) -> None:
+        """The right side wins a shared non-key column in both directions; left-winning gives 'a' on the matched row."""
+        engine = PythonDictMergeEngine()
+
+        result = engine.merge(overlap_left_data, overlap_right_data, make_merge_link(jointype, index_obj, index_obj))
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        ("jointype", "expected_columns"),
+        [
+            (JoinType.LEFT, ["idx", "lv", "rv"]),
+            (JoinType.RIGHT, ["idx", "rv", "lv"]),
+        ],
+        ids=["left", "right"],
+    )
+    def test_directional_join_orders_columns_primary_side_first(
+        self, jointype: JoinType, expected_columns: list[str], index_obj: Any
+    ) -> None:
+        """Columns follow the driving side first: left-then-right for LEFT, right-then-left for RIGHT."""
+        engine = PythonDictMergeEngine()
+        left_data = {"idx": [1, 3], "lv": ["a", "b"]}
+        right_data = {"idx": [1, 2], "rv": ["x", "z"]}
+
+        result = engine.merge(left_data, right_data, make_merge_link(jointype, index_obj, index_obj))
+
+        assert list(result.keys()) == expected_columns
+
+
 class TestPythonDictMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
     """Test PythonDictMergeEngine multi-index support using shared test scenarios."""
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
@@ -307,21 +307,16 @@ class TestPythonDictMergeEngineOneToMany:
 
 
 class TestPythonDictDirectionalJoinShape:
-    """Column precedence and output column order of the left/right joins.
-
-    Both directions share one merge helper, so these pin the two axes that helper can
-    silently get wrong: which side wins an overlapping non-key column, and which side's
-    columns come first in the result.
-    """
+    """Column precedence and output column order of the shared left/right join helper."""
 
     @pytest.fixture
     def overlap_left_data(self) -> Any:
-        """Left dataset whose payload column name collides with the right one."""
+        """Payload column name deliberately collides with the right side."""
         return {"idx": [1, 3], "v": ["a", "b"]}
 
     @pytest.fixture
     def overlap_right_data(self) -> Any:
-        """Right dataset whose payload column name collides with the left one."""
+        """Payload column name deliberately collides with the left side."""
         return {"idx": [1, 2], "v": ["x", "z"]}
 
     @pytest.mark.parametrize(

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_contract.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_contract.py
@@ -202,6 +202,15 @@ def test_strictness_map_agrees_with_signature_lists() -> None:
     assert mismatches == [], f"STRICTNESS disagrees with test_check_source_features_signature for: {mismatches}"
 
 
+@pytest.mark.parametrize("plugin_class", list(STRICTNESS), ids=[cls.__name__ for cls in STRICTNESS])
+def test_class_declares_its_source_feature_strictness(plugin_class: type[Any]) -> None:
+    """The table and the code attribute must not drift, so no class silently flips policy during the migration."""
+    assert plugin_class.STRICT_SOURCE_FEATURES is STRICTNESS[plugin_class], (
+        f"{plugin_class.__name__}.STRICT_SOURCE_FEATURES is {plugin_class.STRICT_SOURCE_FEATURES!r}, "
+        f"STRICTNESS says {STRICTNESS[plugin_class]!r}"
+    )
+
+
 def test_no_base_module_declares_a_hook_in_source() -> None:
     """Static sweep: no base.py under the experimental tree re-adds a hook declaration to a class body."""
     offenders: list[str] = []

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_contract.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_contract.py
@@ -204,7 +204,7 @@ def test_strictness_map_agrees_with_signature_lists() -> None:
 
 @pytest.mark.parametrize("plugin_class", list(STRICTNESS), ids=[cls.__name__ for cls in STRICTNESS])
 def test_class_declares_its_source_feature_strictness(plugin_class: type[Any]) -> None:
-    """The table and the code attribute must not drift, so no class silently flips policy during the migration."""
+    """The table and the declared attribute must not drift, so no class silently flips its presence policy."""
     assert plugin_class.STRICT_SOURCE_FEATURES is STRICTNESS[plugin_class], (
         f"{plugin_class.__name__}.STRICT_SOURCE_FEATURES is {plugin_class.STRICT_SOURCE_FEATURES!r}, "
         f"STRICTNESS says {STRICTNESS[plugin_class]!r}"

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_declaration.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_declaration.py
@@ -69,8 +69,8 @@ CONTRACT_SYMBOLS = (
 
 # Lower bounds only, so a broken glob or a wrong root cannot make the widened sweeps pass vacuously.
 MIN_EXPERIMENTAL_MODULES = 40
-# The structural invariant: every one of the 12 family bases calls its own hooks. A framework module
-# that calls one too is above this floor, so sharing the hooks out of the tree cannot break the sweep.
+# The floor is one hook-calling module per family base, so sharing the hooks out of the
+# experimental tree cannot make the sweep pass vacuously.
 MIN_HOOK_CALLING_MODULES = 12
 
 # The expected declaration per family base, kept as a table so a changed declaration is a visible diff.

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_declaration.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_declaration.py
@@ -69,7 +69,9 @@ CONTRACT_SYMBOLS = (
 
 # Lower bounds only, so a broken glob or a wrong root cannot make the widened sweeps pass vacuously.
 MIN_EXPERIMENTAL_MODULES = 40
-MIN_HOOK_CALLING_MODULES = 13
+# The structural invariant: every one of the 12 family bases calls its own hooks. A framework module
+# that calls one too is above this floor, so sharing the hooks out of the tree cannot break the sweep.
+MIN_HOOK_CALLING_MODULES = 12
 
 # The expected declaration per family base, kept as a table so a changed declaration is a visible diff.
 # A family that resolves column names against the data needs the discovery hook on top of the pair.

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_declaration.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_declaration.py
@@ -16,6 +16,7 @@ that, so no family base is allowed to reach into the deep core path again.
 from __future__ import annotations
 
 import ast
+import gc
 import importlib
 import inspect
 from pathlib import Path
@@ -30,6 +31,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     FeatureChainParserMixin,
     missing_columnwise_hooks,
 )
+from mloda_plugins.feature_group.columnwise_hooks import ColumnwiseHooks
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
@@ -253,9 +255,9 @@ def test_declaration_matches_the_hooks_each_base_module_calls() -> None:
 def test_no_family_module_calls_a_hook_its_base_does_not_declare() -> None:
     """Widened anti-drift sweep: a hook called ANYWHERE in a family must appear in that family's declaration.
 
-    The base-module sweep above only sees base.py, but the hooks are called from framework modules too
-    (missing_value/python_dict.py already calls the discovery hook). A framework module reaching for a
-    hook its family base never declared is exactly the drift the declaration is supposed to prevent.
+    The base-module sweep above only sees base.py; this one sees every module under the tree. Today all
+    hook-calling modules are the 12 base.py files, so it adds nothing, and that is the point: the day a
+    framework module reaches for a hook its family base never declared, this fails instead of the run.
     """
     declarations = _family_declarations()
     offenders: list[str] = []
@@ -311,3 +313,32 @@ def test_shipped_family_class_reports_no_missing_hook(plugin_class: type[Any]) -
     assert missing_columnwise_hooks(plugin_class) == expected, (
         f"missing_columnwise_hooks disagrees with the direct hook comparison for {plugin_class.__name__}"
     )
+
+
+def test_class_without_the_discovery_hook_is_reported_and_raises() -> None:
+    """If the report goes empty here, an unimplemented hook passes the pre-flight check and fails mid-run instead."""
+
+    class _DiscoveryHookProbe(ColumnwiseHooks, AggregatedFeatureGroup):
+        """Owns the writer only, so the declared discovery hook stays unimplemented."""
+
+        @classmethod
+        def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+            return data
+
+    try:
+        assert DISCOVERY_HOOK in _DiscoveryHookProbe.REQUIRED_COLUMNWISE_HOOKS, (
+            f"precondition: mixing in ColumnwiseHooks must declare {DISCOVERY_HOOK} required"
+        )
+        assert missing_columnwise_hooks(_DiscoveryHookProbe) == [DISCOVERY_HOOK], (
+            f"missing_columnwise_hooks must report {DISCOVERY_HOOK} missing: a runtime {DISCOVERY_HOOK} on "
+            "ColumnwiseHooks shadows the raising default the reader compares against, blinding the check"
+        )
+        with pytest.raises(NotImplementedError) as exc_info:
+            _DiscoveryHookProbe._check_source_features_exist({"col_a": [1]}, ["col_a"])
+        assert DISCOVERY_HOOK in str(exc_info.value), (
+            f"the reported hook must be the one that fails at runtime: {exc_info.value}"
+        )
+    finally:
+        # A FeatureGroup subclass lingers in __subclasses__() until collected, and other suites sweep those.
+        del _DiscoveryHookProbe
+        gc.collect()


### PR DESCRIPTION
The three column-wise hooks (`_get_available_columns`, `_check_source_features_exist`,
`_add_result_to_data`) were re-implemented per operation in every framework module: 18 copies of
the check, 10 of the discovery hook, 19 of the writer.

They now live on per-framework mixins in `mloda_plugins/feature_group/columnwise_hooks.py`. The
source-presence check becomes one implementation branching on `STRICT_SOURCE_FEATURES`, which
carries the two policies that already shipped:

- strict: raise as soon as any named source feature is missing
- tolerant: raise only when none of them exists

The split is unchanged for all 18 shipped classes, and the class attribute is pinned against the
strictness table the suite already kept, so a class cannot silently flip policy.

The module sits outside `experimental/` because the hook sweep binds every hook-calling module
under that tree to a family base directory, and a framework adapter belongs to none.

Also collapses the mirrored `_left_join` and `_right_join` in the python_dict merge engine onto one
directional helper. The two were not symmetric: output column order, the null-fill column list, the
iteration side, and the merged-row precedence each differ by direction.

### Behaviour notes

- Error message prefixes are unchanged. Available columns now render sorted by `str`, which makes
  the message deterministic for every framework (PyArrow and python_dict previously rendered a raw
  set) and keeps a mixed-type pandas column index from raising `TypeError` in place of the intended
  `ValueError`.
- `ColumnwiseHooks` declares `COLUMN_DISCOVERY_HOOKS`: the shared check routes through the
  discovery hook, so every class mixing it in owes all three. Its own `_get_available_columns` is a
  type-checker-only declaration, so a class that skips it still falls through to the raising default
  and `missing_columnwise_hooks` keeps reporting it.
- `row_count` is imported from `python_dict_utils`, so importing a pandas feature group no longer
  registers `PythonDictFramework` as a side effect.

### Tests

Two axes of the python_dict side joins were uncovered: which side wins an overlapping non-key
column, and the output column order. Mutating either left the whole suite green. Both are now
pinned in both directions, and each new test was confirmed to fail under its corresponding
mutation.

`tox` green: 9014 passed, 170 skipped, 2 xfailed. Net 335 lines out of `mloda/` and
`mloda_plugins/`.
