### PR TITLE
fix: skip the second upload when cfw.data is already an object id

### DIFF
--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -763,6 +763,18 @@ Available join types:
         return self.upload_table(location, self.uuid)
 
     @final
+    def data_is_uploaded_object_id(self) -> bool:
+        """True when ``self.data`` is an object id string this framework uploaded.
+
+        :meth:`run_calculation` replaces ``self.data`` with the id returned by
+        :meth:`upload_finished_data` once a dataset is complete, so callers that
+        may upload again have to check first: handing the id string back to
+        :meth:`upload_table` would pass a ``str`` to ``FlightServer.upload_table``,
+        which fails on ``table.schema``.
+        """
+        return isinstance(self.data, str) and self.data in self.object_ids
+
+    @final
     def upload_table(self, location: str, object_id: Optional[UUID] = None) -> str:
         pa = require("pyarrow", _PYARROW_REASON)
         if object_id is None:

--- a/mloda/core/core/step/feature_group_step.py
+++ b/mloda/core/core/step/feature_group_step.py
@@ -64,8 +64,15 @@ class FeatureGroupStep(Step):
 
         if self.location:
             if self.need_to_upload:
-                if not isinstance(cfw.data, str):
+                # run_calculation may already have uploaded this dataset and
+                # replaced cfw.data with the returned object id string. Uploading
+                # a second time would hand that string to
+                # FlightServer.upload_table, which fails on table.schema.
+                # JoinStep._upload_data_if_needed guards its own upload likewise.
+                if not cfw.data_is_uploaded_object_id():
                     cfw.upload_finished_data(self.location)
+                # Registered either way: the dataset IS uploaded, so downstream
+                # consumers still need the flyway registration.
                 cfw_register.add_uuid_flyway_datasets(cfw.uuid, set(self.children_if_root))
             return data
         return None

