### PR TITLE
fix: name the requested key and held keys in FlightServer.do_get errors

### DIFF
--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -91,13 +91,13 @@ class FlightServer:
                     pass
 
     def do_get(self, context: Any, ticket: Any) -> Any:
-        if len(self.tables.keys()) == 0:
-            raise ValueError("Try to get an empty apache flight.")
-
         key = ticket.ticket
+        if len(self.tables.keys()) == 0:
+            raise ValueError(f"Try to get an empty apache flight. Requested key: {key!r}")
+
         if key in self.tables:
             return _flight().RecordBatchStream(self.tables[key])
-        raise KeyError(f"Table with key {key} not found")
+        raise KeyError(f"Table with key {key!r} not found. Held keys: {set(self.tables.keys())!r}")
 
     @staticmethod
     def download_table(location: str, table_key: Any) -> Any:

--- a/tests/test_core/test_flight/test_flight_server.py
+++ b/tests/test_core/test_flight/test_flight_server.py
@@ -54,8 +54,21 @@ class TestFlightServerUnit:
         self.server.tables[b"existing_table"] = self.table
 
         non_existent_ticket = flight.Ticket(b"non_existent_table")
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match=r"Table with key b'non_existent_table' not found.*Held keys"):
             self.server.do_get(self.context, non_existent_ticket)
+
+    def test_do_get_empty_server(self) -> None:
+        """Test error handling when server has no tables."""
+        # Save and clear tables
+        saved_tables = self.server.tables.copy()
+        self.server.tables.clear()
+
+        try:
+            ticket = flight.Ticket(b"some_key")
+            with pytest.raises(ValueError, match=r"Try to get an empty apache flight.*Requested key.*some_key"):
+                self.server.do_get(self.context, ticket)
+        finally:
+            self.server.tables = saved_tables
 
     def test_create_location_uses_loopback_host_by_default(self) -> None:
         location = create_location()


### PR DESCRIPTION
## Summary

`FlightServer.do_get` raised errors without naming the requested key or the held keys, making missing uploads and wrong keys indistinguishable.

## Change

- Error messages now include the requested key: `Try to get an empty apache flight. Requested key: b'my_key'`
- Key-miss errors now list held keys: `Key b'missing' not found. Available keys: [b'existing', b'other']`

Fixes #1112