### PR TITLE
feat: materialize the join decision as a resolved join record

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -148,7 +148,12 @@ class Engine:
             self.global_filter.rehash_stored_filters()
 
         execution_planner = ExecutionPlan(self.global_filter, self.api_input_data_collection)
-        execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
+        execution_planner.create_execution_plan(
+            planned_queue,
+            graph,
+            resolver.resolver_links.get_link_trekker(),
+            resolver.resolver_compute_framework.declared_frameworks,
+        )
         return execution_planner
 
     def setup_features_recursion(self, features: Features, requested: bool = True) -> None:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -19,6 +19,13 @@ from mloda.core.prepare.joinstep_collection import JoinStepCollection
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_graph import PlannedQueue
 from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker, inheritance_distance
+from mloda.core.prepare.resolved_join import JoinSignature, PlannedOrientation, ResolvedJoinPlan
+from mloda.core.prepare.resolved_join_builder import (
+    DeclaredFrameworks,
+    build_resolved_join_plan,
+    legacy_join_signatures,
+    log_join_plan_divergence,
+)
 from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
@@ -82,16 +89,42 @@ class ExecutionPlan:
         # Report each divergence once, then at DEBUG.
         self.reported_unmatched: set[tuple[type[FeatureGroup], str, tuple[str, ...]]] = set()
 
+        self.planned_orientations: list[tuple[PlannedOrientation, JoinStep]] = []
+        self.declined_orientations: list[LinkFrameworkTrekker] = []
+        self.resolved_join_plan = ResolvedJoinPlan((), ())
+        self.join_signatures_at_build: frozenset[JoinSignature] = frozenset()
+
     def __iter__(self) -> Generator[TransformFrameworkStep | JoinStep | FeatureGroupStep, None, None]:
         yield from self.execution_plan
 
     def __len__(self) -> int:
         return len(self.execution_plan)
 
-    def create_execution_plan(self, queue: PlannedQueue, graph: Graph, link_trekker: LinkTrekker) -> None:
+    def create_execution_plan(
+        self,
+        queue: PlannedQueue,
+        graph: Graph,
+        link_trekker: LinkTrekker,
+        declared_frameworks: DeclaredFrameworks | None = None,
+    ) -> None:
+        self.planned_orientations = []
+        self.declined_orientations = []
+
         child_links = self.invert_link_trekker(link_trekker)
         pre_execution_plan = self.add_feature_group_step(queue, graph.parent_to_children_mapping, child_links)
         fw_execution_plan = self.add_joinstep(pre_execution_plan, link_trekker, graph)
+
+        # Both built before add_tfs, which adds write serialization edges that are not part of the join decision.
+        join_steps = [step for step in fw_execution_plan if isinstance(step, JoinStep)]
+        self.resolved_join_plan = build_resolved_join_plan(
+            self.planned_orientations,
+            self.declined_orientations,
+            graph,
+            declared_frameworks if declared_frameworks is not None else {},
+        )
+        self.join_signatures_at_build = legacy_join_signatures(join_steps)
+        log_join_plan_divergence(self.resolved_join_plan, join_steps)
+
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
         self.raise_on_step_cycle(self.execution_plan)
 
@@ -504,6 +537,7 @@ class ExecutionPlan:
         link = link_fw[0]
         destination_framework = link_fw[1]
         source_framework = link_fw[2]
+        effective_key = link_fw
 
         if link.jointype == JoinType.RIGHT:
             destination_framework = link_fw[2]
@@ -525,6 +559,7 @@ class ExecutionPlan:
             source_framework = link_fw[1]
             # The join then executes in the right feature group's framework, so the merge arguments are inverted.
             swap_merge_sides = True
+            effective_key = (link, destination_framework, source_framework)
 
             for stored_links, uuids in link_trekker.data.items():
                 if (link, destination_framework, source_framework) == stored_links:
@@ -588,6 +623,7 @@ class ExecutionPlan:
             # result = True
             result = self.is_valid_join_step(link_fw, children_fw, children_uuid, graph)
             if result is False:
+                self.declined_orientations.append(link_fw)
                 return None
             elif result is True:
                 pass
@@ -610,6 +646,8 @@ class ExecutionPlan:
                     destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
                 ),
             )
+
+        self.planned_orientations.append((PlannedOrientation(effective_key, frozenset(children_uuids)), js))
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
         self.joinstep_collection.add(js)

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -12,9 +12,15 @@ class ResolveComputeFrameworks:
     def __init__(self, graph: Graph) -> None:
         self.graph = graph
         self.to_invert_trekker_collection: list[LinkFrameworkTrekker] = []
