### PR TITLE
fix: give each JoinStep its own completion token

### DIFF
--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -31,7 +31,8 @@ class JoinStep(Step):
         self.step_is_done = False
 
     def get_uuids(self) -> set[UUID]:
-        return {self.uuid, self.link.uuid}
+        """Only this step's uuid is a completion token; the link uuid is shared by both orientations."""
+        return {self.uuid}
 
     def _merge_data(self, cfw: ComputeFramework, from_cfw_data: Any) -> None:
         """Merges data from another ComputeFramework into the current one."""

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -122,7 +122,65 @@ class ExecutionPlan:
 
         fw_execution_plan = self.handle_append_or_union_joinstep(fw_execution_plan)
 
+        self.expand_link_tokens(fw_execution_plan, link_trekker)
+        self.raise_on_joinstep_cycle(fw_execution_plan)
+
         return fw_execution_plan
+
+    def expand_link_tokens(
+        self, fw_execution_plan: list[JoinStep | FeatureGroupStep], link_trekker: LinkTrekker
+    ) -> None:
+        """Replace every waited-on link uuid with the uuids of the JoinSteps planned for that link."""
+        links_by_uuid: dict[UUID, Link] = {trekker[0].uuid: trekker[0] for trekker in link_trekker.data}
+        link_uuids = set(links_by_uuid) | set(link_trekker.order)
+
+        joinstep_uuids: dict[UUID, set[UUID]] = defaultdict(set)
+        for step in fw_execution_plan:
+            if isinstance(step, JoinStep):
+                joinstep_uuids[step.link.uuid].add(step.uuid)
+
+        for step in fw_execution_plan:
+            required_links = step.required_uuids & link_uuids
+            if not required_links:
+                continue
+
+            expanded: set[UUID] = set()
+            for link_uuid in required_links:
+                produced = joinstep_uuids.get(link_uuid)
+                if not produced:
+                    raise ValueError(
+                        internal_invariant_error(
+                            "a step waits for a link that no join step of the plan produces.",
+                            f"link={links_by_uuid.get(link_uuid, link_uuid)}",
+                        )
+                    )
+                expanded.update(produced)
+
+            step.required_uuids.difference_update(required_links)
+            # A step must never wait for a token it produces itself.
+            step.required_uuids.update(expanded - step.get_uuids())
+
+    def raise_on_joinstep_cycle(self, fw_execution_plan: list[JoinStep | FeatureGroupStep]) -> None:
+        """Expanded tokens order the join steps against each other, and a cycle would never run."""
+        join_steps: dict[UUID, JoinStep] = {step.uuid: step for step in fw_execution_plan if isinstance(step, JoinStep)}
+        pending = {uuid: step.required_uuids & set(join_steps) for uuid, step in join_steps.items()}
+
+        while True:
+            ready = {uuid for uuid, waits_for in pending.items() if not waits_for}
+            if not ready:
+                break
+            for uuid in ready:
+                del pending[uuid]
+            for waits_for in pending.values():
+                waits_for -= ready
+
+        if pending:
+            raise ValueError(
+                internal_invariant_error(
+                    "the join steps of the plan form a cycle.",
+                    f"links={sorted(str(join_steps[uuid].link) for uuid in pending)}",
+                )
+            )
 
     def handle_append_or_union_joinstep(
         self,
@@ -276,7 +334,7 @@ class ExecutionPlan:
                             match.add(found)
                             break
                     if match:
-                        # parent is served by a join step; the consumer is already ordered after it via the link uuid
+                        # parent is served by a join step; the expanded link token already orders the consumer
                         continue
 
                     # We only want to add TFS for direct parents and not for parent parents.

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1,8 +1,9 @@
+from collections.abc import Sequence
 from copy import copy, deepcopy
 from typing import Any, Generator, Optional
 from uuid import UUID
 
-from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
+from mloda.core.abstract_plugins.components.error_utils import REPORT_URL, internal_invariant_error
 from mloda.core.abstract_plugins.components.utils import safe_field
 from mloda.core.abstract_plugins.components.index.index import Index
 
@@ -18,6 +19,7 @@ from mloda.core.prepare.joinstep_collection import JoinStepCollection
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_graph import PlannedQueue
 from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker, inheritance_distance
+from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
@@ -40,6 +42,20 @@ def _filter_options_sort_key(single_filter: SingleFilter) -> tuple[str, str]:
         repr(sorted((str(k), safe_field(lambda: repr(v), type(v).__name__)) for k, v in options.group.items())),
         repr(sorted((str(k), safe_field(lambda: repr(v), type(v).__name__)) for k, v in options.context.items())),
     )
+
+
+def _describe_step(step: Step) -> str:
+    """Name a step of the plan for an error message."""
+    if isinstance(step, JoinStep):
+        return f"JoinStep(link={step.link})"
+    if isinstance(step, FeatureGroupStep):
+        return f"FeatureGroupStep({format_feature_group_class(step.feature_group)}, uuid={step.uuid})"
+    if isinstance(step, TransformFrameworkStep):
+        return (
+            f"TransformFrameworkStep({step.from_framework.get_class_name()} -> "
+            f"{step.to_framework.get_class_name()}, uuid={step.uuid})"
+        )
+    return f"{type(step).__name__}(uuid={step.uuid})"
 
 
 def _nearest_frameworks(frameworks_by_distance: dict[int, set[type[ComputeFramework]]]) -> set[type[ComputeFramework]]:
