### PR TITLE
refactor: run the upload marking once per plan build, not per step

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -404,12 +404,19 @@ class ExecutionPlan:
                 raise ValueError(f"Element {ep} is not a valid element.")
             new_execution_plan.append(ep)
 
-            # We define that every parent of a transform framework step needs to be uploaded.
-            # This step is only relevant for multi processing.
-            for _ep in new_execution_plan:
-                if isinstance(_ep, FeatureGroupStep):
-                    if not need_to_upload_collector.isdisjoint(_ep.get_uuids()):
-                        _ep.need_to_upload = True
+        # We define that every parent of a transform framework step needs to be uploaded.
+        # This step is only relevant for multi processing.
+        #
+        # One pass over the finished plan, not one per appended step: the marking is
+        # monotone (only ever set to True, and need_to_upload_collector only grows),
+        # nothing inside add_tfs reads need_to_upload, and no step escapes the list
+        # mid-build - so a step ends up marked iff it is non-disjoint from the FINAL
+        # collector either way. That drops the pass from O(steps^2 * features) to
+        # O(steps * features).
+        for _ep in new_execution_plan:
+            if isinstance(_ep, FeatureGroupStep):
+                if not need_to_upload_collector.isdisjoint(_ep.get_uuids()):
+                    _ep.need_to_upload = True
 
         return new_execution_plan
 


### PR DESCRIPTION
Closes #1109.

The `need_to_upload` marking loop in `ExecutionPlan.add_tfs` re-scanned the whole `new_execution_plan` after **every** appended step, making the marking pass quadratic in plan size for no benefit. Hoisted to a single pass after the plan iteration.

`O(steps² × features)` → `O(steps × features)`.

### Why it's equivalent

Three properties, all of which hold today:

1. **The marking is monotone** — `need_to_upload` is only ever set to `True`, never cleared, and `need_to_upload_collector` only grows during the iteration. So a step appended at iteration *i*, re-scanned on every later iteration, ends up marked iff it is non-disjoint from the **final** collector — exactly what one pass at the end computes.
2. **Nothing inside `add_tfs` reads `need_to_upload`** — the only reader is `FeatureGroupStep.execute`, and `add_tfs` is called once per run.
3. **No step object escapes the list mid-build**, so there is no observer that could see an intermediate marking.

Worth noting `get_uuids()` is also stable across the loop: the mutations in the join branch touch `children_if_root`, `tfs_ids` and `features.any_uuid`, while `get_uuids()` reads `features.features`.

The reasoning is recorded in a comment at the call site so the hoist isn't re-nested later.

No behaviour change, so no new test — per the issue's definition of done, the existing coverage is the check.

### Verification

```
tests/test_core/test_prepare/test_execution_plan_upload_marking.py   2 passed
tests/test_core/test_prepare/                                       912 passed, 2 xfailed, 3 failed (pre-existing, see below)
tests/test_core/test_index/ test_setup/ test_integration/test_core/  274 passed
ruff format --check .                                               1000 files already formatted
ruff check .                                                        All checks passed!
```

Pre-existing failures, **confirmed identical on a pristine tree** (`git stash`), so not from this change:

- `test_abstract_feature_group_not_instantiated.py::test_abstract_aggregated_base_raises_clean_value_error`
- `test_deterministic_framework_selection.py::test_fresh_interpreters_reduce_to_the_same_frameworks`
- `test_link_planner_plan_characterization.py::test_fresh_interpreters_plan_the_same_link_orientation`
- `mypy --strict`: one error in `hashable_dict.py:105` (`Non-overlapping identity check`)

**Full `tox` did not complete on this machine**: its `pytest -n 8` fans out to 16 workers here and the run died with `MemoryError` and repeated `node down: Not properly terminated` — resource exhaustion, not test failures. I ran the affected suites serially instead, so CI's tox run is the real gate for this one.