+        self.declared_frameworks: dict[UUID, frozenset[type[ComputeFramework]]] = {}
 
     def links(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
         groups = [p for p in planned_queue if isinstance(p, tuple) and not isinstance(p[0], Link)]
+
+        # The snapshot has to precede rewrite_group_frameworks, which collapses compute_frameworks to the resolution.
+        for p in groups:
+            for f in p[1]:
+                self.declared_frameworks[f.uuid] = frozenset(f.compute_frameworks or ())
 
         trekker_members: dict[LinkFrameworkTrekker, list[Any]] = defaultdict(list)
         feature_trekkers: dict[UUID, list[LinkFrameworkTrekker]] = defaultdict(list)

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -1,0 +1,138 @@
+"""The materialized join decision: one record per planned join orientation.
+
+Records are built in shadow mode next to the join steps and do not run anything yet.
+They carry metadata only (classes, uuids, indices, immutable scalars), so each one pickles to a worker.
+"""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import NamedTuple
+from uuid import UUID
+
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinType
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker
+
+
+class JoinSide(Enum):
+    LEFT = "left"
+    RIGHT = "right"
+
+
+def signed_uuids(uuids: Iterable[UUID]) -> tuple[str, ...]:
+    """Order-free uuid rendering, so two representations of one join sign it the same way."""
+    return tuple(sorted(str(uuid) for uuid in uuids))
+
+
+@dataclass(frozen=True)
+class ResolvedJoinSide:
+    """One declared side of a link: its group, its index and the parents that are that group."""
+
+    feature_group: type[FeatureGroup]
+    index: Index
+    uuids: frozenset[UUID]
+    declared_frameworks: frozenset[type[ComputeFramework]]
+
+
+@dataclass(frozen=True)
+class PlannedOrientation:
+    """The trekker key an orientation was planned under, plus the children it serves."""
+
+    key: LinkFrameworkTrekker
+    consumers: frozenset[UUID]
+
+
+@dataclass(frozen=True)
+class DeclinedOrientation:
+    """An orientation of a link that planned no join step."""
+
+    link_uuid: UUID
+    left_framework: type[ComputeFramework]
+    right_framework: type[ComputeFramework]
+
+
+class JoinSignature(NamedTuple):
+    """The join a record or a join step names, comparable across the two representations."""
+
+    link_uuid: UUID
+    jointype: str
+    destination_uuids: tuple[str, ...]
+    source_uuids: tuple[str, ...]
+    destination_side: str
+    destination_framework: str
+    source_framework: str
+    depends_on_links: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedJoin:
+    """One join decision: which declared side the join runs in, what it moves and what it waits for."""
+
+    link_uuid: UUID
+    jointype: JoinType
+    left: ResolvedJoinSide
+    right: ResolvedJoinSide
+    destination_side: JoinSide
+    destination_uuids: frozenset[UUID]
+    source_uuids: frozenset[UUID]
+    destination_framework: type[ComputeFramework]
+    source_framework: type[ComputeFramework]
+    consumers: frozenset[UUID]
+    # Join dependency edges only; the write serialization edges add_tfs adds later are not part of this.
+    depends_on: frozenset[UUID]
+    token: UUID
+    # Correlation only, never authoritative: the join step this record shadows.
+    shadowed_step_uuid: UUID
+
+    @property
+    def inverted(self) -> bool:
+        return self.destination_side is JoinSide.RIGHT
+
+    @property
+    def destination(self) -> ResolvedJoinSide:
+        return self.right if self.inverted else self.left
+
+    @property
+    def source(self) -> ResolvedJoinSide:
+        return self.left if self.inverted else self.right
+
+    @property
+    def transform_from_feature_group(self) -> type[FeatureGroup]:
+        return self.source.feature_group
+
+    @property
+    def transform_to_feature_group(self) -> type[FeatureGroup]:
+        return self.destination.feature_group
+
+    def signature(self, link_of_token: Mapping[UUID, UUID]) -> JoinSignature:
+        return JoinSignature(
+            link_uuid=self.link_uuid,
+            jointype=self.jointype.value,
+            destination_uuids=signed_uuids(self.destination_uuids),
+            source_uuids=signed_uuids(self.source_uuids),
+            destination_side=self.destination_side.value,
+            destination_framework=self.destination_framework.get_class_name(),
+            source_framework=self.source_framework.get_class_name(),
+            depends_on_links=tuple(sorted({str(link_of_token[token]) for token in self.depends_on})),
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedJoinPlan:
+    """Every record of a run, together with the orientations that planned nothing."""
+
+    records: tuple[ResolvedJoin, ...]
+    declined: tuple[DeclinedOrientation, ...]
+
+    def link_of_token(self) -> dict[UUID, UUID]:
+        return {record.token: record.link_uuid for record in self.records}
+
+    def signatures(self) -> frozenset[JoinSignature]:
+        link_of_token = self.link_of_token()
+        return frozenset(record.signature(link_of_token) for record in self.records)
+
+    def records_of_link(self, link_uuid: UUID) -> tuple[ResolvedJoin, ...]:
+        return tuple(record for record in self.records if record.link_uuid == link_uuid)

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -1,0 +1,201 @@
+"""Builds the resolved join plan from the orientations run_link planned, and signs the legacy join steps.
+
+The two signature sets are compared in shadow mode only; nothing here changes what the plan runs.
+"""
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import replace
+from typing import NamedTuple
+from uuid import UUID, uuid4
+
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, inheritance_distance
+from mloda.core.prepare.resolved_join import (
+    DeclinedOrientation,
+    JoinSide,
+    JoinSignature,
+    PlannedOrientation,
+    ResolvedJoin,
+    ResolvedJoinPlan,
+    ResolvedJoinSide,
+    signed_uuids,
+)
+
+
+logger = logging.getLogger(__name__)
+
+DeclaredFrameworks = Mapping[UUID, frozenset[type[ComputeFramework]]]
+
+
+class _DeclaredSides(NamedTuple):
+    """The side the destination lands in, plus the parents each declared side owns."""
+
+    destination_side: JoinSide
+    left_uuids: frozenset[UUID]
+    right_uuids: frozenset[UUID]
+
+
+def _nearest(uuids_by_distance: dict[int, set[UUID]]) -> frozenset[UUID]:
+    """A declared side is held by its closest subclasses only; farther ones answer for a different side."""
+    if not uuids_by_distance:
+        return frozenset()
+    return frozenset(uuids_by_distance[min(uuids_by_distance)])
+
+
+def _nearest_side_uuids(link: Link, uuids: set[UUID], graph: Graph) -> tuple[frozenset[UUID], frozenset[UUID]]:
+    """Split the join's parents into the nearest subclasses of each declared feature group."""
+    left_by_distance: dict[int, set[UUID]] = defaultdict(set)
+    right_by_distance: dict[int, set[UUID]] = defaultdict(set)
+    nodes = graph.get_nodes()
+
+    for uuid in uuids:
+        if uuid not in nodes:
+            continue
+        feature_group_class = nodes[uuid].feature_group_class
+        if issubclass(feature_group_class, link.left_feature_group):
+            left_by_distance[inheritance_distance(feature_group_class, link.left_feature_group)].add(uuid)
+        if issubclass(feature_group_class, link.right_feature_group):
+            right_by_distance[inheritance_distance(feature_group_class, link.right_feature_group)].add(uuid)
+
+    return _nearest(left_by_distance), _nearest(right_by_distance)
+
+
+def _destination_side(link: Link, join_step: JoinStep, graph: Graph) -> _DeclaredSides:
+    """Name the declared side that holds the destination, next to the parents each side owns."""
+    left_uuids, right_uuids = _nearest_side_uuids(
+        link, join_step.destination_framework_uuids | join_step.source_framework_uuids, graph
+    )
+
+    destination = join_step.destination_framework_uuids
+    holds_left = bool(destination & left_uuids)
+    holds_right = bool(destination & right_uuids)
+
+    if holds_left and not holds_right:
+        side = JoinSide.LEFT
+    elif holds_right and not holds_left:
+        side = JoinSide.RIGHT
+    else:
+        # Self links and sides sharing one feature group are not decidable from the declared groups.
+        side = JoinSide.RIGHT if join_step.swap_merge_sides else JoinSide.LEFT
+
+    resolved_left, resolved_right = (
+        (destination, join_step.source_framework_uuids)
+        if side is JoinSide.LEFT
+        else (join_step.source_framework_uuids, destination)
+    )
+    if left_uuids != right_uuids and left_uuids <= resolved_left and right_uuids <= resolved_right:
+        return _DeclaredSides(side, left_uuids, right_uuids)
+    # One feature group on both sides is not separable by class, so the resolved sets separate the parents.
+    return _DeclaredSides(side, frozenset(resolved_left), frozenset(resolved_right))
+
+
+def _side(
+    feature_group: type[FeatureGroup],
+    index: Index,
+    uuids: frozenset[UUID],
+    declared_frameworks: DeclaredFrameworks,
+) -> ResolvedJoinSide:
+    frameworks: set[type[ComputeFramework]] = set()
+    for uuid in uuids:
+        frameworks |= declared_frameworks.get(uuid, frozenset())
+    return ResolvedJoinSide(feature_group, index, uuids, frozenset(frameworks))
+
+
+def build_resolved_join_plan(
+    planned: Sequence[tuple[PlannedOrientation, JoinStep]],
+    declined: Sequence[LinkFrameworkTrekker],
+    graph: Graph,
+    declared_frameworks: DeclaredFrameworks,
+) -> ResolvedJoinPlan:
+    """One record per planned orientation, ordered as the orientations were planned."""
+    records: list[ResolvedJoin] = []
+    token_by_step: dict[UUID, UUID] = {}
+
+    for orientation, join_step in planned:
+        link = orientation.key[0]
+        sides = _destination_side(link, join_step, graph)
+
+        record = ResolvedJoin(
+            link_uuid=link.uuid,
+            jointype=link.jointype,
+            left=_side(link.left_feature_group, link.left_index, sides.left_uuids, declared_frameworks),
+            right=_side(link.right_feature_group, link.right_index, sides.right_uuids, declared_frameworks),
+            destination_side=sides.destination_side,
+            destination_uuids=frozenset(join_step.destination_framework_uuids),
+            source_uuids=frozenset(join_step.source_framework_uuids),
+            destination_framework=join_step.destination_framework,
+            source_framework=join_step.source_framework,
+            consumers=orientation.consumers,
+            depends_on=frozenset(),
+            token=uuid4(),
+            shadowed_step_uuid=join_step.uuid,
+        )
+        records.append(record)
+        token_by_step[join_step.uuid] = record.token
+
+    # An order edge is keyed by link uuid, so a producer link fans its tokens out over every record it built.
+    resolved = tuple(
+        replace(
+            record,
+            depends_on=frozenset(token_by_step[uuid] for uuid in step.required_uuids if uuid in token_by_step),
+        )
+        for record, (_, step) in zip(records, planned)
+    )
+    return ResolvedJoinPlan(resolved, tuple(DeclinedOrientation(key[0].uuid, key[1], key[2]) for key in declined))
+
+
+def _legacy_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) -> JoinSignature:
+    """The join a legacy step names, with its destination side read off swap_merge_sides."""
+    side = JoinSide.RIGHT if join_step.swap_merge_sides else JoinSide.LEFT
+    return JoinSignature(
+        link_uuid=join_step.link.uuid,
+        jointype=join_step.link.jointype.value,
+        destination_uuids=signed_uuids(join_step.destination_framework_uuids),
+        source_uuids=signed_uuids(join_step.source_framework_uuids),
+        destination_side=side.value,
+        destination_framework=join_step.destination_framework.get_class_name(),
+        source_framework=join_step.source_framework.get_class_name(),
+        depends_on_links=tuple(
+            sorted({str(link_of_step[uuid]) for uuid in join_step.required_uuids if uuid in link_of_step})
+        ),
+    )
+
+
+def legacy_join_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSignature]:
+    """The same signature read off the legacy join steps."""
+    steps = list(join_steps)
+    link_of_step = {step.uuid: step.link.uuid for step in steps}
+    return frozenset(_legacy_signature(step, link_of_step) for step in steps)
+
+
+def log_join_plan_divergence(plan: ResolvedJoinPlan, join_steps: Iterable[JoinStep]) -> None:
+    """Report at DEBUG where the records and the join steps sign different joins."""
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    steps = list(join_steps)
+    link_of_step = {step.uuid: step.link.uuid for step in steps}
+    legacy = {_legacy_signature(step, link_of_step): step.uuid for step in steps}
+
+    link_of_token = plan.link_of_token()
+    recorded = {record.signature(link_of_token): record.shadowed_step_uuid for record in plan.records}
+
+    if recorded.keys() == legacy.keys():
+        return
+
+    logger.debug(
+        "The resolved join plan diverges from the join steps. Only in the records: %s. Only in the steps: %s.",
+        sorted(
+            f"{signature} (step {step_uuid})" for signature, step_uuid in recorded.items() if signature not in legacy
+        ),
+        sorted(
+            f"{signature} (step {step_uuid})" for signature, step_uuid in legacy.items() if signature not in recorded
+        ),
+    )