@@ -77,6 +93,7 @@ class ExecutionPlan:
         pre_execution_plan = self.add_feature_group_step(queue, graph.parent_to_children_mapping, child_links)
         fw_execution_plan = self.add_joinstep(pre_execution_plan, link_trekker, graph)
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
+        self.raise_on_step_cycle(self.execution_plan)
 
     def add_feature_group_step(
         self,
@@ -123,7 +140,6 @@ class ExecutionPlan:
         fw_execution_plan = self.handle_append_or_union_joinstep(fw_execution_plan)
 
         self.expand_link_tokens(fw_execution_plan, link_trekker)
-        self.raise_on_joinstep_cycle(fw_execution_plan)
 
         return fw_execution_plan
 
@@ -132,13 +148,17 @@ class ExecutionPlan:
     ) -> None:
         """Replace every waited-on link uuid with the uuids of the JoinSteps planned for that link."""
         links_by_uuid: dict[UUID, Link] = {trekker[0].uuid: trekker[0] for trekker in link_trekker.data}
-        link_uuids = set(links_by_uuid) | set(link_trekker.order)
 
         joinstep_uuids: dict[UUID, set[UUID]] = defaultdict(set)
         for step in fw_execution_plan:
             if isinstance(step, JoinStep):
                 joinstep_uuids[step.link.uuid].add(step.uuid)
 
+        # The planned steps are a source of link uuids of their own, and handle_append_or_union_joinstep waits on them.
+        link_uuids = set(links_by_uuid) | set(link_trekker.order) | set(joinstep_uuids)
+
+        # Collected first: a raise on a later step must not leave a half expanded plan behind.
+        expansions: list[tuple[JoinStep | FeatureGroupStep, set[UUID], set[UUID]]] = []
         for step in fw_execution_plan:
             required_links = step.required_uuids & link_uuids
             if not required_links:
@@ -148,22 +168,42 @@ class ExecutionPlan:
             for link_uuid in required_links:
                 produced = joinstep_uuids.get(link_uuid)
                 if not produced:
-                    raise ValueError(
-                        internal_invariant_error(
-                            "a step waits for a link that no join step of the plan produces.",
-                            f"link={links_by_uuid.get(link_uuid, link_uuid)}",
-                        )
-                    )
+                    raise ValueError(self._no_joinstep_for_link_error(links_by_uuid.get(link_uuid, link_uuid)))
                 expanded.update(produced)
 
-            step.required_uuids.difference_update(required_links)
             # A step must never wait for a token it produces itself.
-            step.required_uuids.update(expanded - step.get_uuids())
+            expansions.append((step, required_links, expanded - step.get_uuids()))
 
-    def raise_on_joinstep_cycle(self, fw_execution_plan: list[JoinStep | FeatureGroupStep]) -> None:
-        """Expanded tokens order the join steps against each other, and a cycle would never run."""
-        join_steps: dict[UUID, JoinStep] = {step.uuid: step for step in fw_execution_plan if isinstance(step, JoinStep)}
-        pending = {uuid: step.required_uuids & set(join_steps) for uuid, step in join_steps.items()}
+        for step, required_links, expanded in expansions:
+            step.required_uuids.difference_update(required_links)
+            step.required_uuids.update(expanded)
+
+    @staticmethod
+    def _no_joinstep_for_link_error(link: Link | UUID) -> str:
+        """A link a step waits for that planned no join step is a configuration problem, not a bug."""
+        return (
+            f"No join step was planned for a link that a step of the plan waits for: {link}\n"
+            "Possible causes:\n"
+            "  - The left_discriminator or right_discriminator values match none of the features' options.\n"
+            "  - The left compute framework of the link is not the compute framework of the child feature.\n"
+            "Resolution: align the discriminator values with the options you set on the features, and declare "
+            "the link on the compute framework the child is computed in.\n"
+            f"If neither applies, please report this issue at {REPORT_URL} with the full traceback."
+        )
+
+    def raise_on_step_cycle(self, steps: Sequence[Step]) -> None:
+        """Required tokens order the steps of the finished plan against each other, and a cycle would never run."""
+        producer_of: dict[UUID, UUID] = {}
+        steps_by_uuid: dict[UUID, Step] = {}
+        for step in steps:
+            steps_by_uuid[step.uuid] = step
+            for token in step.get_uuids():
+                producer_of[token] = step.uuid
+
+        # A token no step produces is not a cycle; the runtime reports it as a missing producer.
+        pending = {
+            step.uuid: {producer_of[token] for token in step.required_uuids if token in producer_of} for step in steps
+        }
 
         while True:
             ready = {uuid for uuid, waits_for in pending.items() if not waits_for}
@@ -177,8 +217,8 @@ class ExecutionPlan:
         if pending:
             raise ValueError(
                 internal_invariant_error(
-                    "the join steps of the plan form a cycle.",
-                    f"links={sorted(str(join_steps[uuid].link) for uuid in pending)}",
+                    "the steps of the plan form a cycle.",
+                    f"steps={sorted(_describe_step(steps_by_uuid[uuid]) for uuid in pending)}",
                 )
             )
 

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -395,15 +395,8 @@ class ExecutionOrchestrator:
         return self.data_lifecycle_manager.get_result_data(cfw, selected_feature_names, location)
 
     def currently_running_step(self, step_uuids: set[UUID], currently_running_steps: set[UUID]) -> bool:
