### PR TITLE
fix: avoid duplicate feature group upload

### DIFF
--- a/mloda/core/core/step/feature_group_step.py
+++ b/mloda/core/core/step/feature_group_step.py
@@ -64,7 +64,8 @@ class FeatureGroupStep(Step):
 
         if self.location:
             if self.need_to_upload:
-                cfw.upload_finished_data(self.location)
+                if not isinstance(cfw.data, str):
+                    cfw.upload_finished_data(self.location)
                 cfw_register.add_uuid_flyway_datasets(cfw.uuid, set(self.children_if_root))
             return data
         return None

--- a/tests/test_core/test_core/test_step/test_feature_group_step_error_messages.py
+++ b/tests/test_core/test_core/test_step/test_feature_group_step_error_messages.py
@@ -12,6 +12,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.user import Feature, Options
@@ -130,3 +131,28 @@ class TestFeatureGroupStepErrorMessageApiInputDataNotBaseApiData:
         error_message = str(exc_info.value)
         assert "MockFeatureGroup (" in error_message
         assert "test_feature_group_step_error_messages)" in error_message
+
+
+def test_execute_does_not_upload_finished_data_twice() -> None:
+    features = MagicMock(spec=FeatureSet)
+    features.features = set()
+    features.artifact_to_save = None
+    step = FeatureGroupStep(MockFeatureGroup, features, set(), ComputeFramework)
+    step.need_to_upload = True
+
+    cfw_register = MagicMock()
+    cfw_register.get_location.return_value = "flight-location"
+    cfw_register.get_runtime_artifacts.return_value = None
+    cfw = MagicMock(spec=ComputeFramework)
+    cfw.uuid = "framework-id"
+
+    def run_calculation(*_: object) -> str:
+        cfw.data = "object-id"
+        cfw.upload_finished_data("flight-location")
+        return "object-id"
+
+    cfw.run_calculation.side_effect = run_calculation
+
+    step.execute(cfw_register, cfw)
+
+    cfw.upload_finished_data.assert_called_once_with("flight-location")


### PR DESCRIPTION
## Summary

Prevent `FeatureGroupStep.execute` from uploading a finished dataset again when `run_calculation` has already replaced the framework data with its Flight object ID. Flyway dataset registration still occurs for upload-marked steps.

Full `tox` result: 9,128 passed, 170 skipped, 2 xfailed; Ruff formatting and lint, license checks, strict mypy, and Bandit passed.

## Related issue

Closes #1111

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [x] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [x] Tests added or updated for the change (and the skip count adjusted if needed)
- [x] Documentation updated where relevant (no documentation change required)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