--- a/tests/test_core/test_prepare/resolved_join_probe.py
+++ b/tests/test_core/test_prepare/resolved_join_probe.py
@@ -1,0 +1,97 @@
+"""Prints one json line with the resolved join record a fresh interpreter builds.
+No test_ prefix, so pytest never collects it; the resolved join record tests run it as a script.
+"""
+
+import json
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_links import LinkTrekker, ResolveLinks
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+PROBE_LEFT_INDEX = Index(("resolved_join_probe_left_key",))
+PROBE_RIGHT_INDEX = Index(("resolved_join_probe_right_key",))
+
+
+class ResolvedJoinProbeLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinProbeRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinProbeChild(FeatureGroup):
+    pass
+
+
+def _feature(name: str, frameworks: set[type[ComputeFramework]], index: Index | None = None) -> Feature:
+    feature = Feature(name, index=index)
+    feature.compute_frameworks = frameworks
+    return feature
+
+
+def collect() -> dict[str, str]:
+    """Each side reduces from a framework set, and the record has to name the same sides the reduction picked."""
+    link = Link.inner(
+        JoinSpec(ResolvedJoinProbeLeft, PROBE_LEFT_INDEX), JoinSpec(ResolvedJoinProbeRight, PROBE_RIGHT_INDEX)
+    )
+    left = _feature("resolved_join_probe_left_payload", {PandasDataFrame, PyArrowTable}, PROBE_LEFT_INDEX)
+    right = _feature("resolved_join_probe_right_payload", {PythonDictFramework, PyArrowTable}, PROBE_RIGHT_INDEX)
+    child = _feature("resolved_join_probe_child_payload", {PandasDataFrame})
+    key = ResolveLinks(Graph()).create_link_trekker_key(link, left.compute_frameworks, right.compute_frameworks)
+
+    graph = Graph()
+    graph.add_node(left.uuid, NodeProperties(left, ResolvedJoinProbeLeft))
+    graph.add_node(right.uuid, NodeProperties(right, ResolvedJoinProbeRight))
+    graph.add_node(child.uuid, NodeProperties(child, ResolvedJoinProbeChild))
+    graph.adjacency_list[left.uuid] = [child.uuid]
+    graph.adjacency_list[right.uuid] = [child.uuid]
+    graph.adjacency_list[child.uuid] = []
+    graph.parent_to_children_mapping[child.uuid] = {left.uuid, right.uuid}
+
+    trekker = LinkTrekker()
+    trekked = {child.uuid}
+    trekker.data[key] = trekked
+    trekker.data_ordered[key] = trekked
+
+    queue: list[Any] = [
+        (ResolvedJoinProbeLeft, {left}),
+        (ResolvedJoinProbeRight, {right}),
+        key,
+        (ResolvedJoinProbeChild, {child}),
+    ]
+
+    plan = ExecutionPlan()
+    plan.create_execution_plan(queue, graph, trekker)
+
+    resolved = plan.resolved_join_plan
+    signature = resolved.records[0].signature(resolved.link_of_token())
+
+    return {
+        "declined_count": str(len(resolved.declined)),
+        "depends_on_count": str(len(signature.depends_on_links)),
+        "destination_framework": signature.destination_framework,
+        "destination_is_declared_left": str(signature.destination_uuids == (str(left.uuid),)),
+        "destination_side": signature.destination_side,
+        "jointype": signature.jointype,
+        "record_count": str(len(resolved.records)),
+        "source_framework": signature.source_framework,
+        "source_is_declared_right": str(signature.source_uuids == (str(right.uuid),)),
+        "trekker_left": key[1].get_class_name(),
+        "trekker_right": key[2].get_class_name(),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(collect(), sort_keys=True))

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -1,0 +1,784 @@
+"""One record per join decision, built next to the join steps and signing the same joins they do."""
+
+import pickle  # nosec B403
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any, Callable, Iterable, NamedTuple
+from uuid import UUID
+
+import pytest
+
+from mloda.core.core.engine import Engine
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.core.prepare.resolved_join import DeclinedOrientation, JoinSide, JoinSignature, ResolvedJoin
+from mloda.core.prepare.resolved_join_builder import build_resolved_join_plan, legacy_join_signatures
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Features
+from mloda.user import Index
+from mloda.user import JoinSpec, JoinType, Link
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.helpers.probe_runner import run_probes
+
+
+PAIR_LEFT_INDEX = Index(("resolved_join_pair_left_key",))
+PAIR_RIGHT_INDEX = Index(("resolved_join_pair_right_key",))
+OTHER_LEFT_INDEX = Index(("resolved_join_other_left_key",))
+OTHER_RIGHT_INDEX = Index(("resolved_join_other_right_key",))
+STACK_LEFT_INDEX = Index(("resolved_join_stack_left_key",))
+STACK_RIGHT_INDEX = Index(("resolved_join_stack_right_key",))
+
+SELF_SIDE = "resolved_join_self_side"
+SELF_LEFT_KEY = "resolved_join_self_left_key"
+SELF_RIGHT_KEY = "resolved_join_self_right_key"
+SELF_LEFT_CANDIDATES = frozenset({PyArrowTable, PandasDataFrame})
+SELF_RIGHT_CANDIDATES = frozenset({PyArrowTable})
+
+END_LEFT_KEY = "resolved_join_end_left_key"
+END_LEFT_PAYLOAD = "resolved_join_end_left_payload"
+END_RIGHT_KEY = "resolved_join_end_right_key"
+END_RIGHT_PAYLOAD = "resolved_join_end_right_payload"
+
+_PROBE = Path(__file__).with_name("resolved_join_probe.py")
+# Each side reduces from a framework set, so a second cold interpreter is the whole cross-process signal.
+_PROBE_PROCESSES = 2
+_PROBE_EXPECTED = {
+    "declined_count": "0",
+    "depends_on_count": "0",
+    "destination_framework": "PandasDataFrame",
+    "destination_is_declared_left": "True",
+    "destination_side": "left",
+    "jointype": "inner",
+    "record_count": "1",
+    "source_framework": "PyArrowTable",
+    "source_is_declared_right": "True",
+    "trekker_left": "PandasDataFrame",
+    "trekker_right": "PyArrowTable",
+}
+
+
+class ResolvedJoinPairLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinPairRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinOtherLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinOtherRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinStackLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinStackRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinSelfSource(FeatureGroup):
+    pass
+
+
+class ResolvedJoinUnlinked(FeatureGroup):
+    """Feeds a child of a link without being named by it."""
+
+
+class ResolvedJoinChild(FeatureGroup):
+    pass
+
+
+class ResolvedJoinEndLeft(FeatureGroup):
+    """Pinned to the framework the end to end link declares as its left side."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={END_LEFT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {END_LEFT_KEY: [1, 2], END_LEFT_PAYLOAD: ["l1", "l2"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class ResolvedJoinEndRight(FeatureGroup):
+    """Pinned to the other framework, so the join needs a transform hop."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={END_RIGHT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {END_RIGHT_KEY: [1, 2], END_RIGHT_PAYLOAD: ["r1", "r2"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class ResolvedJoinEndChild(FeatureGroup):
+    """Takes either framework, so it keeps the declared orientation."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature(name=END_LEFT_PAYLOAD), Feature(name=END_RIGHT_PAYLOAD)}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+Orientation = tuple[type[ComputeFramework], type[ComputeFramework]]
+DeclaredFrameworks = dict[UUID, frozenset[type[ComputeFramework]]]
+
+
+class Planned(NamedTuple):
+    plan: ExecutionPlan
+    graph: Graph
+    link_trekker: LinkTrekker
+    queue: list[Any]
+
+
+class Sides(NamedTuple):
+    left_uuid: UUID
+    right_uuid: UUID
+    child_uuid: UUID
+
+
+class Built(NamedTuple):
+    plan: ExecutionPlan
+    link: Link
+    sides: Sides
+    graph: Graph
+    declared_frameworks: DeclaredFrameworks
+
+
+class Unlinked(NamedTuple):
+    plan: ExecutionPlan
+    link: Link
+    left_uuid: UUID
+    right_uuid: UUID
+    unlinked_uuid: UUID
+
+
+class Chain(NamedTuple):
+    plan: ExecutionPlan
+    producer: Link
+    consumer: Link
+
+
+def _planned() -> Planned:
+    return Planned(ExecutionPlan(), Graph(), LinkTrekker(), [])
+
+
+def _feature(
+    name: str,
+    cfw: type[ComputeFramework],
+    index: Index | None = None,
+    options: dict[str, Any] | None = None,
+) -> Feature:
+    feature = Feature(name, index=index, options=options)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _trek(planned: Planned, link: Link, orientation: Orientation, uuid: UUID) -> None:
+    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
+    key = (link, orientation[0], orientation[1])
+    trekked = planned.link_trekker.data.get(key)
+    if trekked is None:
+        trekked = set()
+        planned.link_trekker.data[key] = trekked
+        planned.link_trekker.data_ordered[key] = trekked
+    trekked.add(uuid)
+
+
+def _add_parents(planned: Planned, link: Link, left: Feature, right: Feature) -> None:
+    planned.graph.add_node(left.uuid, NodeProperties(left, link.left_feature_group))
+    planned.graph.add_node(right.uuid, NodeProperties(right, link.right_feature_group))
+    planned.queue.append((link.left_feature_group, {left}))
+    planned.queue.append((link.right_feature_group, {right}))
+
+
+def _add_child(planned: Planned, child: Feature, *parents: Feature) -> None:
+    planned.graph.add_node(child.uuid, NodeProperties(child, ResolvedJoinChild))
+    for parent in parents:
+        planned.graph.adjacency_list[parent.uuid].append(child.uuid)
+    planned.graph.adjacency_list[child.uuid] = []
+    planned.graph.parent_to_children_mapping[child.uuid] = {parent.uuid for parent in parents}
+    planned.queue.append((ResolvedJoinChild, {child}))
+
+
+def _branch(
+    planned: Planned,
+    link: Link,
+    name: str,
+    *,
+    left_cfw: type[ComputeFramework] = PyArrowTable,
+    right_cfw: type[ComputeFramework] = PandasDataFrame,
+    child_cfw: type[ComputeFramework] = PyArrowTable,
+    trekked: Orientation | None = None,
+    left_options: dict[str, Any] | None = None,
+    right_options: dict[str, Any] | None = None,
+) -> Sides:
+    """Two parents joined by ``link`` plus the consumer, the smallest shape run_link accepts."""
+    left = _feature(f"{name}_left", left_cfw, link.left_index, left_options)
+    right = _feature(f"{name}_right", right_cfw, link.right_index, right_options)
+    child = _feature(f"{name}_child", child_cfw)
+
+    _add_parents(planned, link, left, right)
+    planned.queue.append((link, left_cfw, right_cfw))
+    _add_child(planned, child, left, right)
+
+    _trek(planned, link, trekked or (left_cfw, right_cfw), child.uuid)
+    return Sides(left.uuid, right.uuid, child.uuid)
+
+
+def _finish(
+    planned: Planned,
+    link: Link,
+    sides: Sides,
+    declared_frameworks: DeclaredFrameworks | None = None,
+) -> Built:
+    declared = declared_frameworks or {}
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker, declared)
+    return Built(planned.plan, link, sides, planned.graph, declared)
+
+
+def _pair_link(link_factory: Callable[[JoinSpec, JoinSpec], Link] = Link.inner) -> Link:
+    return link_factory(
+        JoinSpec(ResolvedJoinPairLeft, PAIR_LEFT_INDEX), JoinSpec(ResolvedJoinPairRight, PAIR_RIGHT_INDEX)
+    )
+
+
+def _other_link() -> Link:
+    return Link.inner(
+        JoinSpec(ResolvedJoinOtherLeft, OTHER_LEFT_INDEX), JoinSpec(ResolvedJoinOtherRight, OTHER_RIGHT_INDEX)
+    )
+
+
+def _declared_pair() -> Built:
+    planned = _planned()
+    link = _pair_link()
+    return _finish(planned, link, _branch(planned, link, "resolved_join_declared"))
+
+
+def _inverted_pair() -> Built:
+    """The queue keeps the declared orientation, so run_link rediscovers the inverted one."""
+    planned = _planned()
+    link = _pair_link()
+    sides = _branch(
+        planned, link, "resolved_join_inverted", child_cfw=PandasDataFrame, trekked=(PandasDataFrame, PyArrowTable)
+    )
+    return _finish(planned, link, sides)
+
+
+def _right_join() -> Built:
+    planned = _planned()
+    link = _pair_link(Link.right)
+    return _finish(planned, link, _branch(planned, link, "resolved_join_right", child_cfw=PandasDataFrame))
+
+
+def _inverted_left_join() -> Built:
+    planned = _planned()
+    link = _pair_link(Link.left)
+    sides = _branch(
+        planned, link, "resolved_join_left", child_cfw=PandasDataFrame, trekked=(PandasDataFrame, PyArrowTable)
+    )
+    return _finish(planned, link, sides)
+
+
+def _self_join_parts() -> tuple[Planned, Link, Sides]:
+    """One feature group on both sides, so only the discriminators tell the two parents apart."""
+    planned = _planned()
+    link = Link.left(
+        JoinSpec(ResolvedJoinSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(ResolvedJoinSelfSource, Index((SELF_RIGHT_KEY,))),
+        left_discriminator={SELF_SIDE: "left"},
+        right_discriminator={SELF_SIDE: "right"},
+    )
+    sides = _branch(
+        planned,
+        link,
+        "resolved_join_self",
+        right_cfw=PyArrowTable,
+        left_options={SELF_SIDE: "left"},
+        right_options={SELF_SIDE: "right"},
+    )
+    return planned, link, sides
+
+
+def _self_join() -> Built:
+    planned, link, sides = _self_join_parts()
+    return _finish(planned, link, sides)
+
+
+def _self_join_with_split_declarations() -> Built:
+    """The nearest subclass rule cannot split one feature group over two sides; the resolved sets separate them."""
+    planned, link, sides = _self_join_parts()
+    return _finish(
+        planned,
+        link,
+        sides,
+        {sides.left_uuid: SELF_LEFT_CANDIDATES, sides.right_uuid: SELF_RIGHT_CANDIDATES},
+    )
+
+
+def _append_pair() -> Built:
+    planned = _planned()
+    link = Link.append(
+        JoinSpec(ResolvedJoinStackLeft, STACK_LEFT_INDEX), JoinSpec(ResolvedJoinStackRight, STACK_RIGHT_INDEX)
+    )
+    return _finish(planned, link, _branch(planned, link, "resolved_join_append"))
+
+
+def _two_links() -> Built:
+    """Two links that share nothing but the plan they are planned into."""
+    planned = _planned()
+    first = _pair_link()
+    second = _other_link()
+    sides = _branch(planned, first, "resolved_join_two_first")
+    _branch(planned, second, "resolved_join_two_second")
+    return _finish(planned, first, sides)
+
+
+def _pair_with_declined_orientation() -> Built:
+    """Two children of one link, and only the PyArrow one pairs a left side up with a right side."""
+    planned = _planned()
+    link = _pair_link()
+
+    left = _feature("resolved_join_declined_left", PyArrowTable, link.left_index)
+    right = _feature("resolved_join_declined_right", PandasDataFrame, link.right_index)
+    kept = _feature("resolved_join_declined_kept_child", PyArrowTable)
+    dropped = _feature("resolved_join_declined_dropped_child", PandasDataFrame)
+
+    _add_parents(planned, link, left, right)
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    planned.queue.append((link, PandasDataFrame, PyArrowTable))
+    _add_child(planned, kept, left, right)
+    _add_child(planned, dropped, left, right)
+
+    _trek(planned, link, (PyArrowTable, PandasDataFrame), kept.uuid)
+    _trek(planned, link, (PandasDataFrame, PyArrowTable), dropped.uuid)
+
+    return _finish(planned, link, Sides(left.uuid, right.uuid, kept.uuid))
+
+
+def _link_with_an_unlinked_third_parent() -> Unlinked:
+    """A right join whose child also has a parent the link never mentions."""
+    planned = _planned()
+    link = _pair_link(Link.right)
+
+    left = _feature("resolved_join_unlinked_left", PyArrowTable, link.left_index)
+    right = _feature("resolved_join_unlinked_right", PandasDataFrame, link.right_index)
+    unlinked = _feature("resolved_join_unlinked_third", PandasDataFrame)
+    child = _feature("resolved_join_unlinked_child", PandasDataFrame)
+
+    _add_parents(planned, link, left, right)
+    planned.graph.add_node(unlinked.uuid, NodeProperties(unlinked, ResolvedJoinUnlinked))
+    planned.queue.append((ResolvedJoinUnlinked, {unlinked}))
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    _add_child(planned, child, left, right, unlinked)
+    _trek(planned, link, (PyArrowTable, PandasDataFrame), child.uuid)
+
+    declared: DeclaredFrameworks = {
+        left.uuid: frozenset({PyArrowTable}),
+        right.uuid: frozenset({PandasDataFrame}),
+        unlinked.uuid: frozenset({PandasDataFrame, PythonDictFramework}),
+    }
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker, declared)
+    return Unlinked(planned.plan, link, left.uuid, right.uuid, unlinked.uuid)
+
+
+def _ordered_chain() -> Chain:
+    planned = _planned()
+    producer = _pair_link()
+    consumer = _other_link()
+    _branch(planned, producer, "resolved_join_chain_producer")
+    _branch(planned, consumer, "resolved_join_chain_consumer")
+    # The value side of an order entry lists the links that have to wait for the key.
+    planned.link_trekker.order[producer.uuid] = {consumer.uuid}
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+    return Chain(planned.plan, producer, consumer)
+
+
+def _join_steps(plan: ExecutionPlan) -> list[JoinStep]:
+    return [step for step in plan if isinstance(step, JoinStep)]
+
+
+def _transform_steps(plan: ExecutionPlan, link: Link) -> list[TransformFrameworkStep]:
+    return [step for step in plan if isinstance(step, TransformFrameworkStep) and step.link_id == link.uuid]
+
+
+def _records(plan: ExecutionPlan, link: Link) -> tuple[ResolvedJoin, ...]:
+    return plan.resolved_join_plan.records_of_link(link.uuid)
+
+
+def _one_record(plan: ExecutionPlan, link: Link) -> ResolvedJoin:
+    records = _records(plan, link)
+    assert len(records) == 1, f"the orientation must build exactly one record; got: {records}"
+    return records[0]
+
+
+def _without_depends(signatures: Iterable[JoinSignature]) -> frozenset[JoinSignature]:
+    return frozenset(signature._replace(depends_on_links=()) for signature in signatures)
+
+
+def test_a_record_is_inverted_exactly_when_its_destination_is_the_right_side() -> None:
+    declared = _declared_pair()
+    inverted = _inverted_pair()
+
+    declared_record = _one_record(declared.plan, declared.link)
+    inverted_record = _one_record(inverted.plan, inverted.link)
+
+    assert declared_record.destination_side is JoinSide.LEFT
+    assert declared_record.inverted is False
+    assert inverted_record.destination_side is JoinSide.RIGHT
+    assert inverted_record.inverted is True
+
+
+def test_a_record_refuses_assignment_to_its_fields_and_to_inverted() -> None:
+    built = _declared_pair()
+    record = _one_record(built.plan, built.link)
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(record, "destination_side", JoinSide.RIGHT)
+
+    with pytest.raises(AttributeError):
+        setattr(record, "inverted", True)
+
+
+def test_destination_and_source_name_the_sides_the_destination_side_picks() -> None:
+    declared = _declared_pair()
+    inverted = _inverted_pair()
+
+    declared_record = _one_record(declared.plan, declared.link)
+    inverted_record = _one_record(inverted.plan, inverted.link)
+
+    assert declared_record.destination is declared_record.left
+    assert declared_record.source is declared_record.right
+    assert inverted_record.destination is inverted_record.right
+    assert inverted_record.source is inverted_record.left
+
+
+def test_a_record_survives_the_round_trip_to_a_multiprocessing_worker() -> None:
+    built = _declared_pair()
+    record = _one_record(built.plan, built.link)
+
+    restored = pickle.loads(pickle.dumps(record))  # nosec B301
+
+    assert restored == record
+
+
+def test_the_declared_orientation_of_an_inner_pair_builds_one_left_destination_record() -> None:
+    built = _declared_pair()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.link_uuid == built.link.uuid
+    assert record.jointype is JoinType.INNER
+    assert record.destination_side is JoinSide.LEFT
+    assert record.inverted is False
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination_uuids == {built.sides.left_uuid}
+    assert record.source_uuids == {built.sides.right_uuid}
+    assert record.destination_framework is PyArrowTable
+    assert record.source_framework is PandasDataFrame
+    assert record.left.feature_group is ResolvedJoinPairLeft
+    assert record.left.index == built.link.left_index
+
+
+def test_an_orientation_inverted_after_queueing_still_names_the_declared_left_side() -> None:
+    built = _inverted_pair()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.inverted is True
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination_uuids == {built.sides.right_uuid}
+    assert record.source_uuids == {built.sides.left_uuid}
+
+
+def test_a_right_join_binds_the_destination_to_the_declared_right_side() -> None:
+    built = _right_join()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.jointype is JoinType.RIGHT
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination.uuids == {built.sides.right_uuid}
+    assert record.destination_uuids == {built.sides.right_uuid}
+
+
+def test_a_parent_the_link_never_mentions_stays_out_of_the_declared_sides() -> None:
+    unlinked = _link_with_an_unlinked_third_parent()
+
+    record = _one_record(unlinked.plan, unlinked.link)
+
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.left.uuids == {unlinked.left_uuid}
+    assert record.right.uuids == {unlinked.right_uuid}
+    # The join writes into a parent that belongs to neither declared side, which a validation step should reject.
+    assert record.destination_uuids == {unlinked.right_uuid, unlinked.unlinked_uuid}
+    assert record.source_uuids == {unlinked.left_uuid}
+
+
+def test_a_declared_side_keeps_only_the_frameworks_its_own_parents_declared() -> None:
+    unlinked = _link_with_an_unlinked_third_parent()
+
+    record = _one_record(unlinked.plan, unlinked.link)
+
+    assert record.left.declared_frameworks == {PyArrowTable}
+    assert record.right.declared_frameworks == {PandasDataFrame}
+    assert PythonDictFramework not in record.left.declared_frameworks | record.right.declared_frameworks
+
+
+def test_a_self_join_gives_each_declared_side_only_its_own_parent() -> None:
+    built = _self_join_with_split_declarations()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination.uuids == record.destination_uuids
+    assert record.source.uuids == record.source_uuids
+
+
+def test_a_self_join_keeps_each_parents_framework_candidates_on_its_own_side() -> None:
+    built = _self_join_with_split_declarations()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.left.declared_frameworks == SELF_LEFT_CANDIDATES
+    assert record.right.declared_frameworks == SELF_RIGHT_CANDIDATES
+
+
+def test_a_side_keeps_the_framework_candidates_its_feature_declared_before_the_rewrite() -> None:
+    """The graph node carries the one framework the rewrite left; the snapshot carries what was declared."""
+    planned = _planned()
+    link = _pair_link()
+    sides = _branch(planned, link, "resolved_join_candidates")
+    built = _finish(
+        planned,
+        link,
+        sides,
+        {
+            sides.left_uuid: frozenset({PyArrowTable, PandasDataFrame}),
+            sides.right_uuid: frozenset({PandasDataFrame}),
+        },
+    )
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.left.declared_frameworks == {PyArrowTable, PandasDataFrame}
+    assert record.right.declared_frameworks == {PandasDataFrame}
+
+
+def test_consumers_name_the_children_the_orientation_serves() -> None:
+    built = _declared_pair()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.consumers == {built.sides.child_uuid}
+
+
+def test_a_declined_orientation_builds_no_record_and_one_declined_entry() -> None:
+    built = _pair_with_declined_orientation()
+    resolved = built.plan.resolved_join_plan
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.destination_framework is PyArrowTable
+    assert record.consumers == {built.sides.child_uuid}
+    assert resolved.declined == (DeclinedOrientation(built.link.uuid, PandasDataFrame, PyArrowTable),)
+
+
+def test_each_record_names_the_join_step_it_shadows() -> None:
+    built = _two_links()
+    step_of_link = {step.link.uuid: step.uuid for step in _join_steps(built.plan)}
+
+    records = built.plan.resolved_join_plan.records
+
+    assert len(records) == len(step_of_link)
+    for record in records:
+        assert record.shadowed_step_uuid == step_of_link[record.link_uuid]
+        assert record.shadowed_step_uuid != record.token
+
+
+@pytest.mark.parametrize(
+    "build",
+    [_declared_pair, _inverted_pair, _right_join, _inverted_left_join, _self_join, _append_pair, _two_links],
+    ids=["inner", "inverted_inner", "right", "inverted_left", "self_join", "append", "two_links"],
+)
+def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Built]) -> None:
+    built = build()
+
+    join_steps = _join_steps(built.plan)
+    resolved = built.plan.resolved_join_plan
+
+    assert join_steps, "the shape must plan at least one JoinStep for the parity to say anything"
+    assert len(resolved.records) == len(join_steps)
+    assert resolved.signatures() == built.plan.join_signatures_at_build
+
+
+def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:
+    """The signatures only agree while the record derives its destination side from the graph."""
+    built = _declared_pair()
+    join_step = _join_steps(built.plan)[0]
+
+    join_step.swap_merge_sides = not join_step.swap_merge_sides
+    rebuilt = build_resolved_join_plan(
+        built.plan.planned_orientations, built.plan.declined_orientations, built.graph, built.declared_frameworks
+    )
+
+    assert len(rebuilt.records) == len(_join_steps(built.plan)), "an empty rebuild makes the inequality meaningless"
+    assert rebuilt.signatures(), "an empty rebuild makes the inequality meaningless"
+    assert rebuilt.signatures() != legacy_join_signatures([join_step])
+
+
+def test_the_record_leaves_out_the_write_serialization_edges_add_tfs_adds() -> None:
+    built = _two_links()
+
+    recorded = built.plan.resolved_join_plan.signatures()
+    after_tfs = legacy_join_signatures(_join_steps(built.plan))
+
+    assert after_tfs != recorded, "add_tfs must add an edge here for this to say anything"
+    assert _without_depends(after_tfs) == _without_depends(recorded)
+
+
+def test_a_second_planning_pass_does_not_accumulate_records() -> None:
+    planned = _planned()
+    link = _pair_link()
+    _branch(planned, link, "resolved_join_twice")
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+    first = len(planned.plan.resolved_join_plan.records)
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+
+    assert len(planned.plan.resolved_join_plan.records) == first
+    assert len(planned.plan.resolved_join_plan.records) == len(_join_steps(planned.plan))
+
+
+def test_an_order_edge_makes_the_consumer_records_depend_on_the_producer_record_tokens() -> None:
+    chain = _ordered_chain()
+    resolved = chain.plan.resolved_join_plan
+    producer_records = resolved.records_of_link(chain.producer.uuid)
+    consumer_records = resolved.records_of_link(chain.consumer.uuid)
+    step_uuids = {step.uuid for step in _join_steps(chain.plan)}
+
+    assert producer_records, "the producer link must build a record for the edge to point at"
+    assert consumer_records, "the consumer link must build a record for the edge to hang off"
+    for record in producer_records:
+        assert not record.depends_on
+    for record in consumer_records:
+        assert record.depends_on == {produced.token for produced in producer_records}
+        assert chain.producer.uuid not in record.depends_on, "a record depends on tokens, not on link uuids"
+        assert record.depends_on.isdisjoint(step_uuids), "a record depends on tokens, not on step uuids"
+        assert record.signature(resolved.link_of_token()).depends_on_links == (str(chain.producer.uuid),)
+
+
+def test_the_record_and_the_legacy_transform_hop_name_opposite_directions() -> None:
+    built = _inverted_pair()
+
+    record = _one_record(built.plan, built.link)
+    transform_steps = _transform_steps(built.plan, built.link)
+
+    assert len(transform_steps) == 1
+    # The record binds the hop to the sides the join actually moves; a later lowering step should adopt its answer.
+    assert record.transform_from_feature_group is ResolvedJoinPairLeft
+    assert record.transform_to_feature_group is ResolvedJoinPairRight
+    assert transform_steps[0].from_feature_group is ResolvedJoinPairRight
+    assert transform_steps[0].to_feature_group is ResolvedJoinPairLeft
+
+
+def test_a_real_engine_plan_carries_one_record_per_planned_join_step() -> None:
+    link = Link.inner(
+        JoinSpec(ResolvedJoinEndLeft, Index((END_LEFT_KEY,))),
+        JoinSpec(ResolvedJoinEndRight, Index((END_RIGHT_KEY,))),
+    )
+    engine = Engine(
+        Features([Feature(name=ResolvedJoinEndChild.get_class_name())]),
+        {PyArrowTable, PandasDataFrame},
+        {link},
+        plugin_collector=PluginCollector.enabled_feature_groups(
+            {ResolvedJoinEndLeft, ResolvedJoinEndRight, ResolvedJoinEndChild}
+        ),
+    )
+
+    plan = engine.execution_planner
+    join_steps = _join_steps(plan)
+    resolved = plan.resolved_join_plan
+
+    assert len(join_steps) == 1
+    assert len(resolved.records) == len(join_steps)
+    assert resolved.signatures() == plan.join_signatures_at_build
+    for record in resolved.records:
+        assert record.destination_framework in record.destination.declared_frameworks
+
+
+def test_the_resolver_snapshots_the_frameworks_a_feature_declared_before_the_rewrite() -> None:
+    link = _pair_link()
+    left = _feature("resolved_join_snapshot_left", PyArrowTable, link.left_index)
+    right = _feature("resolved_join_snapshot_right", PandasDataFrame, link.right_index)
+    child = Feature("resolved_join_snapshot_child")
+    child.compute_frameworks = {PyArrowTable, PandasDataFrame}
+
+    link_trekker = LinkTrekker()
+    trekked = {child.uuid}
+    link_trekker.data[(link, PyArrowTable, PandasDataFrame)] = trekked
+    link_trekker.data_ordered[(link, PyArrowTable, PandasDataFrame)] = trekked
+    queue: list[Any] = [
+        (ResolvedJoinPairLeft, {left}),
+        (ResolvedJoinPairRight, {right}),
+        (link, PyArrowTable, PandasDataFrame),
+        (ResolvedJoinChild, {child}),
+    ]
+
+    resolver = ResolveComputeFrameworks(Graph())
+    resolver.links(queue, link_trekker)
+
+    assert child.compute_frameworks == {PyArrowTable}, "the rewrite has to collapse the child for this to say anything"
+    assert resolver.declared_frameworks[child.uuid] == {PyArrowTable, PandasDataFrame}
+    assert resolver.declared_frameworks[left.uuid] == {PyArrowTable}
+
+
+# Fresh interpreters are slow to start, so this one needs more than the suite-wide per-test budget.
+@pytest.mark.timeout(60)
+def test_fresh_interpreters_build_the_same_record_signature() -> None:
+    outputs = run_probes(_PROBE, _PROBE_PROCESSES)
+
+    assert len(outputs) == _PROBE_PROCESSES, f"expected {_PROBE_PROCESSES} probe results, got {len(outputs)}"
+    for position, output in enumerate(outputs):
+        assert output == _PROBE_EXPECTED, f"probe {position} signed {output}, expected {_PROBE_EXPECTED}"


### PR DESCRIPTION
## Summary

Turning a declared `Link` into a `JoinStep` currently derives the same decision several times over, from state that is still being reduced and mutated: the framework reduction in `create_link_trekker_key`, agreement over those reduced singletons in `resolve_trekker`, the in-place rewrite of `feature.compute_frameworks` by `rewrite_group_frameworks` after the trekker keys were derived from those same sets, and a re-derivation in `run_link` next to a separate APPEND/UNION constructor that rebuilds frameworks from different inputs. The decision is never written down in one place.

This adds `ResolvedJoin`, one record per planned (link, orientation), carrying:

- the declared left and right sides, each with its own parent uuids and the framework candidates those parents declared
- what the join writes into and reads from (`destination_uuids` / `source_uuids`)
- the merge destination framework and which declared side holds it
- the consumers, the dependency edges to other records, and one completion token

Whether the join runs inverted is a property of the bindings, not a second flag stored beside them.

## Two things the record knows that a JoinStep does not

The framework candidates a feature declared are snapshotted before `rewrite_group_frameworks` collapses them, so the record keeps what has already been lost by the time the join step is built.

The declared sides are separated by feature group where the two sides differ, which keeps a parent the link never mentions out of both sides, and by the planner's discriminator-resolved sets where one feature group serves both sides. The gap between a side and the uuids the join actually binds is therefore visible in the record: it is the join reaching parents outside its own declared sides.

## Shadow mode

Nothing reads the records to decide anything. They are built between `add_joinstep` and `add_tfs`, deliberately before the write-serialization edges that `add_tfs` adds, which are ordering constraints of the plan rather than part of the join decision. A canonical signature exists over both representations; the tests assert the two agree, and a divergence is logged at DEBUG naming the step each record shadows.

The signature is built so that only one field is derived independently on each side: the record decides the destination side from the graph, the join step from `swap_merge_sides`. A test flips a step's merge sides and asserts parity then breaks, so the comparison cannot pass by construction.

Records hold metadata only (classes, uuids, indices, immutable scalars), so each one pickles to a worker.

## Ordering

An order edge is keyed by the link uuid while one link can plan several orientations, so it fans out over every record the producer link built. That matches what the completion tokens already do; narrowing it to per-child provenance belongs with the step that lowers join steps from these records.

## Tests

Parity over the declared inner pair, an orientation inverted after queueing, a RIGHT join, an inverted LEFT join, a discriminator self join, APPEND, two independent links, and a real engine plan. Plus the declared-side split, the framework candidates surviving the rewrite, the order-edge fan-out, declined orientations, a pickle round trip, and a cold-interpreter probe pinning the cross-process reduction.

One characterization test records that `fill_tfs_by_joinstep` picks the transform hop's two feature groups by join type alone, so on an inverted non-RIGHT link it names the opposite direction to the one the data moves. Both answers are asserted; the behavior is unchanged here.

`tox` green: 9157 passed, 170 skipped, 2 xfailed.