-        """
-        Checks if a step is currently running.
-
-        Returns:
-            True if the step is currently running, False otherwise.
-        """
-        if next(iter(step_uuids)) not in currently_running_steps:
-            return False
-        return True
+        """True if any uuid of the step is running, the same rule _can_run_step refuses on."""
+        return not step_uuids.isdisjoint(currently_running_steps)
 
     def __enter__(
         self,

--- a/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
+++ b/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
@@ -1,0 +1,216 @@
+"""One completion token per JoinStep, expanded into every step that waits on the link."""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+from uuid import UUID
+
+import pytest
+
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.provider import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+TOKEN_LEFT_INDEX = Index(("token_left_key",))
+TOKEN_RIGHT_INDEX = Index(("token_right_key",))
+OTHER_LEFT_INDEX = Index(("token_other_left_key",))
+OTHER_RIGHT_INDEX = Index(("token_other_right_key",))
+
+
+class TokenLeft(FeatureGroup):
+    pass
+
+
+class TokenRight(FeatureGroup):
+    pass
+
+
+class TokenChild(FeatureGroup):
+    pass
+
+
+class TokenOtherLeft(FeatureGroup):
+    pass
+
+
+class TokenOtherRight(FeatureGroup):
+    pass
+
+
+class Planned(NamedTuple):
+    plan: ExecutionPlan
+    graph: Graph
+    link_trekker: LinkTrekker
+    pre_execution_plan: list[Any]
+
+
+def _feature(name: str, cfw: type[ComputeFramework], index: Index | None = None) -> Feature:
+    feature = Feature(name, index=index)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _step(fg: type[FeatureGroup], feature: Feature, required_uuids: set[UUID]) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    feature_set.add(feature)
+    return FeatureGroupStep(fg, feature_set, required_uuids, feature.get_compute_framework())
+
+
+def _planned() -> Planned:
+    return Planned(ExecutionPlan(), Graph(), LinkTrekker(), [])
+
+
+def _token_link() -> Link:
+    return Link.inner(JoinSpec(TokenLeft, TOKEN_LEFT_INDEX), JoinSpec(TokenRight, TOKEN_RIGHT_INDEX))
+
+
+def _other_link() -> Link:
+    return Link.inner(JoinSpec(TokenOtherLeft, OTHER_LEFT_INDEX), JoinSpec(TokenOtherRight, OTHER_RIGHT_INDEX))
+
+
+def _add_branch(
+    planned: Planned,
+    link: Link,
+    name: str,
+    left_cfw: type[ComputeFramework] = PyArrowTable,
+    right_cfw: type[ComputeFramework] = PandasDataFrame,
+    plan_the_link: bool = True,
+) -> FeatureGroupStep:
+    """Two parents joined by ``link`` plus the consumer, the smallest shape run_link accepts."""
+    left = _feature(f"{name}_left", left_cfw, link.left_index)
+    right = _feature(f"{name}_right", right_cfw, link.right_index)
+    child = _feature(f"{name}_child", left_cfw)
+
+    graph = planned.graph
+    graph.add_node(left.uuid, NodeProperties(left, link.left_feature_group))
+    graph.add_node(right.uuid, NodeProperties(right, link.right_feature_group))
+    graph.add_node(child.uuid, NodeProperties(child, TokenChild))
+    graph.adjacency_list[left.uuid] = [child.uuid]
+    graph.adjacency_list[right.uuid] = [child.uuid]
+    graph.adjacency_list[child.uuid] = []
+    graph.parent_to_children_mapping[child.uuid] = {left.uuid, right.uuid}
+
+    planned.plan.feature_set_collections.extend([{left.uuid}, {right.uuid}, {child.uuid}])
+
+    consumer = _step(TokenChild, child, {left.uuid, right.uuid, link.uuid})
+    planned.pre_execution_plan.append(_step(link.left_feature_group, left, set()))
+    planned.pre_execution_plan.append(_step(link.right_feature_group, right, set()))
+    if plan_the_link:
+        planned.pre_execution_plan.append((link, left_cfw, right_cfw))
+    planned.pre_execution_plan.append(consumer)
+
+    # Production shares one set object between data and data_ordered, and invert_link relies on that.
+    trekked = {child.uuid}
+    planned.link_trekker.data[(link, left_cfw, right_cfw)] = trekked
+    planned.link_trekker.data_ordered[(link, left_cfw, right_cfw)] = trekked
+    return consumer
+
+
+def _add_joinstep(planned: Planned) -> list[JoinStep | FeatureGroupStep]:
+    return planned.plan.add_joinstep(planned.pre_execution_plan, planned.link_trekker, planned.graph)
+
+
+def _join_steps(fw_execution_plan: list[JoinStep | FeatureGroupStep], link: Link) -> list[JoinStep]:
+    return [step for step in fw_execution_plan if isinstance(step, JoinStep) and step.link is link]
+
+
+def test_a_joinstep_stamps_only_its_own_completion_token() -> None:
+    link = _token_link()
+    step = JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+
+    assert step.get_uuids() == {step.uuid}
+    assert link.uuid not in step.get_uuids(), "the link uuid is an identity, not a completion token"
+
+
+def test_two_joinsteps_of_one_link_carry_disjoint_completion_tokens() -> None:
+    link = _token_link()
+    declared = JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+    inverted = JoinStep(link, PandasDataFrame, PyArrowTable, set(), set(), set())
+
+    assert declared.get_uuids().isdisjoint(inverted.get_uuids()), (
+        "a shared token lets a consumer unblock after whichever orientation finishes first"
+    )
+
+
+def test_add_joinstep_replaces_the_link_token_of_a_consumer_with_the_planned_joinstep() -> None:
+    planned = _planned()
+    link = _token_link()
+    consumer = _add_branch(planned, link, "single")
+
+    fw_execution_plan = _add_joinstep(planned)
+
+    join_steps = _join_steps(fw_execution_plan, link)
+    assert len(join_steps) == 1, f"the declared orientation must plan one JoinStep; got: {join_steps}"
+    assert link.uuid not in consumer.required_uuids, "no step may keep waiting on the link uuid"
+    assert join_steps[0].uuid in consumer.required_uuids
+
+
+def test_add_joinstep_makes_a_consumer_wait_for_both_orientations_of_its_link() -> None:
+    planned = _planned()
+    link = _token_link()
+    declared_consumer = _add_branch(planned, link, "declared", PyArrowTable, PandasDataFrame)
+    inverted_consumer = _add_branch(planned, link, "inverted", PandasDataFrame, PyArrowTable)
+
+    fw_execution_plan = _add_joinstep(planned)
+
+    join_uuids = {step.uuid for step in _join_steps(fw_execution_plan, link)}
+    assert len(join_uuids) == 2, f"both orientations must plan a JoinStep; got: {join_uuids}"
+    for consumer in (declared_consumer, inverted_consumer):
+        assert link.uuid not in consumer.required_uuids, "no step may keep waiting on the link uuid"
+        assert join_uuids.issubset(consumer.required_uuids), (
+            f"a consumer of the link must wait for every JoinStep of it; got: {consumer.required_uuids}"
+        )
+
+
+def test_add_joinstep_rejects_a_link_token_that_no_joinstep_produces() -> None:
+    """The link reaches the trekker but never the plan, so nothing would ever stamp its token."""
+    planned = _planned()
+    link = _token_link()
+    _add_branch(planned, link, "unplanned", plan_the_link=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        _add_joinstep(planned)
+
+    assert str(link.uuid) in str(excinfo.value), f"the unproduced link must be named; got: {excinfo.value}"
+
+
+def test_add_joinstep_never_makes_a_joinstep_wait_for_itself() -> None:
+    """Hand built: the ordering entry names the link itself, which the expansion must not honour."""
+    planned = _planned()
+    link = _token_link()
+    _add_branch(planned, link, "selfwait")
+    planned.link_trekker.order[link.uuid] = {link.uuid}
+
+    fw_execution_plan = _add_joinstep(planned)
+
+    join_step = _join_steps(fw_execution_plan, link)[0]
+    assert link.uuid not in join_step.required_uuids
+    assert join_step.required_uuids.isdisjoint(join_step.get_uuids()), (
+        f"a JoinStep may not wait for a token it produces itself; got: {join_step.required_uuids}"
+    )
+
+
+def test_add_joinstep_rejects_a_cycle_the_expansion_leaves_between_two_joinsteps() -> None:
+    """Hand built: each link is ordered after the other, so expanding both tokens deadlocks the run."""
+    planned = _planned()
+    link = _token_link()
+    other = _other_link()
+    _add_branch(planned, link, "cycle_first")
+    _add_branch(planned, other, "cycle_second")
+    planned.link_trekker.order[link.uuid] = {other.uuid}
+    planned.link_trekker.order[other.uuid] = {link.uuid}
+
+    with pytest.raises(ValueError, match="(?i)cycl"):
+        _add_joinstep(planned)

--- a/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
+++ b/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
@@ -1,24 +1,35 @@
-"""One completion token per JoinStep, expanded into every step that waits on the link."""
+"""One completion token per JoinStep, expanded into every step that waits on the link.
+
+The cycle guard runs over the finished plan, so it sees join steps and feature group steps alike.
+"""
 
 from __future__ import annotations
 
-from typing import Any, NamedTuple
-from uuid import UUID
+from collections.abc import Sequence
+from typing import Any, NamedTuple, Optional
+from uuid import UUID, uuid4
 
 import pytest
 
+from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.graph.properties import NodeProperties
 from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.user import Feature
+from mloda.user import FeatureName
 from mloda.user import Index
 from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
@@ -27,6 +38,16 @@ TOKEN_LEFT_INDEX = Index(("token_left_key",))
 TOKEN_RIGHT_INDEX = Index(("token_right_key",))
 OTHER_LEFT_INDEX = Index(("token_other_left_key",))
 OTHER_RIGHT_INDEX = Index(("token_other_right_key",))
+
+APPEND_HEAD_INDEX = Index(("token_append_head_key",))
+APPEND_MIDDLE_INDEX = Index(("token_append_middle_key",))
+APPEND_TAIL_INDEX = Index(("token_append_tail_key",))
+
+SELF_SIDE = "token_self_side"
+SELF_LEFT_KEY = "token_self_left_key"
+SELF_LEFT_PAYLOAD = "token_self_left_payload"
+SELF_RIGHT_KEY = "token_self_right_key"
+SELF_RIGHT_PAYLOAD = "token_self_right_payload"
 
 
 class TokenLeft(FeatureGroup):
@@ -49,11 +70,58 @@ class TokenOtherRight(FeatureGroup):
     pass
 
 
+class TokenAppendSource(FeatureGroup):
+    pass
+
+
+class TokenSelfSource(FeatureGroup):
+    """Serves both sides of the self join; the requested feature name picks the side."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={SELF_LEFT_PAYLOAD, SELF_RIGHT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if SELF_LEFT_PAYLOAD in {str(feature.name) for feature in features.features}:
+            return {SELF_LEFT_KEY: [1, 2], SELF_LEFT_PAYLOAD: ["l1", "l2"]}
+        return {SELF_RIGHT_KEY: [1, 2], SELF_RIGHT_PAYLOAD: ["r1", "r2"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class TokenSelfConsumer(FeatureGroup):
+    """Consumes both sides of the self join; the options are what the discriminators match on."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name=SELF_LEFT_PAYLOAD, options={SELF_SIDE: "left"}),
+            Feature(name=SELF_RIGHT_PAYLOAD, options={SELF_SIDE: "right"}),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
 class Planned(NamedTuple):
     plan: ExecutionPlan
     graph: Graph
     link_trekker: LinkTrekker
     pre_execution_plan: list[Any]
+    queue: list[Any]
+
+
+class Branch(NamedTuple):
+    consumer: FeatureGroupStep
+    left_uuid: UUID
+    right_uuid: UUID
 
 
 def _feature(name: str, cfw: type[ComputeFramework], index: Index | None = None) -> Feature:
@@ -69,7 +137,7 @@ def _step(fg: type[FeatureGroup], feature: Feature, required_uuids: set[UUID]) -
 
 
 def _planned() -> Planned:
-    return Planned(ExecutionPlan(), Graph(), LinkTrekker(), [])
+    return Planned(ExecutionPlan(), Graph(), LinkTrekker(), [], [])
 
 
 def _token_link() -> Link:
@@ -80,6 +148,15 @@ def _other_link() -> Link:
     return Link.inner(JoinSpec(TokenOtherLeft, OTHER_LEFT_INDEX), JoinSpec(TokenOtherRight, OTHER_RIGHT_INDEX))
 
 
+def _self_link(left_side: str, right_side: str) -> Link:
+    return Link.left(
+        JoinSpec(TokenSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(TokenSelfSource, Index((SELF_RIGHT_KEY,))),
+        left_discriminator={SELF_SIDE: left_side},
+        right_discriminator={SELF_SIDE: right_side},
+    )
+
+
 def _add_branch(
     planned: Planned,
     link: Link,
@@ -87,7 +164,7 @@ def _add_branch(
     left_cfw: type[ComputeFramework] = PyArrowTable,
     right_cfw: type[ComputeFramework] = PandasDataFrame,
     plan_the_link: bool = True,
-) -> FeatureGroupStep:
+) -> Branch:
     """Two parents joined by ``link`` plus the consumer, the smallest shape run_link accepts."""
     left = _feature(f"{name}_left", left_cfw, link.left_index)
     right = _feature(f"{name}_right", right_cfw, link.right_index)
@@ -102,28 +179,56 @@ def _add_branch(
     graph.adjacency_list[child.uuid] = []
     graph.parent_to_children_mapping[child.uuid] = {left.uuid, right.uuid}
 
-    planned.plan.feature_set_collections.extend([{left.uuid}, {right.uuid}, {child.uuid}])
-
     consumer = _step(TokenChild, child, {left.uuid, right.uuid, link.uuid})
     planned.pre_execution_plan.append(_step(link.left_feature_group, left, set()))
     planned.pre_execution_plan.append(_step(link.right_feature_group, right, set()))
+    planned.queue.append((link.left_feature_group, {left}))
+    planned.queue.append((link.right_feature_group, {right}))
     if plan_the_link:
         planned.pre_execution_plan.append((link, left_cfw, right_cfw))
+        planned.queue.append((link, left_cfw, right_cfw))
     planned.pre_execution_plan.append(consumer)
+    planned.queue.append((TokenChild, {child}))
 
-    # Production shares one set object between data and data_ordered, and invert_link relies on that.
-    trekked = {child.uuid}
+    _trek(planned, link, left_cfw, right_cfw, child.uuid)
+    return Branch(consumer, left.uuid, right.uuid)
+
+
+def _trek(
+    planned: Planned, link: Link, left_cfw: type[ComputeFramework], right_cfw: type[ComputeFramework], uuid: UUID
+) -> None:
+    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
+    trekked = {uuid}
     planned.link_trekker.data[(link, left_cfw, right_cfw)] = trekked
     planned.link_trekker.data_ordered[(link, left_cfw, right_cfw)] = trekked
-    return consumer
 
 
 def _add_joinstep(planned: Planned) -> list[JoinStep | FeatureGroupStep]:
+    """add_feature_group_step fills the collections on the queue path; this path has to do it itself."""
+    planned.plan.feature_set_collections = [
+        step.get_uuids() for step in planned.pre_execution_plan if isinstance(step, FeatureGroupStep)
+    ]
     return planned.plan.add_joinstep(planned.pre_execution_plan, planned.link_trekker, planned.graph)
 
 
-def _join_steps(fw_execution_plan: list[JoinStep | FeatureGroupStep], link: Link) -> list[JoinStep]:
-    return [step for step in fw_execution_plan if isinstance(step, JoinStep) and step.link is link]
+def _create_execution_plan(planned: Planned) -> list[Step]:
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+    return list(planned.plan)
+
+
+def _join_steps(steps: Sequence[Step], link: Link) -> list[JoinStep]:
+    return [step for step in steps if isinstance(step, JoinStep) and step.link is link]
+
+
+def _run_self_join(link: Link) -> list[Any]:
+    return list(
+        mloda.run_all(
+            [Feature(name=TokenSelfConsumer.get_class_name())],
+            links={link},
+            compute_frameworks=["PyArrowTable"],
+            plugin_collector=PluginCollector.enabled_feature_groups({TokenSelfSource, TokenSelfConsumer}),
+        )
+    )
 
 
 def test_a_joinstep_stamps_only_its_own_completion_token() -> None:
@@ -147,30 +252,42 @@ def test_two_joinsteps_of_one_link_carry_disjoint_completion_tokens() -> None:
 def test_add_joinstep_replaces_the_link_token_of_a_consumer_with_the_planned_joinstep() -> None:
     planned = _planned()
     link = _token_link()
-    consumer = _add_branch(planned, link, "single")
+    branch = _add_branch(planned, link, "single")
 
     fw_execution_plan = _add_joinstep(planned)
 
     join_steps = _join_steps(fw_execution_plan, link)
     assert len(join_steps) == 1, f"the declared orientation must plan one JoinStep; got: {join_steps}"
-    assert link.uuid not in consumer.required_uuids, "no step may keep waiting on the link uuid"
-    assert join_steps[0].uuid in consumer.required_uuids
+    assert link.uuid not in branch.consumer.required_uuids, "no step may keep waiting on the link uuid"
+    assert join_steps[0].uuid in branch.consumer.required_uuids
+
+
+def test_add_joinstep_leaves_the_parent_uuids_a_consumer_waits_for_untouched() -> None:
+    """Only link uuids are expanded; the feature uuids of both parents stay required."""
+    planned = _planned()
+    branch = _add_branch(planned, _token_link(), "parents")
+
+    _add_joinstep(planned)
+
+    assert {branch.left_uuid, branch.right_uuid} <= branch.consumer.required_uuids, (
+        f"the expansion swallowed a parent uuid; got: {branch.consumer.required_uuids}"
+    )
 
 
 def test_add_joinstep_makes_a_consumer_wait_for_both_orientations_of_its_link() -> None:
     planned = _planned()
     link = _token_link()
-    declared_consumer = _add_branch(planned, link, "declared", PyArrowTable, PandasDataFrame)
-    inverted_consumer = _add_branch(planned, link, "inverted", PandasDataFrame, PyArrowTable)
+    declared = _add_branch(planned, link, "declared", PyArrowTable, PandasDataFrame)
+    inverted = _add_branch(planned, link, "inverted", PandasDataFrame, PyArrowTable)
 
     fw_execution_plan = _add_joinstep(planned)
 
     join_uuids = {step.uuid for step in _join_steps(fw_execution_plan, link)}
     assert len(join_uuids) == 2, f"both orientations must plan a JoinStep; got: {join_uuids}"
-    for consumer in (declared_consumer, inverted_consumer):
-        assert link.uuid not in consumer.required_uuids, "no step may keep waiting on the link uuid"
-        assert join_uuids.issubset(consumer.required_uuids), (
-            f"a consumer of the link must wait for every JoinStep of it; got: {consumer.required_uuids}"
+    for branch in (declared, inverted):
+        assert link.uuid not in branch.consumer.required_uuids, "no step may keep waiting on the link uuid"
+        assert join_uuids.issubset(branch.consumer.required_uuids), (
+            f"a consumer of the link must wait for every JoinStep of it; got: {branch.consumer.required_uuids}"
         )
 
 
@@ -184,6 +301,25 @@ def test_add_joinstep_rejects_a_link_token_that_no_joinstep_produces() -> None:
         _add_joinstep(planned)
 
     assert str(link.uuid) in str(excinfo.value), f"the unproduced link must be named; got: {excinfo.value}"
+
+
+def test_a_self_join_whose_discriminators_match_nothing_is_rejected_naming_the_link() -> None:
+    """No orientation pairs the two nodes up, so no JoinStep stamps the token the consumer waits for."""
+    link = _self_link("no_such_left", "no_such_right")
+
+    with pytest.raises(ValueError) as excinfo:
+        _run_self_join(link)
+
+    assert str(link.uuid) in str(excinfo.value), f"the link that planned nothing must be named; got: {excinfo.value}"
+
+
+def test_a_discriminator_that_matches_nothing_is_reported_as_configuration_not_as_an_mloda_bug() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _run_self_join(_self_link("no_such_left", "no_such_right"))
+
+    message = str(excinfo.value)
+    assert "discriminator" in message, f"the cause the user can fix must be named; got: {message}"
+    assert "Internal error" not in message, f"this is user configuration, not an invariant breach; got: {message}"
 
 
 def test_add_joinstep_never_makes_a_joinstep_wait_for_itself() -> None:
@@ -202,7 +338,31 @@ def test_add_joinstep_never_makes_a_joinstep_wait_for_itself() -> None:
     )
 
 
-def test_add_joinstep_rejects_a_cycle_the_expansion_leaves_between_two_joinsteps() -> None:
+def test_a_chained_append_joinstep_waits_for_the_joinstep_of_the_link_it_was_handed() -> None:
+    """Hand built JoinSteps stand in for run_link's output: the head appends what the tail first completed."""
+    planned = _planned()
+    head_link = Link.append(
+        JoinSpec(TokenAppendSource, APPEND_HEAD_INDEX), JoinSpec(TokenAppendSource, APPEND_MIDDLE_INDEX)
+    )
+    tail_link = Link.append(
+        JoinSpec(TokenAppendSource, APPEND_MIDDLE_INDEX), JoinSpec(TokenAppendSource, APPEND_TAIL_INDEX)
+    )
+    head_uuid, middle_uuid, tail_uuid = uuid4(), uuid4(), uuid4()
+
+    head = JoinStep(head_link, PyArrowTable, PyArrowTable, {head_uuid, middle_uuid}, {head_uuid}, {middle_uuid})
+    tail = JoinStep(tail_link, PyArrowTable, PyArrowTable, {middle_uuid, tail_uuid}, {middle_uuid}, {tail_uuid})
+    planned.pre_execution_plan.extend([head, tail])
+    _trek(planned, head_link, PyArrowTable, PyArrowTable, head_uuid)
+    _trek(planned, tail_link, PyArrowTable, PyArrowTable, middle_uuid)
+
+    _add_joinstep(planned)
+
+    assert tail.uuid in head.required_uuids, f"the chained edge must name the tail JoinStep; got: {head.required_uuids}"
+    assert tail_link.uuid not in head.required_uuids, "no step may keep waiting on the link uuid"
+    assert {head_uuid, middle_uuid} <= head.required_uuids, "the expansion swallowed a parent uuid"
+
+
+def test_create_execution_plan_rejects_a_cycle_the_expansion_leaves_between_two_joinsteps() -> None:
     """Hand built: each link is ordered after the other, so expanding both tokens deadlocks the run."""
     planned = _planned()
     link = _token_link()
@@ -213,4 +373,52 @@ def test_add_joinstep_rejects_a_cycle_the_expansion_leaves_between_two_joinsteps
     planned.link_trekker.order[other.uuid] = {link.uuid}
 
     with pytest.raises(ValueError, match="(?i)cycl"):
-        _add_joinstep(planned)
+        _create_execution_plan(planned)
+
+
+def test_create_execution_plan_plans_a_chain_of_two_ordered_links() -> None:
+    """One ordering edge is a chain, not a cycle, and the finished plan keeps it as a JoinStep token."""
+    planned = _planned()
+    link = _token_link()
+    other = _other_link()
+    _add_branch(planned, link, "chain_first")
+    _add_branch(planned, other, "chain_second")
+    planned.link_trekker.order[link.uuid] = {other.uuid}
+
+    execution_plan = _create_execution_plan(planned)
+
+    first = _join_steps(execution_plan, link)[0]
+    second = _join_steps(execution_plan, other)[0]
+    assert first.uuid in second.required_uuids, (
+        f"the chained JoinStep must wait for the first; got: {second.required_uuids}"
+    )
+    assert link.uuid not in second.required_uuids, "no step may keep waiting on the link uuid"
+
+
+def test_raise_on_step_cycle_rejects_three_joinsteps_waiting_on_each_other() -> None:
+    """The pair shape is broken upstream already, so a three step ring is what this guard is for."""
+    steps: list[Step] = [JoinStep(_token_link(), PyArrowTable, PandasDataFrame, set(), set(), set()) for _ in range(3)]
+    for step, waits_for in zip(steps, steps[1:] + steps[:1]):
+        step.required_uuids.add(waits_for.uuid)
+
+    with pytest.raises(ValueError, match="(?i)cycl"):
+        ExecutionPlan().raise_on_step_cycle(steps)
+
+
+def test_raise_on_step_cycle_rejects_a_cycle_running_through_a_feature_group_step() -> None:
+    """A JoinStep waiting on a feature its consumer produces is as unrunnable as a JoinStep pair."""
+    feature = _feature("token_cycle_feature", PyArrowTable)
+    join_step = JoinStep(_token_link(), PyArrowTable, PandasDataFrame, set(), set(), set())
+    feature_group_step = _step(TokenChild, feature, {join_step.uuid})
+    join_step.required_uuids.add(feature.uuid)
+    steps: list[Step] = [join_step, feature_group_step]
+
+    with pytest.raises(ValueError, match="(?i)cycl"):
+        ExecutionPlan().raise_on_step_cycle(steps)
+
+
+def test_raise_on_step_cycle_accepts_a_token_no_step_of_the_plan_produces() -> None:
+    """The runtime already raises for an unproduced token; a missing producer is not a cycle."""
+    steps: list[Step] = [JoinStep(_token_link(), PyArrowTable, PandasDataFrame, {uuid4()}, set(), set())]
+
+    ExecutionPlan().raise_on_step_cycle(steps)

--- a/tests/test_core/test_runtime/test_currently_running_step.py
+++ b/tests/test_core/test_runtime/test_currently_running_step.py
@@ -1,0 +1,55 @@
+"""The running check must answer for the whole step, not for one arbitrary uuid."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.core.cfw_manager import CfwManager
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.runtime.run import ExecutionOrchestrator
+
+
+def _orchestrator() -> ExecutionOrchestrator:
+    """A SYNC orchestrator over an empty plan; the running check never touches a plan step."""
+    orchestrator = ExecutionOrchestrator(ExecutionPlan())
+    orchestrator.cfw_register = CfwManager({ParallelizationMode.SYNC})
+    return orchestrator
+
+
+def _step_uuids_and_a_later_one() -> tuple[set[UUID], UUID]:
+    """A two-uuid step plus the uuid its iterator does not reach first."""
+    step_uuids = {uuid4(), uuid4()}
+    first = next(iter(step_uuids))
+    later = next(uuid for uuid in step_uuids if uuid != first)
+    return step_uuids, later
+
+
+def test_currently_running_step_reports_a_uuid_the_iterator_reaches_second() -> None:
+    step_uuids, later = _step_uuids_and_a_later_one()
+
+    assert _orchestrator().currently_running_step(step_uuids, {later}) is True
+
+
+def test_currently_running_step_reports_every_running_uuid_of_the_step() -> None:
+    orchestrator = _orchestrator()
+    step_uuids = {uuid4(), uuid4()}
+
+    running = [uuid for uuid in step_uuids if orchestrator.currently_running_step(step_uuids, {uuid})]
+
+    assert sorted(running) == sorted(step_uuids), f"every uuid of the step must count as running; got: {running}"
+
+
+def test_currently_running_step_agrees_with_the_refusal_of_can_run_step() -> None:
+    orchestrator = _orchestrator()
+    step_uuids, later = _step_uuids_and_a_later_one()
+
+    refused = not orchestrator._can_run_step(set(), step_uuids, set(), {later}, None)
+
+    assert orchestrator.currently_running_step(step_uuids, {later}) is refused
+
+
+def test_currently_running_step_is_false_when_no_uuid_of_the_step_is_running() -> None:
+    step_uuids = {uuid4(), uuid4()}
+
+    assert _orchestrator().currently_running_step(step_uuids, {uuid4()}) is False

--- a/tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py
+++ b/tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py
@@ -114,9 +114,7 @@ class SwappedChildPyArrowLeft(FeatureGroup):
         return {PyArrowTable, PandasDataFrame}
 
 
-# Threading is left out: both orientations produce a JoinStep carrying the same link uuid as its completion
-# token, so a child can start once either join reported done. That predates this scenario.
-@pytest.mark.parametrize("modes", [({ParallelizationMode.SYNC})])
+@pytest.mark.parametrize("modes", [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}])
 class TestSwappedLinkOrientationReconciliation:
     def test_both_children_receive_the_joined_columns(
         self, modes: set[ParallelizationMode], flight_server: Any


### PR DESCRIPTION
## Problem

`JoinStep.get_uuids()` returned `{self.uuid, self.link.uuid}`. When one `Link` is planned in both orientations the planner emits two `JoinStep`s, and both stamped the same `link.uuid` as their completion token. A consumer holding that uuid in `required_uuids` therefore unblocked as soon as *either* join reported done, and under `ParallelizationMode.THREADING` it computed against unjoined data.

Independently, `ExecutionOrchestrator.currently_running_step` decided "is this step running" from `next(iter(step_uuids))`, i.e. from set iteration order, while `_can_run_step` refuses on the whole set. With a two-element token set that disagreement was a second nondeterminism contributor.

## Change

`get_uuids()` now returns only the step uuid. The link uuid keeps its identity and lookup roles untouched: `children_if_root`, `TransformFrameworkStep.link_id`, and the `cfw_register.get_cfw_uuid(..., link.uuid)` lookups in the executor and the multiprocessing worker.

`ExecutionPlan.add_joinstep` gained an expansion pass that replaces every link uuid a step waits on with the uuids of the JoinSteps planned for that link. It runs before `add_tfs` copies dependency sets, collects before it mutates, and excludes the requiring step's own tokens.

Two plan-time guards come with it:

- A link that planned no join step raises, naming the link and the causes a user can act on. Dropping the token silently would lose a required join; keeping it would stall the run.
- The finished plan is rejected if its steps form a cycle. The check peels over every step after `add_tfs`, so it sees the join-collection and transform edges too; a token no step produces is not a cycle, since the runtime already reports that as a missing producer.

`currently_running_step` now uses the same intersection rule `_can_run_step` refuses on.

## Behaviour change

A consumer of a link now waits for every JoinStep planned for it, not for whichever finished first. Where a link is planned in both orientations the two joins already serialized against each other through `JoinStepCollection`, so this costs no parallelism.

A misconfiguration that previously stalled at runtime now fails during planning with a message naming the link.

## Tests

`test_swapped_link_orientation_reconciliation.py` runs under THREADING as well; it was pinned to SYNC precisely because of this defect. It failed deterministically before the change and passed 25 isolated and 6 loaded (`-n 8`) repeats after it, alongside the shared-link orientation scenario that was intermittently losing a child group's columns.

New unit coverage: token identity per JoinStep, the expansion leaving non-link tokens alone, a consumer waiting for both orientations, the APPEND chain edge, the two guards including a three-step cycle and one running through a feature group step, an ordered two-link chain that must not be rejected, and the order independence of the running check.