--- a/tests/test_core/test_core/test_step/test_feature_group_step_double_upload.py
+++ b/tests/test_core/test_core/test_step/test_feature_group_step_double_upload.py
@@ -1,0 +1,113 @@
+"""FeatureGroupStep must not upload a dataset that run_calculation already uploaded.
+
+``ComputeFramework.run_calculation`` replaces ``self.data`` with the object id
+string returned by ``upload_finished_data`` once a dataset is complete. If
+``FeatureGroupStep.execute`` then uploads again it hands that string to
+``FlightServer.upload_table``, which fails on ``table.schema``.
+
+Latent in-tree: reaching it needs a step with ``need_to_upload`` set *and* the
+``run_calculation`` upload branch taken, and in-tree plans always leave
+unconsumed children on marked steps so the branch early-returns first. These
+tests drive ``execute`` directly to pin the guard regardless.
+"""
+
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.user import Feature, Options
+
+
+class _UploadFeatureGroup(FeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _step(*, need_to_upload: bool = True) -> FeatureGroupStep:
+    features = MagicMock(spec=FeatureSet)
+    features.features = set()
+    step = FeatureGroupStep(
+        feature_group=_UploadFeatureGroup,
+        features=features,
+        required_uuids=set(),
+        compute_framework=MagicMock(),
+    )
+    step.need_to_upload = need_to_upload
+    return step
+
+
+def _cfw(data: Any, object_ids: list[str]) -> MagicMock:
+    """A compute framework whose ``data``/``object_ids`` drive the real predicate."""
+    from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+
+    cfw = MagicMock()
+    cfw.data = data
+    cfw.object_ids = object_ids
+    # Bind the real predicate so the test exercises production logic, not a mock.
+    cfw.data_is_uploaded_object_id = lambda: ComputeFramework.data_is_uploaded_object_id(cfw)
+    return cfw
+
+
+def _execute(step: FeatureGroupStep, cfw: MagicMock, calculated: Any) -> Any:
+    cfw_register = MagicMock()
+    cfw_register.get_location.return_value = "grpc://localhost:1234"
+    cfw_register.get_runtime_artifacts.return_value = None
+    step.run_calculate_feature = MagicMock(return_value=calculated)  # type: ignore[method-assign]
+    step.save_artifact = MagicMock()  # type: ignore[method-assign]
+    return step.execute(cfw_register, cfw), cfw_register
+
+
+def test_second_upload_is_skipped_when_data_is_already_an_object_id() -> None:
+    """The regression: run_calculation already uploaded and returned the id."""
+    object_id = "8f14e45f-ea6d-4b3a-9c2f-000000000001"
+    cfw = _cfw(data=object_id, object_ids=[object_id])
+
+    result, cfw_register = _execute(_step(), cfw, calculated=object_id)
+
+    cfw.upload_finished_data.assert_not_called()
+    # The dataset IS uploaded, so the flyway registration must still happen.
+    cfw_register.add_uuid_flyway_datasets.assert_called_once()
+    assert result == object_id
+
+
+def test_upload_still_happens_for_a_real_table() -> None:
+    """The guard must not suppress the normal path."""
+    table = {"col": [1, 2, 3]}  # stands in for a framework-native table
+    cfw = _cfw(data=table, object_ids=[])
+
+    _result, cfw_register = _execute(_step(), cfw, calculated=table)
+
+    cfw.upload_finished_data.assert_called_once_with("grpc://localhost:1234")
+    cfw_register.add_uuid_flyway_datasets.assert_called_once()
+
+
+def test_a_string_that_was_never_uploaded_still_uploads() -> None:
+    """Only an id this framework actually uploaded counts.
+
+    A feature group is free to compute a plain string; that is data, not an
+    already-uploaded dataset, so it must not be mistaken for one.
+    """
+    cfw = _cfw(data="not-an-object-id", object_ids=["8f14e45f-ea6d-4b3a-9c2f-000000000001"])
+
+    _execute(_step(), cfw, calculated="not-an-object-id")
+
+    cfw.upload_finished_data.assert_called_once()
+
+
+def test_no_upload_when_the_step_is_not_marked() -> None:
+    cfw = _cfw(data={"col": [1]}, object_ids=[])
+
+    _execute(_step(need_to_upload=False), cfw, calculated={"col": [1]})
+
+    cfw.upload_finished_data.assert_not_called()
+
+
+def test_predicate_is_false_for_non_string_data() -> None:
+    from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+
+    for data in ({"col": [1]}, None, 42, ["8f14e45f"]):
+        cfw = _cfw(data=data, object_ids=["8f14e45f"])
+        assert ComputeFramework.data_is_uploaded_object_id(cfw) is False


### PR DESCRIPTION
Closes #1111.

`ComputeFramework.run_calculation` replaces `self.data` with the object id string returned by `upload_finished_data` once a dataset is complete (`compute_framework.py:301`). `FeatureGroupStep.execute` then uploaded again with no guard, which would hand that string to `FlightServer.upload_table` and die on `table.schema`.

### Change

- New `ComputeFramework.data_is_uploaded_object_id()` — `self.data` is a `str` **and** is one of the ids this framework has uploaded.
- `FeatureGroupStep.execute` gates its upload on it, mirroring how `JoinStep._upload_data_if_needed` already guards its own.

Two details worth review:

- **The flyway registration still runs either way.** In the skip branch the dataset *is* uploaded — just by `run_calculation` — so `add_uuid_flyway_datasets` must still happen or downstream consumers lose it. Only the redundant upload is skipped.
- **The predicate checks membership in `object_ids`, not merely `isinstance(str)`.** A feature group is free to compute a plain string; that is data, not an already-uploaded dataset, and must not be mistaken for one. `test_a_string_that_was_never_uploaded_still_uploads` pins that distinction.

### Test

`tests/.../test_feature_group_step_double_upload.py` drives `execute()` directly, because reaching this through a real plan needs a marked step whose features are its only children, and in-tree plans always leave unconsumed children so the `run_calculation` upload branch early-returns first (as the issue notes). Five cases: the regression itself, the normal table path still uploading, a never-uploaded string still uploading, an unmarked step, and the predicate against non-string data.

The test binds the *real* predicate onto the mock rather than stubbing it, so it exercises production logic.

Confirmed load-bearing: with the guard removed, `test_second_upload_is_skipped_when_data_is_already_an_object_id` fails.

### Verification

```
ruff format --check .    1001 files already formatted
ruff check .             All checks passed!
pytest (serial) tests/test_core/test_core/test_step/ + test_execution_plan_upload_marking.py    20 passed
mypy --strict --ignore-missing-imports (touched files + test_step/)    clean
```

Two honest gaps on my side:

- **Full `tox` did not complete on this machine.** Its `pytest -n 8` fans out to 16 workers here and the run died with `MemoryError` and repeated `node down: Not properly terminated`, i.e. resource exhaustion rather than test failures. I ran the affected suites serially instead.
- `mypy --strict` reports one error in `mloda/core/abstract_plugins/components/hashable_dict.py:105` (`Non-overlapping identity check`). It reproduces identically on a pristine tree (`git stash`), so it is pre-existing and not from this change.