### PR TITLE
fix: cross-framework joins under MULTIPROCESSING in the transform hop

### DIFF
--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -9,6 +9,7 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.core.cfw_manager import CfwManager
 from mloda.core.core.step.abstract_step import Step
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.optional_dependency import loaded
 from mloda.core.runtime.flight.flight_server import FlightServer
 
 
@@ -117,11 +118,21 @@ class TransformFrameworkStep(Step):
         cfw.set_data(data)
 
     def transform(self, cfw: ComputeFramework, data: Any, feature_names: set[str]) -> Any:
-        if self.equal_frameworks():
-            return data
-
         _from_fw = self.from_framework.expected_data_framework()
         _to_fw = self.to_framework.expected_data_framework()
+
+        pa = loaded("pyarrow")
+        if (
+            pa is not None
+            and isinstance(data, pa.Table)
+            and isinstance(_from_fw, type)
+            and not isinstance(data, _from_fw)
+        ):
+            # Flight transport hands back a pa.Table whatever the source framework's native type is.
+            _from_fw = pa.Table
+
+        if _from_fw == _to_fw:
+            return data
 
         # Try to find a transformation chain (direct or through PyArrow)
         transformation_chain = self.transformer.get_transformation_chain(_from_fw, _to_fw)
@@ -135,8 +146,3 @@ class TransformFrameworkStep(Step):
         return self.transformer.apply_chain(
             _from_fw, _to_fw, transformation_chain, data, cfw.framework_connection_object
         )
-
-    def equal_frameworks(self) -> bool:
-        if self.from_framework.expected_data_framework() == self.to_framework.expected_data_framework():
-            return True
-        return False

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -310,7 +310,7 @@ class ExecutionPlan:
             # This step is only relevant for multi processing.
             for _ep in new_execution_plan:
                 if isinstance(_ep, FeatureGroupStep):
-                    if _ep.features.any_uuid in need_to_upload_collector:
+                    if not need_to_upload_collector.isdisjoint(_ep.get_uuids()):
                         _ep.need_to_upload = True
 
         return new_execution_plan

