### PR TITLE
feat: improve FlightServer missing-key errors

### DIFF
--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -91,13 +91,13 @@ class FlightServer:
                     pass
 
     def do_get(self, context: Any, ticket: Any) -> Any:
-        if len(self.tables.keys()) == 0:
-            raise ValueError("Try to get an empty apache flight.")
-
         key = ticket.ticket
+        if len(self.tables.keys()) == 0:
+            raise ValueError(f"Table with key {key} not found. Available keys: {list(self.tables.keys())}")
+
         if key in self.tables:
             return _flight().RecordBatchStream(self.tables[key])
-        raise KeyError(f"Table with key {key} not found")
+        raise KeyError(f"Table with key {key} not found. Available keys: {list(self.tables.keys())}")
 
     @staticmethod
     def download_table(location: str, table_key: Any) -> Any:

--- a/tests/test_core/test_flight/test_flight_server.py
+++ b/tests/test_core/test_flight/test_flight_server.py
@@ -47,15 +47,25 @@ class TestFlightServerUnit:
         result_stream = self.server.do_get(self.context, self.ticket)
         assert isinstance(result_stream, flight.RecordBatchStream)
 
-    def test_do_get_not_found(self) -> None:
-        """Test error handling when table is not found."""
-        # Ensure server has at least one table so we test the KeyError path,
-        # not the ValueError path for empty tables
-        self.server.tables[b"existing_table"] = self.table
+    def test_do_get_empty_tables_error_names_requested_and_available_keys(self) -> None:
+        self.server.tables = {}
+        missing_ticket = flight.Ticket(b"missing_table")
 
-        non_existent_ticket = flight.Ticket(b"non_existent_table")
-        with pytest.raises(KeyError):
-            self.server.do_get(self.context, non_existent_ticket)
+        with pytest.raises(ValueError) as exc_info:
+            self.server.do_get(self.context, missing_ticket)
+
+        assert exc_info.value.args[0] == "Table with key b'missing_table' not found. Available keys: []"
+
+    def test_do_get_missing_key_error_names_requested_and_available_keys(self) -> None:
+        self.server.tables = {b"first_table": self.table, b"second_table": self.table}
+        missing_ticket = flight.Ticket(b"missing_table")
+
+        with pytest.raises(KeyError) as exc_info:
+            self.server.do_get(self.context, missing_ticket)
+
+        assert exc_info.value.args[0] == (
+            "Table with key b'missing_table' not found. Available keys: [b'first_table', b'second_table']"
+        )
 
     def test_create_location_uses_loopback_host_by_default(self) -> None:
         location = create_location()


### PR DESCRIPTION
## Summary

Include the requested table key and the keys currently held by `FlightServer` in both `do_get` failure paths. Add isolated regression tests for empty and non-empty table mappings.

Validation: `uvx tox` passed (9,081 tests passed, 170 skipped, 2 xfailed; Ruff, mypy strict, license checks, and Bandit passed).

## Related issue

Closes #1112

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [x] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [x] Tests added or updated for the change (and the skip count adjusted if needed)
- [x] Documentation updated where relevant
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