--- a/tests/test_core/test_core/test_step/test_transform_step_flight_data.py
+++ b/tests/test_core/test_core/test_step/test_transform_step_flight_data.py
@@ -1,0 +1,124 @@
+"""The flight server hands transform a pa.Table whatever the source framework is, so transform must accept it."""
+
+from uuid import uuid4
+
+import pandas as pd
+import pyarrow as pa
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+import mloda_plugins.compute_framework.base_implementations.pandas.pandas_pyarrow_transformer  # noqa: F401
+import mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_pyarrow_transformer  # noqa: F401
+
+
+COLUMN_NAMES = {"flight_data_key", "flight_data_payload"}
+KEYS = [1, 2, 3]
+PAYLOADS = ["a", "b", "c"]
+
+
+class FlightDataMockFeatureGroup(FeatureGroup):
+    """Placeholder feature group; the transform hop never touches it."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+def _step(from_framework: type[ComputeFramework], to_framework: type[ComputeFramework]) -> TransformFrameworkStep:
+    return TransformFrameworkStep(
+        from_framework=from_framework,
+        to_framework=to_framework,
+        required_uuids={uuid4()},
+        from_feature_group=FlightDataMockFeatureGroup,
+        to_feature_group=FlightDataMockFeatureGroup,
+    )
+
+
+def _cfw(framework: type[ComputeFramework], mode: ParallelizationMode) -> ComputeFramework:
+    return framework(mode, frozenset(), uuid4())
+
+
+def _flight_table() -> pa.Table:
+    return pa.table({"flight_data_key": KEYS, "flight_data_payload": PAYLOADS})
+
+
+def test_python_dict_to_pandas_accepts_a_flight_table() -> None:
+    step = _step(PythonDictFramework, PandasDataFrame)
+    cfw = _cfw(PandasDataFrame, ParallelizationMode.MULTIPROCESSING)
+
+    result = step.transform(cfw, _flight_table(), COLUMN_NAMES)
+
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == COLUMN_NAMES
+    assert list(result["flight_data_key"]) == KEYS
+    assert list(result["flight_data_payload"]) == PAYLOADS
+
+
+def test_pandas_to_python_dict_accepts_a_flight_table() -> None:
+    step = _step(PandasDataFrame, PythonDictFramework)
+    cfw = _cfw(PythonDictFramework, ParallelizationMode.MULTIPROCESSING)
+
+    result = step.transform(cfw, _flight_table(), COLUMN_NAMES)
+
+    assert result == {"flight_data_key": KEYS, "flight_data_payload": PAYLOADS}
+
+
+def test_pandas_to_pyarrow_passes_a_flight_table_through_unchanged() -> None:
+    step = _step(PandasDataFrame, PyArrowTable)
+    cfw = _cfw(PyArrowTable, ParallelizationMode.MULTIPROCESSING)
+    data = _flight_table()
+
+    result = step.transform(cfw, data, COLUMN_NAMES)
+
+    assert result is data
+
+
+def test_pyarrow_source_still_transforms_a_flight_table() -> None:
+    step = _step(PyArrowTable, PandasDataFrame)
+    cfw = _cfw(PandasDataFrame, ParallelizationMode.MULTIPROCESSING)
+
+    result = step.transform(cfw, _flight_table(), COLUMN_NAMES)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["flight_data_key"]) == KEYS
+    assert list(result["flight_data_payload"]) == PAYLOADS
+
+
+def test_native_pandas_to_pyarrow_still_transforms() -> None:
+    step = _step(PandasDataFrame, PyArrowTable)
+    cfw = _cfw(PyArrowTable, ParallelizationMode.SYNC)
+    frame = pd.DataFrame({"flight_data_key": KEYS, "flight_data_payload": PAYLOADS})
+
+    result = step.transform(cfw, frame, COLUMN_NAMES)
+
+    assert isinstance(result, pa.Table)
+    assert result.column("flight_data_key").to_pylist() == KEYS
+    assert result.column("flight_data_payload").to_pylist() == PAYLOADS
+
+
+def test_equal_expected_frameworks_return_native_data_unchanged() -> None:
+    step = _step(PandasDataFrame, PandasDataFrame)
+    cfw = _cfw(PandasDataFrame, ParallelizationMode.SYNC)
+    frame = pd.DataFrame({"flight_data_key": KEYS, "flight_data_payload": PAYLOADS})
+
+    result = step.transform(cfw, frame, COLUMN_NAMES)
+
+    assert result is frame

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -34,12 +34,6 @@ THIRD_PAYLOADS = ["T1", "T3", "T4", "T7"]
 
 MISSING = "-"
 
-# MULTIPROCESSING is opt-in per shape: the rest fail in the transform hop, on a flight the server has no table for.
-MODES_SYNC_THREADING = pytest.mark.parametrize(
-    "modes",
-    [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}],
-)
-
 MODES_WITH_MULTIPROCESSING = pytest.mark.parametrize(
     "modes",
     [
@@ -294,7 +288,7 @@ RIGHT_JOIN_ROWS = ["k3|L3|k3|R3", "k4|L4|k4|R4", f"{MISSING}|{MISSING}|k5|R5"]
 CHAIN_ROWS = ["k4|L4|R4|T4", "k3|L3|R3|T3"]
 
 
-@MODES_SYNC_THREADING
+@MODES_WITH_MULTIPROCESSING
 def test_inner_join_declared_orientation_keeps_left_group_first(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
@@ -303,7 +297,7 @@ def test_inner_join_declared_orientation_keeps_left_group_first(
     assert rows == INNER_ROWS
 
 
-@MODES_SYNC_THREADING
+@MODES_WITH_MULTIPROCESSING
 def test_inner_join_inverted_orientation_keeps_left_group_first(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
@@ -321,7 +315,7 @@ def test_left_join_declared_orientation_keeps_every_left_row(
     assert rows == LEFT_JOIN_ROWS
 
 
-@MODES_SYNC_THREADING
+@MODES_WITH_MULTIPROCESSING
 def test_left_join_inverted_orientation_keeps_every_left_row(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
@@ -330,7 +324,7 @@ def test_left_join_inverted_orientation_keeps_every_left_row(
     assert rows == LEFT_JOIN_ROWS
 
 
-@MODES_SYNC_THREADING
+@MODES_WITH_MULTIPROCESSING
 def test_right_join_rejects_a_child_declaring_only_the_left_framework(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
@@ -346,7 +340,7 @@ def test_right_join_rejects_a_child_declaring_only_the_left_framework(
     assert PandasDataFrame.get_class_name() in message
 
 
-@MODES_SYNC_THREADING
+@MODES_WITH_MULTIPROCESSING
 def test_right_join_keeps_every_right_row_for_a_child_on_the_right_framework(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:
@@ -355,7 +349,7 @@ def test_right_join_keeps_every_right_row_for_a_child_on_the_right_framework(
     assert sorted(rows) == sorted(RIGHT_JOIN_ROWS)
 
 
-@MODES_SYNC_THREADING
+@MODES_WITH_MULTIPROCESSING
 def test_chained_join_across_three_frameworks_keeps_left_group_order(
     modes: set[ParallelizationMode], flight_server: Any
 ) -> None:

--- a/tests/test_core/test_prepare/test_execution_plan_upload_marking.py
+++ b/tests/test_core/test_prepare/test_execution_plan_upload_marking.py
@@ -1,0 +1,122 @@
+"""Upload marking must key on any step uuid in the collector, not on one arbitrary FeatureSet representative."""
+
+from typing import NamedTuple
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.provider import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+UPLOAD_MARK_KEY = "upload_mark_key"
+UPLOAD_MARK_INDEX = Index((UPLOAD_MARK_KEY,))
+
+
+class UploadMarkBaseFG(FeatureGroup):
+    """Unmatchable base so a leaked subclass stays invisible to feature resolution."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class UploadMarkSourceFG(UploadMarkBaseFG):
+    pass
+
+
+class UploadMarkDestFG(UploadMarkBaseFG):
+    pass
+
+
+class UploadMarkUnrelatedFG(UploadMarkBaseFG):
+    pass
+
+
+class Scenario(NamedTuple):
+    source_step: FeatureGroupStep
+    unrelated_step: FeatureGroupStep
+    steps: list[JoinStep | FeatureGroupStep]
+    graph: Graph
+
+
+def _feature(name: str, cfw: type[ComputeFramework], index: Index | None = None) -> Feature:
+    feature = Feature(name, index=index)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _fg_step(
+    fg: type[FeatureGroup], features: list[Feature], cfw: type[ComputeFramework], graph: Graph
+) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    for feature in features:
+        feature_set.add(feature)
+        graph.add_node(feature.uuid, NodeProperties(feature, fg))
+        graph.parent_to_children_mapping[feature.uuid] = set()
+    return FeatureGroupStep(fg, feature_set, set(), cfw)
+
+
+def _scenario() -> Scenario:
+    """Cross-framework join whose source-side set carries the link's index feature added FIRST."""
+    graph = Graph()
+
+    index_feature = _feature(UPLOAD_MARK_KEY, PyArrowTable, UPLOAD_MARK_INDEX)
+    payload_one = _feature("upload_mark_payload_one", PyArrowTable)
+    payload_two = _feature("upload_mark_payload_two", PyArrowTable)
+    source_step = _fg_step(UploadMarkSourceFG, [index_feature, payload_one, payload_two], PyArrowTable, graph)
+    assert source_step.features.any_uuid == index_feature.uuid
+
+    dest_feature = _feature("upload_mark_dest_payload", PandasDataFrame)
+    dest_step = _fg_step(UploadMarkDestFG, [dest_feature], PandasDataFrame, graph)
+
+    unrelated_feature = _feature("upload_mark_unrelated_payload", PyArrowTable)
+    unrelated_step = _fg_step(UploadMarkUnrelatedFG, [unrelated_feature], PyArrowTable, graph)
+
+    link = Link.inner(JoinSpec(UploadMarkDestFG, UPLOAD_MARK_INDEX), JoinSpec(UploadMarkSourceFG, UPLOAD_MARK_INDEX))
+    join_step = JoinStep(
+        link=link,
+        destination_framework=PandasDataFrame,
+        source_framework=PyArrowTable,
+        required_uuids={dest_feature.uuid, payload_one.uuid, payload_two.uuid},
+        destination_framework_uuids={dest_feature.uuid},
+        source_framework_uuids={payload_one.uuid, payload_two.uuid},
+    )
+
+    steps: list[JoinStep | FeatureGroupStep] = [source_step, dest_step, unrelated_step, join_step]
+    return Scenario(source_step, unrelated_step, steps, graph)
+
+
+def test_source_step_whose_representative_is_the_index_feature_is_marked_for_upload() -> None:
+    scenario = _scenario()
+
+    ExecutionPlan().add_tfs(scenario.steps, scenario.graph)
+
+    assert scenario.source_step.need_to_upload is True
+
+
+def test_step_sharing_no_uuid_with_the_collector_stays_unmarked() -> None:
+    scenario = _scenario()
+
+    ExecutionPlan().add_tfs(scenario.steps, scenario.graph)
+
+    assert scenario.unrelated_step.need_to_upload is False


### PR DESCRIPTION
Cross-framework joins failed under ParallelizationMode.MULTIPROCESSING in the TransformFrameworkStep that moves one join side into the other's framework, in two distinct ways.

**Upload marking keyed on an arbitrary representative.** `add_tfs` marked a producing FeatureGroupStep for flight upload only when `features.any_uuid` was in the upload collector. `any_uuid` is the first feature added to the set, and the planner inserts from an unordered set, so a join-source step whose representative happened to be the link's index feature was silently never marked. Its data then never reached the flight server and the transform hop failed with `ArrowInvalid: Try to get an empty apache flight`, intermittently, since the representative varies per plan build. The marking now fires when any of the step's feature uuids overlaps the collector, which is deterministic and marks exactly the steps whose data is consumed cross-process.

**Transform chain applied to the wrong representation.** Under multiprocessing the flight server always hands back a `pyarrow.Table`, but `transform` applied the chain declared for the source framework's native type, so any non-arrow-native source fed a `pa.Table` into a transformer expecting its own representation (`Expected dict, got pyarrow.lib.Table` for PythonDict, an `is_unique` AttributeError for pandas). `transform` now resolves the chain source to `pa.Table` when the incoming data actually is one and does not match the declared source's expected type; a target that already expects arrow gets the table passed through unchanged. Native-input paths under SYNC and THREADING are unchanged, and arrow-native sources keep their declared chain.

**Tests.** New unit tests pin the upload marking (including a guard that unrelated steps stay unmarked) and the transform's handling of flight tables for dict, pandas, and arrow sources and targets, alongside native-input regression guards. The join orientation characterization suite now runs its MULTIPROCESSING parametrization for every shape: both orientations, right joins, and the chain across three distinct frameworks, which were previously limited to SYNC and THREADING.

Fixes #1079
