### PR TITLE
feat: materialize the join decision as a resolved join record

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -152,7 +152,7 @@ class Engine:
             planned_queue,
             graph,
             resolver.resolver_links.get_link_trekker(),
-            resolver.resolver_compute_framework.declared_frameworks,
+            resolver.resolver_compute_framework.get_declared_frameworks(),
         )
         return execution_planner
 

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -148,7 +148,12 @@ class Engine:
             self.global_filter.rehash_stored_filters()
 
         execution_planner = ExecutionPlan(self.global_filter, self.api_input_data_collection)
-        execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
+        execution_planner.create_execution_plan(
+            planned_queue,
+            graph,
+            resolver.resolver_links.get_link_trekker(),
+            resolver.resolver_compute_framework.declared_frameworks,
+        )
         return execution_planner
 
     def setup_features_recursion(self, features: Features, requested: bool = True) -> None:

--- a/mloda/core/prepare/declared_sides.py
+++ b/mloda/core/prepare/declared_sides.py
@@ -1,0 +1,41 @@
+"""Splits a join's parents by the declared sides of its link.
+
+run_link computes the split once; the resolved join records reuse its decision."""
+
+from collections import defaultdict
+from typing import NamedTuple
+from uuid import UUID
+
+from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_links import inheritance_distance
+
+
+class DeclaredSideSplit(NamedTuple):
+    """The parents each declared side of a link owns."""
+
+    left_uuids: frozenset[UUID]
+    right_uuids: frozenset[UUID]
+
+
+def _nearest(uuids_by_distance: dict[int, set[UUID]]) -> frozenset[UUID]:
+    """The minimum-distance bucket, or an empty side."""
+    if not uuids_by_distance:
+        return frozenset()
+    return frozenset(uuids_by_distance[min(uuids_by_distance)])
+
+
+def split_by_declared_side(link: Link, uuids: set[UUID], graph: Graph) -> DeclaredSideSplit:
+    """A declared side is held by its nearest subclasses only."""
+    left_by_distance: dict[int, set[UUID]] = defaultdict(set)
+    right_by_distance: dict[int, set[UUID]] = defaultdict(set)
+    nodes = graph.get_nodes()
+
+    for uuid in uuids:
+        feature_group_class = nodes[uuid].feature_group_class
+        if issubclass(feature_group_class, link.left_feature_group):
+            left_by_distance[inheritance_distance(feature_group_class, link.left_feature_group)].add(uuid)
+        if issubclass(feature_group_class, link.right_feature_group):
+            right_by_distance[inheritance_distance(feature_group_class, link.right_feature_group)].add(uuid)
+
+    return DeclaredSideSplit(_nearest(left_by_distance), _nearest(right_by_distance))

--- a/mloda/core/prepare/declared_sides.py
+++ b/mloda/core/prepare/declared_sides.py
@@ -1,6 +1,4 @@
-"""Splits a join's parents by the declared sides of its link.
-
-run_link computes the split once; the resolved join records reuse its decision."""
+"""Splits a join's parents by the declared sides of its link, once, for run_link and the resolved join records."""
 
 from collections import defaultdict
 from typing import NamedTuple

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -107,7 +107,7 @@ class ExecutionPlan:
         pre_execution_plan = self.add_feature_group_step(queue, graph.parent_to_children_mapping, child_links)
         fw_execution_plan = self.add_joinstep(pre_execution_plan, link_trekker, graph)
 
-        # Both built before add_tfs, which adds write serialization edges that are not part of the join decision.
+        # Built before add_tfs, whose write serialization edges are not part of the join decision.
         join_steps = [step for step in fw_execution_plan if isinstance(step, JoinStep)]
         self.resolved_join_plan = build_resolved_join_plan(
             self.planned_orientations,
@@ -564,7 +564,7 @@ class ExecutionPlan:
         for uuid in children_uuids:
             required_uuids.update(graph.parent_to_children_mapping[uuid])
 
-        # Links match polymorphically; decided once here, before the order-edge link uuids join required_uuids.
+        # Split before the order-edge link uuids join required_uuids.
         split = split_by_declared_side(link, required_uuids, graph)
 
         # This filters the required_uuids to only the one with the final compute framework.

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -15,16 +15,16 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data import
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.filter.single_filter import SingleFilter
+from mloda.core.prepare.declared_sides import split_by_declared_side
 from mloda.core.prepare.joinstep_collection import JoinStepCollection
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_graph import PlannedQueue
-from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker, inheritance_distance
-from mloda.core.prepare.resolved_join import JoinSignature, PlannedOrientation, ResolvedJoinPlan
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker
+from mloda.core.prepare.resolved_join import JoinSide, JoinSignature, PlannedOrientation, ResolvedJoinPlan
 from mloda.core.prepare.resolved_join_builder import (
     DeclaredFrameworks,
     build_resolved_join_plan,
     legacy_join_signatures,
-    log_join_plan_divergence,
 )
 from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
@@ -63,13 +63,6 @@ def _describe_step(step: Step) -> str:
             f"{step.to_framework.get_class_name()}, uuid={step.uuid})"
         )
     return f"{type(step).__name__}(uuid={step.uuid})"
-
-
-def _nearest_frameworks(frameworks_by_distance: dict[int, set[type[ComputeFramework]]]) -> set[type[ComputeFramework]]:
-    """A declared side is held by its closest subclasses only; farther ones answer for a different side."""
-    if not frameworks_by_distance:
-        return set()
-    return frameworks_by_distance[min(frameworks_by_distance)]
 
 
 class ExecutionPlan:
@@ -119,11 +112,9 @@ class ExecutionPlan:
         self.resolved_join_plan = build_resolved_join_plan(
             self.planned_orientations,
             self.declined_orientations,
-            graph,
             declared_frameworks if declared_frameworks is not None else {},
         )
         self.join_signatures_at_build = legacy_join_signatures(join_steps)
-        log_join_plan_divergence(self.resolved_join_plan, join_steps)
 
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
         self.raise_on_step_cycle(self.execution_plan)
@@ -537,7 +528,6 @@ class ExecutionPlan:
         link = link_fw[0]
         destination_framework = link_fw[1]
         source_framework = link_fw[2]
-        effective_key = link_fw
 
         if link.jointype == JoinType.RIGHT:
             destination_framework = link_fw[2]
@@ -559,7 +549,6 @@ class ExecutionPlan:
             source_framework = link_fw[1]
             # The join then executes in the right feature group's framework, so the merge arguments are inverted.
             swap_merge_sides = True
-            effective_key = (link, destination_framework, source_framework)
 
             for stored_links, uuids in link_trekker.data.items():
                 if (link, destination_framework, source_framework) == stored_links:
@@ -575,16 +564,15 @@ class ExecutionPlan:
         for uuid in children_uuids:
             required_uuids.update(graph.parent_to_children_mapping[uuid])
 
+        # Links match polymorphically; decided once here, before the order-edge link uuids join required_uuids.
+        split = split_by_declared_side(link, required_uuids, graph)
+
         # This filters the required_uuids to only the one with the final compute framework.
         destination_framework_uuids: set[UUID] = set()
         source_framework_uuids: set[UUID] = set()
 
-        left_frameworks_by_distance: dict[int, set[type[ComputeFramework]]] = defaultdict(set)
-        right_frameworks_by_distance: dict[int, set[type[ComputeFramework]]] = defaultdict(set)
-
         for uuid in required_uuids:
-            node = graph.get_nodes()[uuid]
-            node_framework = node.feature.get_compute_framework()
+            node_framework = graph.get_nodes()[uuid].feature.get_compute_framework()
 
             if node_framework == destination_framework:
                 destination_framework_uuids.add(uuid)
@@ -592,17 +580,8 @@ class ExecutionPlan:
             if node_framework == source_framework:
                 source_framework_uuids.add(uuid)
 
-            # Links match polymorphically, so a subclass of a declared side counts as that side, ranked by distance.
-            if issubclass(node.feature_group_class, link.left_feature_group):
-                left_distance = inheritance_distance(node.feature_group_class, link.left_feature_group)
-                left_frameworks_by_distance[left_distance].add(node_framework)
-
-            if issubclass(node.feature_group_class, link.right_feature_group):
-                right_distance = inheritance_distance(node.feature_group_class, link.right_feature_group)
-                right_frameworks_by_distance[right_distance].add(node_framework)
-
-        declared_left_frameworks = _nearest_frameworks(left_frameworks_by_distance)
-        declared_right_frameworks = _nearest_frameworks(right_frameworks_by_distance)
+        declared_left_frameworks = {graph.get_nodes()[u].feature.get_compute_framework() for u in split.left_uuids}
+        declared_right_frameworks = {graph.get_nodes()[u].feature.get_compute_framework() for u in split.right_uuids}
 
         # The order shows which items should be added first.
         # Thus, we need to make sure that higher ordered links are calculated first.
@@ -635,6 +614,9 @@ class ExecutionPlan:
                 link, link_fw, required_uuids, graph, pre_execution_plan
             )
         else:
+            swap_sides = self.swap_merge_sides_by_declared_side(
+                destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
+            )
             js = JoinStep(
                 link,
                 destination_framework,
@@ -642,12 +624,13 @@ class ExecutionPlan:
                 required_uuids,
                 destination_framework_uuids,
                 source_framework_uuids,
-                self.swap_merge_sides_by_declared_side(
-                    destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
-                ),
+                swap_sides,
             )
 
-        self.planned_orientations.append((PlannedOrientation(effective_key, frozenset(children_uuids)), js))
+        side = JoinSide.RIGHT if js.swap_merge_sides else JoinSide.LEFT
+        self.planned_orientations.append(
+            (PlannedOrientation(link, frozenset(children_uuids), side, split.left_uuids, split.right_uuids), js)
+        )
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
         self.joinstep_collection.add(js)

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -25,6 +25,7 @@ from mloda.core.prepare.resolved_join_builder import (
     DeclaredFrameworks,
     build_resolved_join_plan,
     legacy_join_signatures,
+    raise_on_join_plan_divergence,
 )
 from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
@@ -102,6 +103,9 @@ class ExecutionPlan:
     ) -> None:
         self.planned_orientations = []
         self.declined_orientations = []
+        self.tfs_collection = set()
+        self.joinstep_collection = JoinStepCollection()
+        self.feature_set_collections = []
 
         child_links = self.invert_link_trekker(link_trekker)
         pre_execution_plan = self.add_feature_group_step(queue, graph.parent_to_children_mapping, child_links)
@@ -115,6 +119,7 @@ class ExecutionPlan:
             declared_frameworks if declared_frameworks is not None else {},
         )
         self.join_signatures_at_build = legacy_join_signatures(join_steps)
+        raise_on_join_plan_divergence(self.resolved_join_plan, join_steps)
 
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
         self.raise_on_step_cycle(self.execution_plan)
@@ -535,6 +540,7 @@ class ExecutionPlan:
 
         # This gets the id of the children which needs the link to be calculated.
         children_uuids: set[UUID] = set()
+        attempted_key = link_fw
 
         for stored_links, uuids in link_trekker.data.items():
             if link_fw == stored_links:
@@ -549,6 +555,7 @@ class ExecutionPlan:
             source_framework = link_fw[1]
             # The join then executes in the right feature group's framework, so the merge arguments are inverted.
             swap_merge_sides = True
+            attempted_key = (link, destination_framework, source_framework)
 
             for stored_links, uuids in link_trekker.data.items():
                 if (link, destination_framework, source_framework) == stored_links:
@@ -602,7 +609,7 @@ class ExecutionPlan:
             # result = True
             result = self.is_valid_join_step(link_fw, children_fw, children_uuid, graph)
             if result is False:
-                self.declined_orientations.append(link_fw)
+                self.declined_orientations.append(attempted_key)
                 return None
             elif result is True:
                 pass

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -19,6 +19,13 @@ from mloda.core.prepare.joinstep_collection import JoinStepCollection
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_graph import PlannedQueue
 from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker, inheritance_distance
+from mloda.core.prepare.resolved_join import JoinSignature, PlannedOrientation, ResolvedJoinPlan
+from mloda.core.prepare.resolved_join_builder import (
+    DeclaredFrameworks,
+    build_resolved_join_plan,
+    legacy_join_signatures,
+    log_join_plan_divergence,
+)
 from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
@@ -82,16 +89,42 @@ class ExecutionPlan:
         # Report each divergence once, then at DEBUG.
         self.reported_unmatched: set[tuple[type[FeatureGroup], str, tuple[str, ...]]] = set()
 
+        self.planned_orientations: list[tuple[PlannedOrientation, JoinStep]] = []
+        self.declined_orientations: list[LinkFrameworkTrekker] = []
+        self.resolved_join_plan = ResolvedJoinPlan((), ())
+        self.join_signatures_at_build: frozenset[JoinSignature] = frozenset()
+
     def __iter__(self) -> Generator[TransformFrameworkStep | JoinStep | FeatureGroupStep, None, None]:
         yield from self.execution_plan
 
     def __len__(self) -> int:
         return len(self.execution_plan)
 
-    def create_execution_plan(self, queue: PlannedQueue, graph: Graph, link_trekker: LinkTrekker) -> None:
+    def create_execution_plan(
+        self,
+        queue: PlannedQueue,
+        graph: Graph,
+        link_trekker: LinkTrekker,
+        declared_frameworks: DeclaredFrameworks | None = None,
+    ) -> None:
+        self.planned_orientations = []
+        self.declined_orientations = []
+
         child_links = self.invert_link_trekker(link_trekker)
         pre_execution_plan = self.add_feature_group_step(queue, graph.parent_to_children_mapping, child_links)
         fw_execution_plan = self.add_joinstep(pre_execution_plan, link_trekker, graph)
+
+        # Both built before add_tfs, which adds write serialization edges that are not part of the join decision.
+        join_steps = [step for step in fw_execution_plan if isinstance(step, JoinStep)]
+        self.resolved_join_plan = build_resolved_join_plan(
+            self.planned_orientations,
+            self.declined_orientations,
+            graph,
+            declared_frameworks if declared_frameworks is not None else {},
+        )
+        self.join_signatures_at_build = legacy_join_signatures(join_steps)
+        log_join_plan_divergence(self.resolved_join_plan, join_steps)
+
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
         self.raise_on_step_cycle(self.execution_plan)
 
@@ -504,6 +537,7 @@ class ExecutionPlan:
         link = link_fw[0]
         destination_framework = link_fw[1]
         source_framework = link_fw[2]
+        effective_key = link_fw
 
         if link.jointype == JoinType.RIGHT:
             destination_framework = link_fw[2]
@@ -525,6 +559,7 @@ class ExecutionPlan:
             source_framework = link_fw[1]
             # The join then executes in the right feature group's framework, so the merge arguments are inverted.
             swap_merge_sides = True
+            effective_key = (link, destination_framework, source_framework)
 
             for stored_links, uuids in link_trekker.data.items():
                 if (link, destination_framework, source_framework) == stored_links:
@@ -588,6 +623,7 @@ class ExecutionPlan:
             # result = True
             result = self.is_valid_join_step(link_fw, children_fw, children_uuid, graph)
             if result is False:
+                self.declined_orientations.append(link_fw)
                 return None
             elif result is True:
                 pass
@@ -610,6 +646,8 @@ class ExecutionPlan:
                     destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
                 ),
             )
+
+        self.planned_orientations.append((PlannedOrientation(effective_key, frozenset(children_uuids)), js))
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
         self.joinstep_collection.add(js)

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -20,7 +20,7 @@ class ResolveComputeFrameworks:
     def links(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
         groups = [p for p in planned_queue if isinstance(p, tuple) and not isinstance(p[0], Link)]
 
-        # The snapshot has to precede rewrite_group_frameworks, which collapses compute_frameworks to the resolution.
+        # Must precede rewrite_group_frameworks, which collapses compute_frameworks to the resolution.
         for p in groups:
             for f in p[1]:
                 self.declared_frameworks[f.uuid] = frozenset(f.compute_frameworks or ())

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -14,6 +14,9 @@ class ResolveComputeFrameworks:
         self.to_invert_trekker_collection: list[LinkFrameworkTrekker] = []
         self.declared_frameworks: dict[UUID, frozenset[type[ComputeFramework]]] = {}
 
+    def get_declared_frameworks(self) -> dict[UUID, frozenset[type[ComputeFramework]]]:
+        return self.declared_frameworks
+
     def links(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
         groups = [p for p in planned_queue if isinstance(p, tuple) and not isinstance(p[0], Link)]
 

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -12,9 +12,15 @@ class ResolveComputeFrameworks:
     def __init__(self, graph: Graph) -> None:
         self.graph = graph
         self.to_invert_trekker_collection: list[LinkFrameworkTrekker] = []
+        self.declared_frameworks: dict[UUID, frozenset[type[ComputeFramework]]] = {}
 
     def links(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
         groups = [p for p in planned_queue if isinstance(p, tuple) and not isinstance(p[0], Link)]
+
+        # The snapshot has to precede rewrite_group_frameworks, which collapses compute_frameworks to the resolution.
+        for p in groups:
+            for f in p[1]:
+                self.declared_frameworks[f.uuid] = frozenset(f.compute_frameworks or ())
 
         trekker_members: dict[LinkFrameworkTrekker, list[Any]] = defaultdict(list)
         feature_trekkers: dict[UUID, list[LinkFrameworkTrekker]] = defaultdict(list)

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -1,7 +1,6 @@
 """The materialized join decision: one record per planned join orientation.
 
-Records are built in shadow mode next to the join steps and do not run anything yet.
-They carry metadata only (classes, uuids, indices, immutable scalars), so each one pickles to a worker.
+Shadow mode, nothing runs yet. Metadata only (classes, uuids, indices, scalars), so a record pickles to a worker.
 """
 
 from collections.abc import Iterable, Mapping
@@ -28,7 +27,7 @@ def signed_uuids(uuids: Iterable[UUID]) -> tuple[str, ...]:
 
 @dataclass(frozen=True)
 class ResolvedJoinSide:
-    """One declared side of a link: its group, its index and the parents that are that group."""
+    """One declared side of a link, with the parents that are that group."""
 
     feature_group: type[FeatureGroup]
     index: Index
@@ -57,7 +56,7 @@ class DeclinedOrientation:
 
 
 class JoinSignature(NamedTuple):
-    """The join a record or a join step names, comparable across the two representations."""
+    """The join a record or a join step names, comparable across both."""
 
     link_uuid: UUID
     jointype: str
@@ -71,7 +70,7 @@ class JoinSignature(NamedTuple):
 
 @dataclass(frozen=True)
 class ResolvedJoin:
-    """One join decision: which declared side the join runs in, what it moves and what it waits for."""
+    """One join decision: the declared side it runs in, what it moves, what it waits for."""
 
     link_uuid: UUID
     jointype: JoinType
@@ -83,7 +82,7 @@ class ResolvedJoin:
     destination_framework: type[ComputeFramework]
     source_framework: type[ComputeFramework]
     consumers: frozenset[UUID]
-    # Join dependency edges only; the write serialization edges add_tfs adds later are not part of this.
+    # Join dependency edges only, not the write serialization edges add_tfs adds later.
     depends_on: frozenset[UUID]
     token: UUID
     # Correlation only, never authoritative: the join step this record shadows.

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -1,0 +1,138 @@
+"""The materialized join decision: one record per planned join orientation.
+
+Records are built in shadow mode next to the join steps and do not run anything yet.
+They carry metadata only (classes, uuids, indices, immutable scalars), so each one pickles to a worker.
+"""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import NamedTuple
+from uuid import UUID
+
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinType
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker
+
+
+class JoinSide(Enum):
+    LEFT = "left"
+    RIGHT = "right"
+
+
+def signed_uuids(uuids: Iterable[UUID]) -> tuple[str, ...]:
+    """Order-free uuid rendering, so two representations of one join sign it the same way."""
+    return tuple(sorted(str(uuid) for uuid in uuids))
+
+
+@dataclass(frozen=True)
+class ResolvedJoinSide:
+    """One declared side of a link: its group, its index and the parents that are that group."""
+
+    feature_group: type[FeatureGroup]
+    index: Index
+    uuids: frozenset[UUID]
+    declared_frameworks: frozenset[type[ComputeFramework]]
+
+
+@dataclass(frozen=True)
+class PlannedOrientation:
+    """The trekker key an orientation was planned under, plus the children it serves."""
+
+    key: LinkFrameworkTrekker
+    consumers: frozenset[UUID]
+
+
+@dataclass(frozen=True)
+class DeclinedOrientation:
+    """An orientation of a link that planned no join step."""
+
+    link_uuid: UUID
+    left_framework: type[ComputeFramework]
+    right_framework: type[ComputeFramework]
+
+
+class JoinSignature(NamedTuple):
+    """The join a record or a join step names, comparable across the two representations."""
+
+    link_uuid: UUID
+    jointype: str
+    destination_uuids: tuple[str, ...]
+    source_uuids: tuple[str, ...]
+    destination_side: str
+    destination_framework: str
+    source_framework: str
+    depends_on_links: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedJoin:
+    """One join decision: which declared side the join runs in, what it moves and what it waits for."""
+
+    link_uuid: UUID
+    jointype: JoinType
+    left: ResolvedJoinSide
+    right: ResolvedJoinSide
+    destination_side: JoinSide
+    destination_uuids: frozenset[UUID]
+    source_uuids: frozenset[UUID]
+    destination_framework: type[ComputeFramework]
+    source_framework: type[ComputeFramework]
+    consumers: frozenset[UUID]
+    # Join dependency edges only; the write serialization edges add_tfs adds later are not part of this.
+    depends_on: frozenset[UUID]
+    token: UUID
+    # Correlation only, never authoritative: the join step this record shadows.
+    shadowed_step_uuid: UUID
+
+    @property
+    def inverted(self) -> bool:
+        return self.destination_side is JoinSide.RIGHT
+
+    @property
+    def destination(self) -> ResolvedJoinSide:
+        return self.right if self.inverted else self.left
+
+    @property
+    def source(self) -> ResolvedJoinSide:
+        return self.left if self.inverted else self.right
+
+    @property
+    def transform_from_feature_group(self) -> type[FeatureGroup]:
+        return self.source.feature_group
+
+    @property
+    def transform_to_feature_group(self) -> type[FeatureGroup]:
+        return self.destination.feature_group
+
+    def signature(self, link_of_token: Mapping[UUID, UUID]) -> JoinSignature:
+        return JoinSignature(
+            link_uuid=self.link_uuid,
+            jointype=self.jointype.value,
+            destination_uuids=signed_uuids(self.destination_uuids),
+            source_uuids=signed_uuids(self.source_uuids),
+            destination_side=self.destination_side.value,
+            destination_framework=self.destination_framework.get_class_name(),
+            source_framework=self.source_framework.get_class_name(),
+            depends_on_links=tuple(sorted({str(link_of_token[token]) for token in self.depends_on})),
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedJoinPlan:
+    """Every record of a run, together with the orientations that planned nothing."""
+
+    records: tuple[ResolvedJoin, ...]
+    declined: tuple[DeclinedOrientation, ...]
+
+    def link_of_token(self) -> dict[UUID, UUID]:
+        return {record.token: record.link_uuid for record in self.records}
+
+    def signatures(self) -> frozenset[JoinSignature]:
+        link_of_token = self.link_of_token()
+        return frozenset(record.signature(link_of_token) for record in self.records)
+
+    def records_of_link(self, link_uuid: UUID) -> tuple[ResolvedJoin, ...]:
+        return tuple(record for record in self.records if record.link_uuid == link_uuid)

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -11,10 +11,9 @@ from typing import NamedTuple
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.link import JoinType
+from mloda.core.abstract_plugins.components.link import JoinType, Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.prepare.resolve_links import LinkFrameworkTrekker
 
 
 class JoinSide(Enum):
@@ -39,10 +38,13 @@ class ResolvedJoinSide:
 
 @dataclass(frozen=True)
 class PlannedOrientation:
-    """The trekker key an orientation was planned under, plus the children it serves."""
+    """The join an orientation decided, not just the trekker key it was planned under."""
 
-    key: LinkFrameworkTrekker
+    link: Link
     consumers: frozenset[UUID]
+    destination_side: JoinSide
+    left_uuids: frozenset[UUID]
+    right_uuids: frozenset[UUID]
 
 
 @dataclass(frozen=True)

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -1,12 +1,13 @@
 """Materializes the join decision run_link made as records, and signs the legacy join steps the same way.
 
-Shadow mode: the two signature sets are only compared, nothing here changes what the plan runs.
+Shadow mode: the two signature sets must agree and divergence raises; nothing here changes what the plan runs.
 """
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import replace
 from uuid import UUID, uuid4
 
+from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -33,6 +34,7 @@ def _side(
     uuids: frozenset[UUID],
     declared_frameworks: DeclaredFrameworks,
 ) -> ResolvedJoinSide:
+    # Unions the parents' declared candidates; a multi-parent side may claim a framework only one parent declared.
     frameworks: set[type[ComputeFramework]] = set()
     for uuid in uuids:
         frameworks |= declared_frameworks.get(uuid, frozenset())
@@ -51,12 +53,21 @@ def build_resolved_join_plan(
     for orientation, join_step in planned:
         link = orientation.link
         side = orientation.destination_side
-        left_uuids, right_uuids = orientation.left_uuids, orientation.right_uuids
-        if left_uuids == right_uuids:
-            # A self link cannot be split by class, so the step's resolved sets separate the parents.
-            destination = frozenset(join_step.destination_framework_uuids)
-            source = frozenset(join_step.source_framework_uuids)
-            left_uuids, right_uuids = (destination, source) if side is JoinSide.LEFT else (source, destination)
+        destination = frozenset(join_step.destination_framework_uuids)
+        source = frozenset(join_step.source_framework_uuids)
+        resolved_left, resolved_right = (destination, source) if side is JoinSide.LEFT else (source, destination)
+        if link.left_feature_group == link.right_feature_group:
+            # run_link resolves a self link's left-discriminated parents into the destination set unconditionally.
+            left_uuids, right_uuids = destination, source
+        elif (
+            orientation.left_uuids <= resolved_left
+            and orientation.right_uuids <= resolved_right
+            and orientation.left_uuids != orientation.right_uuids
+        ):
+            left_uuids, right_uuids = orientation.left_uuids, orientation.right_uuids
+        else:
+            # The step's sets, so a record can never name parents outside its own destination/source claim.
+            left_uuids, right_uuids = resolved_left, resolved_right
 
         record = ResolvedJoin(
             link_uuid=link.uuid,
@@ -64,8 +75,8 @@ def build_resolved_join_plan(
             left=_side(link.left_feature_group, link.left_index, left_uuids, declared_frameworks),
             right=_side(link.right_feature_group, link.right_index, right_uuids, declared_frameworks),
             destination_side=side,
-            destination_uuids=frozenset(join_step.destination_framework_uuids),
-            source_uuids=frozenset(join_step.source_framework_uuids),
+            destination_uuids=destination,
+            source_uuids=source,
             destination_framework=join_step.destination_framework,
             source_framework=join_step.source_framework,
             consumers=orientation.consumers,
@@ -108,3 +119,17 @@ def legacy_join_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSign
     steps = list(join_steps)
     link_of_step = {step.uuid: step.link.uuid for step in steps}
     return frozenset(_legacy_signature(step, link_of_step) for step in steps)
+
+
+def raise_on_join_plan_divergence(plan: ResolvedJoinPlan, join_steps: Iterable[JoinStep]) -> object:
+    """Returns None when the records and the steps sign the same joins; a divergence is a planning bug."""
+    recorded = plan.signatures()
+    legacy = legacy_join_signatures(join_steps)
+    if recorded == legacy:
+        return None
+    raise ValueError(
+        internal_invariant_error(
+            "the resolved join records and the planned join steps sign different joins.",
+            f"only_in_records={sorted(recorded - legacy)}, only_in_steps={sorted(legacy - recorded)}",
+        )
+    )

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -1,22 +1,17 @@
-"""Builds the resolved join plan from the orientations run_link planned, and signs the legacy join steps.
+"""Materializes the join decision run_link made as resolved join records, and signs the legacy join steps.
 
-The two signature sets are compared in shadow mode only; nothing here changes what the plan runs.
+Still shadow mode: the two signature sets are only compared; nothing here changes what the plan runs.
 """
 
-import logging
-from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import replace
-from typing import NamedTuple
 from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.core.step.join_step import JoinStep
-from mloda.core.prepare.graph.graph import Graph
-from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, inheritance_distance
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker
 from mloda.core.prepare.resolved_join import (
     DeclinedOrientation,
     JoinSide,
@@ -29,71 +24,7 @@ from mloda.core.prepare.resolved_join import (
 )
 
 
-logger = logging.getLogger(__name__)
-
 DeclaredFrameworks = Mapping[UUID, frozenset[type[ComputeFramework]]]
-
-
-class _DeclaredSides(NamedTuple):
-    """The side the destination lands in, plus the parents each declared side owns."""
-
-    destination_side: JoinSide
-    left_uuids: frozenset[UUID]
-    right_uuids: frozenset[UUID]
-
-
-def _nearest(uuids_by_distance: dict[int, set[UUID]]) -> frozenset[UUID]:
-    """A declared side is held by its closest subclasses only; farther ones answer for a different side."""
-    if not uuids_by_distance:
-        return frozenset()
-    return frozenset(uuids_by_distance[min(uuids_by_distance)])
-
-
-def _nearest_side_uuids(link: Link, uuids: set[UUID], graph: Graph) -> tuple[frozenset[UUID], frozenset[UUID]]:
-    """Split the join's parents into the nearest subclasses of each declared feature group."""
-    left_by_distance: dict[int, set[UUID]] = defaultdict(set)
-    right_by_distance: dict[int, set[UUID]] = defaultdict(set)
-    nodes = graph.get_nodes()
-
-    for uuid in uuids:
-        if uuid not in nodes:
-            continue
-        feature_group_class = nodes[uuid].feature_group_class
-        if issubclass(feature_group_class, link.left_feature_group):
-            left_by_distance[inheritance_distance(feature_group_class, link.left_feature_group)].add(uuid)
-        if issubclass(feature_group_class, link.right_feature_group):
-            right_by_distance[inheritance_distance(feature_group_class, link.right_feature_group)].add(uuid)
-
-    return _nearest(left_by_distance), _nearest(right_by_distance)
-
-
-def _destination_side(link: Link, join_step: JoinStep, graph: Graph) -> _DeclaredSides:
-    """Name the declared side that holds the destination, next to the parents each side owns."""
-    left_uuids, right_uuids = _nearest_side_uuids(
-        link, join_step.destination_framework_uuids | join_step.source_framework_uuids, graph
-    )
-
-    destination = join_step.destination_framework_uuids
-    holds_left = bool(destination & left_uuids)
-    holds_right = bool(destination & right_uuids)
-
-    if holds_left and not holds_right:
-        side = JoinSide.LEFT
-    elif holds_right and not holds_left:
-        side = JoinSide.RIGHT
-    else:
-        # Self links and sides sharing one feature group are not decidable from the declared groups.
-        side = JoinSide.RIGHT if join_step.swap_merge_sides else JoinSide.LEFT
-
-    resolved_left, resolved_right = (
-        (destination, join_step.source_framework_uuids)
-        if side is JoinSide.LEFT
-        else (join_step.source_framework_uuids, destination)
-    )
-    if left_uuids != right_uuids and left_uuids <= resolved_left and right_uuids <= resolved_right:
-        return _DeclaredSides(side, left_uuids, right_uuids)
-    # One feature group on both sides is not separable by class, so the resolved sets separate the parents.
-    return _DeclaredSides(side, frozenset(resolved_left), frozenset(resolved_right))
 
 
 def _side(
@@ -111,7 +42,6 @@ def _side(
 def build_resolved_join_plan(
     planned: Sequence[tuple[PlannedOrientation, JoinStep]],
     declined: Sequence[LinkFrameworkTrekker],
-    graph: Graph,
     declared_frameworks: DeclaredFrameworks,
 ) -> ResolvedJoinPlan:
     """One record per planned orientation, ordered as the orientations were planned."""
@@ -119,15 +49,21 @@ def build_resolved_join_plan(
     token_by_step: dict[UUID, UUID] = {}
 
     for orientation, join_step in planned:
-        link = orientation.key[0]
-        sides = _destination_side(link, join_step, graph)
+        link = orientation.link
+        side = orientation.destination_side
+        left_uuids, right_uuids = orientation.left_uuids, orientation.right_uuids
+        if left_uuids == right_uuids:
+            # A self link cannot be split by class, so the step's resolved sets separate the parents.
+            destination = frozenset(join_step.destination_framework_uuids)
+            source = frozenset(join_step.source_framework_uuids)
+            left_uuids, right_uuids = (destination, source) if side is JoinSide.LEFT else (source, destination)
 
         record = ResolvedJoin(
             link_uuid=link.uuid,
             jointype=link.jointype,
-            left=_side(link.left_feature_group, link.left_index, sides.left_uuids, declared_frameworks),
-            right=_side(link.right_feature_group, link.right_index, sides.right_uuids, declared_frameworks),
-            destination_side=sides.destination_side,
+            left=_side(link.left_feature_group, link.left_index, left_uuids, declared_frameworks),
+            right=_side(link.right_feature_group, link.right_index, right_uuids, declared_frameworks),
+            destination_side=side,
             destination_uuids=frozenset(join_step.destination_framework_uuids),
             source_uuids=frozenset(join_step.source_framework_uuids),
             destination_framework=join_step.destination_framework,
@@ -173,29 +109,3 @@ def legacy_join_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSign
     steps = list(join_steps)
     link_of_step = {step.uuid: step.link.uuid for step in steps}
     return frozenset(_legacy_signature(step, link_of_step) for step in steps)
-
-
-def log_join_plan_divergence(plan: ResolvedJoinPlan, join_steps: Iterable[JoinStep]) -> None:
-    """Report at DEBUG where the records and the join steps sign different joins."""
-    if not logger.isEnabledFor(logging.DEBUG):
-        return
-
-    steps = list(join_steps)
-    link_of_step = {step.uuid: step.link.uuid for step in steps}
-    legacy = {_legacy_signature(step, link_of_step): step.uuid for step in steps}
-
-    link_of_token = plan.link_of_token()
-    recorded = {record.signature(link_of_token): record.shadowed_step_uuid for record in plan.records}
-
-    if recorded.keys() == legacy.keys():
-        return
-
-    logger.debug(
-        "The resolved join plan diverges from the join steps. Only in the records: %s. Only in the steps: %s.",
-        sorted(
-            f"{signature} (step {step_uuid})" for signature, step_uuid in recorded.items() if signature not in legacy
-        ),
-        sorted(
-            f"{signature} (step {step_uuid})" for signature, step_uuid in legacy.items() if signature not in recorded
-        ),
-    )

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -1,6 +1,6 @@
-"""Materializes the join decision run_link made as resolved join records, and signs the legacy join steps.
+"""Materializes the join decision run_link made as records, and signs the legacy join steps the same way.
 
-Still shadow mode: the two signature sets are only compared; nothing here changes what the plan runs.
+Shadow mode: the two signature sets are only compared, nothing here changes what the plan runs.
 """
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -76,7 +76,7 @@ def build_resolved_join_plan(
         records.append(record)
         token_by_step[join_step.uuid] = record.token
 
-    # An order edge is keyed by link uuid, so a producer link fans its tokens out over every record it built.
+    # An order edge is keyed by link uuid, so a producer fans its tokens over every record it built.
     resolved = tuple(
         replace(
             record,
@@ -105,7 +105,6 @@ def _legacy_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) ->
 
 
 def legacy_join_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSignature]:
-    """The same signature read off the legacy join steps."""
     steps = list(join_steps)
     link_of_step = {step.uuid: step.link.uuid for step in steps}
     return frozenset(_legacy_signature(step, link_of_step) for step in steps)

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -1,0 +1,201 @@
+"""Builds the resolved join plan from the orientations run_link planned, and signs the legacy join steps.
+
+The two signature sets are compared in shadow mode only; nothing here changes what the plan runs.
+"""
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import replace
+from typing import NamedTuple
+from uuid import UUID, uuid4
+
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, inheritance_distance
+from mloda.core.prepare.resolved_join import (
+    DeclinedOrientation,
+    JoinSide,
+    JoinSignature,
+    PlannedOrientation,
+    ResolvedJoin,
+    ResolvedJoinPlan,
+    ResolvedJoinSide,
+    signed_uuids,
+)
+
+
+logger = logging.getLogger(__name__)
+
+DeclaredFrameworks = Mapping[UUID, frozenset[type[ComputeFramework]]]
+
+
+class _DeclaredSides(NamedTuple):
+    """The side the destination lands in, plus the parents each declared side owns."""
+
+    destination_side: JoinSide
+    left_uuids: frozenset[UUID]
+    right_uuids: frozenset[UUID]
+
+
+def _nearest(uuids_by_distance: dict[int, set[UUID]]) -> frozenset[UUID]:
+    """A declared side is held by its closest subclasses only; farther ones answer for a different side."""
+    if not uuids_by_distance:
+        return frozenset()
+    return frozenset(uuids_by_distance[min(uuids_by_distance)])
+
+
+def _nearest_side_uuids(link: Link, uuids: set[UUID], graph: Graph) -> tuple[frozenset[UUID], frozenset[UUID]]:
+    """Split the join's parents into the nearest subclasses of each declared feature group."""
+    left_by_distance: dict[int, set[UUID]] = defaultdict(set)
+    right_by_distance: dict[int, set[UUID]] = defaultdict(set)
+    nodes = graph.get_nodes()
+
+    for uuid in uuids:
+        if uuid not in nodes:
+            continue
+        feature_group_class = nodes[uuid].feature_group_class
+        if issubclass(feature_group_class, link.left_feature_group):
+            left_by_distance[inheritance_distance(feature_group_class, link.left_feature_group)].add(uuid)
+        if issubclass(feature_group_class, link.right_feature_group):
+            right_by_distance[inheritance_distance(feature_group_class, link.right_feature_group)].add(uuid)
+
+    return _nearest(left_by_distance), _nearest(right_by_distance)
+
+
+def _destination_side(link: Link, join_step: JoinStep, graph: Graph) -> _DeclaredSides:
+    """Name the declared side that holds the destination, next to the parents each side owns."""
+    left_uuids, right_uuids = _nearest_side_uuids(
+        link, join_step.destination_framework_uuids | join_step.source_framework_uuids, graph
+    )
+
+    destination = join_step.destination_framework_uuids
+    holds_left = bool(destination & left_uuids)
+    holds_right = bool(destination & right_uuids)
+
+    if holds_left and not holds_right:
+        side = JoinSide.LEFT
+    elif holds_right and not holds_left:
+        side = JoinSide.RIGHT
+    else:
+        # Self links and sides sharing one feature group are not decidable from the declared groups.
+        side = JoinSide.RIGHT if join_step.swap_merge_sides else JoinSide.LEFT
+
+    resolved_left, resolved_right = (
+        (destination, join_step.source_framework_uuids)
+        if side is JoinSide.LEFT
+        else (join_step.source_framework_uuids, destination)
+    )
+    if left_uuids != right_uuids and left_uuids <= resolved_left and right_uuids <= resolved_right:
+        return _DeclaredSides(side, left_uuids, right_uuids)
+    # One feature group on both sides is not separable by class, so the resolved sets separate the parents.
+    return _DeclaredSides(side, frozenset(resolved_left), frozenset(resolved_right))
+
+
+def _side(
+    feature_group: type[FeatureGroup],
+    index: Index,
+    uuids: frozenset[UUID],
+    declared_frameworks: DeclaredFrameworks,
+) -> ResolvedJoinSide:
+    frameworks: set[type[ComputeFramework]] = set()
+    for uuid in uuids:
+        frameworks |= declared_frameworks.get(uuid, frozenset())
+    return ResolvedJoinSide(feature_group, index, uuids, frozenset(frameworks))
+
+
+def build_resolved_join_plan(
+    planned: Sequence[tuple[PlannedOrientation, JoinStep]],
+    declined: Sequence[LinkFrameworkTrekker],
+    graph: Graph,
+    declared_frameworks: DeclaredFrameworks,
+) -> ResolvedJoinPlan:
+    """One record per planned orientation, ordered as the orientations were planned."""
+    records: list[ResolvedJoin] = []
+    token_by_step: dict[UUID, UUID] = {}
+
+    for orientation, join_step in planned:
+        link = orientation.key[0]
+        sides = _destination_side(link, join_step, graph)
+
+        record = ResolvedJoin(
+            link_uuid=link.uuid,
+            jointype=link.jointype,
+            left=_side(link.left_feature_group, link.left_index, sides.left_uuids, declared_frameworks),
+            right=_side(link.right_feature_group, link.right_index, sides.right_uuids, declared_frameworks),
+            destination_side=sides.destination_side,
+            destination_uuids=frozenset(join_step.destination_framework_uuids),
+            source_uuids=frozenset(join_step.source_framework_uuids),
+            destination_framework=join_step.destination_framework,
+            source_framework=join_step.source_framework,
+            consumers=orientation.consumers,
+            depends_on=frozenset(),
+            token=uuid4(),
+            shadowed_step_uuid=join_step.uuid,
+        )
+        records.append(record)
+        token_by_step[join_step.uuid] = record.token
+
+    # An order edge is keyed by link uuid, so a producer link fans its tokens out over every record it built.
+    resolved = tuple(
+        replace(
+            record,
+            depends_on=frozenset(token_by_step[uuid] for uuid in step.required_uuids if uuid in token_by_step),
+        )
+        for record, (_, step) in zip(records, planned)
+    )
+    return ResolvedJoinPlan(resolved, tuple(DeclinedOrientation(key[0].uuid, key[1], key[2]) for key in declined))
+
+
+def _legacy_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) -> JoinSignature:
+    """The join a legacy step names, with its destination side read off swap_merge_sides."""
+    side = JoinSide.RIGHT if join_step.swap_merge_sides else JoinSide.LEFT
+    return JoinSignature(
+        link_uuid=join_step.link.uuid,
+        jointype=join_step.link.jointype.value,
+        destination_uuids=signed_uuids(join_step.destination_framework_uuids),
+        source_uuids=signed_uuids(join_step.source_framework_uuids),
+        destination_side=side.value,
+        destination_framework=join_step.destination_framework.get_class_name(),
+        source_framework=join_step.source_framework.get_class_name(),
+        depends_on_links=tuple(
+            sorted({str(link_of_step[uuid]) for uuid in join_step.required_uuids if uuid in link_of_step})
+        ),
+    )
+
+
+def legacy_join_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSignature]:
+    """The same signature read off the legacy join steps."""
+    steps = list(join_steps)
+    link_of_step = {step.uuid: step.link.uuid for step in steps}
+    return frozenset(_legacy_signature(step, link_of_step) for step in steps)
+
+
+def log_join_plan_divergence(plan: ResolvedJoinPlan, join_steps: Iterable[JoinStep]) -> None:
+    """Report at DEBUG where the records and the join steps sign different joins."""
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    steps = list(join_steps)
+    link_of_step = {step.uuid: step.link.uuid for step in steps}
+    legacy = {_legacy_signature(step, link_of_step): step.uuid for step in steps}
+
+    link_of_token = plan.link_of_token()
+    recorded = {record.signature(link_of_token): record.shadowed_step_uuid for record in plan.records}
+
+    if recorded.keys() == legacy.keys():
+        return
+
+    logger.debug(
+        "The resolved join plan diverges from the join steps. Only in the records: %s. Only in the steps: %s.",
+        sorted(
+            f"{signature} (step {step_uuid})" for signature, step_uuid in recorded.items() if signature not in legacy
+        ),
+        sorted(
+            f"{signature} (step {step_uuid})" for signature, step_uuid in legacy.items() if signature not in recorded
+        ),
+    )

--- a/tests/test_core/test_prepare/join_plan_helpers.py
+++ b/tests/test_core/test_prepare/join_plan_helpers.py
@@ -1,0 +1,37 @@
+"""Shared feature and link-trekker helpers for the join plan tests in this package."""
+
+from typing import Any
+from uuid import UUID
+
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.provider import ComputeFramework
+from mloda.user import Feature
+from mloda.user import Index
+from mloda.user import Link
+
+
+def feature(
+    name: str,
+    cfw: type[ComputeFramework],
+    index: Index | None = None,
+    options: dict[str, Any] | None = None,
+) -> Feature:
+    built = Feature(name, index=index, options=options)
+    built.compute_frameworks = {cfw}
+    return built
+
+
+def trek(
+    link_trekker: LinkTrekker,
+    link: Link,
+    orientation: tuple[type[ComputeFramework], type[ComputeFramework]],
+    uuid: UUID,
+) -> None:
+    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
+    key = (link, orientation[0], orientation[1])
+    trekked = link_trekker.data.get(key)
+    if trekked is None:
+        trekked = set()
+        link_trekker.data[key] = trekked
+        link_trekker.data_ordered[key] = trekked
+    trekked.add(uuid)

--- a/tests/test_core/test_prepare/join_plan_helpers.py
+++ b/tests/test_core/test_prepare/join_plan_helpers.py
@@ -1,4 +1,4 @@
-"""Shared feature and link-trekker helpers for the join plan tests in this package."""
+"""Shared feature and link-trekker helpers for the join plan tests."""
 
 from typing import Any
 from uuid import UUID

--- a/tests/test_core/test_prepare/resolved_join_probe.py
+++ b/tests/test_core/test_prepare/resolved_join_probe.py
@@ -1,5 +1,5 @@
 """Prints one json line with the resolved join record a fresh interpreter builds.
-No test_ prefix, so pytest never collects it; the resolved join record tests run it as a script.
+No test_ prefix, so pytest never collects it; the record tests run it as a script.
 """
 
 import json

--- a/tests/test_core/test_prepare/resolved_join_probe.py
+++ b/tests/test_core/test_prepare/resolved_join_probe.py
@@ -1,0 +1,97 @@
+"""Prints one json line with the resolved join record a fresh interpreter builds.
+No test_ prefix, so pytest never collects it; the resolved join record tests run it as a script.
+"""
+
+import json
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_links import LinkTrekker, ResolveLinks
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+PROBE_LEFT_INDEX = Index(("resolved_join_probe_left_key",))
+PROBE_RIGHT_INDEX = Index(("resolved_join_probe_right_key",))
+
+
+class ResolvedJoinProbeLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinProbeRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinProbeChild(FeatureGroup):
+    pass
+
+
+def _feature(name: str, frameworks: set[type[ComputeFramework]], index: Index | None = None) -> Feature:
+    feature = Feature(name, index=index)
+    feature.compute_frameworks = frameworks
+    return feature
+
+
+def collect() -> dict[str, str]:
+    """Each side reduces from a framework set, and the record has to name the same sides the reduction picked."""
+    link = Link.inner(
+        JoinSpec(ResolvedJoinProbeLeft, PROBE_LEFT_INDEX), JoinSpec(ResolvedJoinProbeRight, PROBE_RIGHT_INDEX)
+    )
+    left = _feature("resolved_join_probe_left_payload", {PandasDataFrame, PyArrowTable}, PROBE_LEFT_INDEX)
+    right = _feature("resolved_join_probe_right_payload", {PythonDictFramework, PyArrowTable}, PROBE_RIGHT_INDEX)
+    child = _feature("resolved_join_probe_child_payload", {PandasDataFrame})
+    key = ResolveLinks(Graph()).create_link_trekker_key(link, left.compute_frameworks, right.compute_frameworks)
+
+    graph = Graph()
+    graph.add_node(left.uuid, NodeProperties(left, ResolvedJoinProbeLeft))
+    graph.add_node(right.uuid, NodeProperties(right, ResolvedJoinProbeRight))
+    graph.add_node(child.uuid, NodeProperties(child, ResolvedJoinProbeChild))
+    graph.adjacency_list[left.uuid] = [child.uuid]
+    graph.adjacency_list[right.uuid] = [child.uuid]
+    graph.adjacency_list[child.uuid] = []
+    graph.parent_to_children_mapping[child.uuid] = {left.uuid, right.uuid}
+
+    trekker = LinkTrekker()
+    trekked = {child.uuid}
+    trekker.data[key] = trekked
+    trekker.data_ordered[key] = trekked
+
+    queue: list[Any] = [
+        (ResolvedJoinProbeLeft, {left}),
+        (ResolvedJoinProbeRight, {right}),
+        key,
+        (ResolvedJoinProbeChild, {child}),
+    ]
+
+    plan = ExecutionPlan()
+    plan.create_execution_plan(queue, graph, trekker)
+
+    resolved = plan.resolved_join_plan
+    signature = resolved.records[0].signature(resolved.link_of_token())
+
+    return {
+        "declined_count": str(len(resolved.declined)),
+        "depends_on_count": str(len(signature.depends_on_links)),
+        "destination_framework": signature.destination_framework,
+        "destination_is_declared_left": str(signature.destination_uuids == (str(left.uuid),)),
+        "destination_side": signature.destination_side,
+        "jointype": signature.jointype,
+        "record_count": str(len(resolved.records)),
+        "source_framework": signature.source_framework,
+        "source_is_declared_right": str(signature.source_uuids == (str(right.uuid),)),
+        "trekker_left": key[1].get_class_name(),
+        "trekker_right": key[2].get_class_name(),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(collect(), sort_keys=True))

--- a/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
+++ b/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
@@ -32,6 +32,7 @@ from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from tests.test_core.test_prepare.join_plan_helpers import feature, trek
 
 
 TOKEN_LEFT_INDEX = Index(("token_left_key",))
@@ -124,12 +125,6 @@ class Branch(NamedTuple):
     right_uuid: UUID
 
 
-def _feature(name: str, cfw: type[ComputeFramework], index: Index | None = None) -> Feature:
-    feature = Feature(name, index=index)
-    feature.compute_frameworks = {cfw}
-    return feature
-
-
 def _step(fg: type[FeatureGroup], feature: Feature, required_uuids: set[UUID]) -> FeatureGroupStep:
     feature_set = FeatureSet()
     feature_set.add(feature)
@@ -166,9 +161,9 @@ def _add_branch(
     plan_the_link: bool = True,
 ) -> Branch:
     """Two parents joined by ``link`` plus the consumer, the smallest shape run_link accepts."""
-    left = _feature(f"{name}_left", left_cfw, link.left_index)
-    right = _feature(f"{name}_right", right_cfw, link.right_index)
-    child = _feature(f"{name}_child", left_cfw)
+    left = feature(f"{name}_left", left_cfw, link.left_index)
+    right = feature(f"{name}_right", right_cfw, link.right_index)
+    child = feature(f"{name}_child", left_cfw)
 
     graph = planned.graph
     graph.add_node(left.uuid, NodeProperties(left, link.left_feature_group))
@@ -190,17 +185,8 @@ def _add_branch(
     planned.pre_execution_plan.append(consumer)
     planned.queue.append((TokenChild, {child}))
 
-    _trek(planned, link, left_cfw, right_cfw, child.uuid)
+    trek(planned.link_trekker, link, (left_cfw, right_cfw), child.uuid)
     return Branch(consumer, left.uuid, right.uuid)
-
-
-def _trek(
-    planned: Planned, link: Link, left_cfw: type[ComputeFramework], right_cfw: type[ComputeFramework], uuid: UUID
-) -> None:
-    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
-    trekked = {uuid}
-    planned.link_trekker.data[(link, left_cfw, right_cfw)] = trekked
-    planned.link_trekker.data_ordered[(link, left_cfw, right_cfw)] = trekked
 
 
 def _add_joinstep(planned: Planned) -> list[JoinStep | FeatureGroupStep]:
@@ -352,8 +338,8 @@ def test_a_chained_append_joinstep_waits_for_the_joinstep_of_the_link_it_was_han
     head = JoinStep(head_link, PyArrowTable, PyArrowTable, {head_uuid, middle_uuid}, {head_uuid}, {middle_uuid})
     tail = JoinStep(tail_link, PyArrowTable, PyArrowTable, {middle_uuid, tail_uuid}, {middle_uuid}, {tail_uuid})
     planned.pre_execution_plan.extend([head, tail])
-    _trek(planned, head_link, PyArrowTable, PyArrowTable, head_uuid)
-    _trek(planned, tail_link, PyArrowTable, PyArrowTable, middle_uuid)
+    trek(planned.link_trekker, head_link, (PyArrowTable, PyArrowTable), head_uuid)
+    trek(planned.link_trekker, tail_link, (PyArrowTable, PyArrowTable), middle_uuid)
 
     _add_joinstep(planned)
 
@@ -407,10 +393,10 @@ def test_raise_on_step_cycle_rejects_three_joinsteps_waiting_on_each_other() -> 
 
 def test_raise_on_step_cycle_rejects_a_cycle_running_through_a_feature_group_step() -> None:
     """A JoinStep waiting on a feature its consumer produces is as unrunnable as a JoinStep pair."""
-    feature = _feature("token_cycle_feature", PyArrowTable)
+    cycle_feature = feature("token_cycle_feature", PyArrowTable)
     join_step = JoinStep(_token_link(), PyArrowTable, PandasDataFrame, set(), set(), set())
-    feature_group_step = _step(TokenChild, feature, {join_step.uuid})
-    join_step.required_uuids.add(feature.uuid)
+    feature_group_step = _step(TokenChild, cycle_feature, {join_step.uuid})
+    join_step.required_uuids.add(cycle_feature.uuid)
     steps: list[Step] = [join_step, feature_group_step]
 
     with pytest.raises(ValueError, match="(?i)cycl"):

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -80,6 +80,10 @@ class ResolvedJoinPairRight(FeatureGroup):
     pass
 
 
+class ResolvedJoinPairLeftDescendant(ResolvedJoinPairLeft):
+    """Matches the declared left side polymorphically, at inheritance distance one."""
+
+
 class ResolvedJoinOtherLeft(FeatureGroup):
     pass
 
@@ -639,10 +643,30 @@ def test_each_record_names_the_join_step_it_shadows() -> None:
 
 @pytest.mark.parametrize(
     "build",
-    [_declared_pair, _inverted_pair, _right_join, _inverted_left_join, _self_join, _append_pair, _two_links],
-    ids=["inner", "inverted_inner", "right", "inverted_left", "self_join", "append", "two_links"],
+    [
+        _declared_pair,
+        _inverted_pair,
+        _right_join,
+        _inverted_left_join,
+        _self_join,
+        _self_join_with_split_declarations,
+        _append_pair,
+        _two_links,
+        _link_with_an_unlinked_third_parent,
+    ],
+    ids=[
+        "inner",
+        "inverted_inner",
+        "right",
+        "inverted_left",
+        "self_join",
+        "self_join_split_declarations",
+        "append",
+        "two_links",
+        "unlinked_third_parent",
+    ],
 )
-def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Built]) -> None:
+def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Any]) -> None:
     built = build()
 
     join_steps = _join_steps(built.plan)
@@ -653,14 +677,41 @@ def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[
     assert resolved.signatures() == built.plan.join_signatures_at_build
 
 
+def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_steps_side() -> None:
+    """run_link ranks the left side over all required parents; the record must not re-rank over fewer of them."""
+    planned = _planned()
+    link = _pair_link()
+
+    descendant = _feature("resolved_join_third_fw_descendant", PandasDataFrame, link.left_index)
+    nearest_left = _feature("resolved_join_third_fw_nearest_left", PythonDictFramework, link.left_index)
+    right = _feature("resolved_join_third_fw_right", PyArrowTable, link.right_index)
+    child = _feature("resolved_join_third_fw_child", PandasDataFrame)
+
+    planned.graph.add_node(descendant.uuid, NodeProperties(descendant, ResolvedJoinPairLeftDescendant))
+    planned.graph.add_node(nearest_left.uuid, NodeProperties(nearest_left, ResolvedJoinPairLeft))
+    planned.graph.add_node(right.uuid, NodeProperties(right, ResolvedJoinPairRight))
+    planned.queue.append((ResolvedJoinPairLeftDescendant, {descendant}))
+    planned.queue.append((ResolvedJoinPairLeft, {nearest_left}))
+    planned.queue.append((ResolvedJoinPairRight, {right}))
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    _add_child(planned, child, descendant, nearest_left, right)
+    _trek(planned, link, (PandasDataFrame, PyArrowTable), child.uuid)
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+
+    assert len(_join_steps(planned.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"
+    assert planned.plan.resolved_join_plan.signatures() == planned.plan.join_signatures_at_build
+    assert _one_record(planned.plan, link).destination_side is JoinSide.RIGHT
+
+
 def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:
-    """The signatures only agree while the record derives its destination side from the graph."""
+    """The signatures only agree while the record derives its destination side from the planned orientation."""
     built = _declared_pair()
     join_step = _join_steps(built.plan)[0]
 
     join_step.swap_merge_sides = not join_step.swap_merge_sides
     rebuilt = build_resolved_join_plan(
-        built.plan.planned_orientations, built.plan.declined_orientations, built.graph, built.declared_frameworks
+        built.plan.planned_orientations, built.plan.declined_orientations, built.declared_frameworks
     )
 
     assert len(rebuilt.records) == len(_join_steps(built.plan)), "an empty rebuild makes the inequality meaningless"
@@ -770,8 +821,8 @@ def test_the_resolver_snapshots_the_frameworks_a_feature_declared_before_the_rew
     resolver.links(queue, link_trekker)
 
     assert child.compute_frameworks == {PyArrowTable}, "the rewrite has to collapse the child for this to say anything"
-    assert resolver.declared_frameworks[child.uuid] == {PyArrowTable, PandasDataFrame}
-    assert resolver.declared_frameworks[left.uuid] == {PyArrowTable}
+    assert resolver.get_declared_frameworks()[child.uuid] == {PyArrowTable, PandasDataFrame}
+    assert resolver.get_declared_frameworks()[left.uuid] == {PyArrowTable}
 
 
 # Fresh interpreters are slow to start, so this one needs more than the suite-wide per-test budget.

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -34,6 +34,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 from tests.helpers.probe_runner import run_probes
+from tests.test_core.test_prepare.join_plan_helpers import feature, trek
 
 
 PAIR_LEFT_INDEX = Index(("resolved_join_pair_left_key",))
@@ -202,28 +203,6 @@ def _planned() -> Planned:
     return Planned(ExecutionPlan(), Graph(), LinkTrekker(), [])
 
 
-def _feature(
-    name: str,
-    cfw: type[ComputeFramework],
-    index: Index | None = None,
-    options: dict[str, Any] | None = None,
-) -> Feature:
-    feature = Feature(name, index=index, options=options)
-    feature.compute_frameworks = {cfw}
-    return feature
-
-
-def _trek(planned: Planned, link: Link, orientation: Orientation, uuid: UUID) -> None:
-    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
-    key = (link, orientation[0], orientation[1])
-    trekked = planned.link_trekker.data.get(key)
-    if trekked is None:
-        trekked = set()
-        planned.link_trekker.data[key] = trekked
-        planned.link_trekker.data_ordered[key] = trekked
-    trekked.add(uuid)
-
-
 def _add_parents(planned: Planned, link: Link, left: Feature, right: Feature) -> None:
     planned.graph.add_node(left.uuid, NodeProperties(left, link.left_feature_group))
     planned.graph.add_node(right.uuid, NodeProperties(right, link.right_feature_group))
@@ -253,15 +232,15 @@ def _branch(
     right_options: dict[str, Any] | None = None,
 ) -> Sides:
     """Two parents joined by ``link`` plus the consumer, the smallest shape run_link accepts."""
-    left = _feature(f"{name}_left", left_cfw, link.left_index, left_options)
-    right = _feature(f"{name}_right", right_cfw, link.right_index, right_options)
-    child = _feature(f"{name}_child", child_cfw)
+    left = feature(f"{name}_left", left_cfw, link.left_index, left_options)
+    right = feature(f"{name}_right", right_cfw, link.right_index, right_options)
+    child = feature(f"{name}_child", child_cfw)
 
     _add_parents(planned, link, left, right)
     planned.queue.append((link, left_cfw, right_cfw))
     _add_child(planned, child, left, right)
 
-    _trek(planned, link, trekked or (left_cfw, right_cfw), child.uuid)
+    trek(planned.link_trekker, link, trekked or (left_cfw, right_cfw), child.uuid)
     return Sides(left.uuid, right.uuid, child.uuid)
 
 
@@ -378,10 +357,10 @@ def _pair_with_declined_orientation() -> Built:
     planned = _planned()
     link = _pair_link()
 
-    left = _feature("resolved_join_declined_left", PyArrowTable, link.left_index)
-    right = _feature("resolved_join_declined_right", PandasDataFrame, link.right_index)
-    kept = _feature("resolved_join_declined_kept_child", PyArrowTable)
-    dropped = _feature("resolved_join_declined_dropped_child", PandasDataFrame)
+    left = feature("resolved_join_declined_left", PyArrowTable, link.left_index)
+    right = feature("resolved_join_declined_right", PandasDataFrame, link.right_index)
+    kept = feature("resolved_join_declined_kept_child", PyArrowTable)
+    dropped = feature("resolved_join_declined_dropped_child", PandasDataFrame)
 
     _add_parents(planned, link, left, right)
     planned.queue.append((link, PyArrowTable, PandasDataFrame))
@@ -389,8 +368,8 @@ def _pair_with_declined_orientation() -> Built:
     _add_child(planned, kept, left, right)
     _add_child(planned, dropped, left, right)
 
-    _trek(planned, link, (PyArrowTable, PandasDataFrame), kept.uuid)
-    _trek(planned, link, (PandasDataFrame, PyArrowTable), dropped.uuid)
+    trek(planned.link_trekker, link, (PyArrowTable, PandasDataFrame), kept.uuid)
+    trek(planned.link_trekker, link, (PandasDataFrame, PyArrowTable), dropped.uuid)
 
     return _finish(planned, link, Sides(left.uuid, right.uuid, kept.uuid))
 
@@ -400,17 +379,17 @@ def _link_with_an_unlinked_third_parent() -> Unlinked:
     planned = _planned()
     link = _pair_link(Link.right)
 
-    left = _feature("resolved_join_unlinked_left", PyArrowTable, link.left_index)
-    right = _feature("resolved_join_unlinked_right", PandasDataFrame, link.right_index)
-    unlinked = _feature("resolved_join_unlinked_third", PandasDataFrame)
-    child = _feature("resolved_join_unlinked_child", PandasDataFrame)
+    left = feature("resolved_join_unlinked_left", PyArrowTable, link.left_index)
+    right = feature("resolved_join_unlinked_right", PandasDataFrame, link.right_index)
+    unlinked = feature("resolved_join_unlinked_third", PandasDataFrame)
+    child = feature("resolved_join_unlinked_child", PandasDataFrame)
 
     _add_parents(planned, link, left, right)
     planned.graph.add_node(unlinked.uuid, NodeProperties(unlinked, ResolvedJoinUnlinked))
     planned.queue.append((ResolvedJoinUnlinked, {unlinked}))
     planned.queue.append((link, PyArrowTable, PandasDataFrame))
     _add_child(planned, child, left, right, unlinked)
-    _trek(planned, link, (PyArrowTable, PandasDataFrame), child.uuid)
+    trek(planned.link_trekker, link, (PyArrowTable, PandasDataFrame), child.uuid)
 
     declared: DeclaredFrameworks = {
         left.uuid: frozenset({PyArrowTable}),
@@ -682,10 +661,10 @@ def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_step
     planned = _planned()
     link = _pair_link()
 
-    descendant = _feature("resolved_join_third_fw_descendant", PandasDataFrame, link.left_index)
-    nearest_left = _feature("resolved_join_third_fw_nearest_left", PythonDictFramework, link.left_index)
-    right = _feature("resolved_join_third_fw_right", PyArrowTable, link.right_index)
-    child = _feature("resolved_join_third_fw_child", PandasDataFrame)
+    descendant = feature("resolved_join_third_fw_descendant", PandasDataFrame, link.left_index)
+    nearest_left = feature("resolved_join_third_fw_nearest_left", PythonDictFramework, link.left_index)
+    right = feature("resolved_join_third_fw_right", PyArrowTable, link.right_index)
+    child = feature("resolved_join_third_fw_child", PandasDataFrame)
 
     planned.graph.add_node(descendant.uuid, NodeProperties(descendant, ResolvedJoinPairLeftDescendant))
     planned.graph.add_node(nearest_left.uuid, NodeProperties(nearest_left, ResolvedJoinPairLeft))
@@ -695,7 +674,7 @@ def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_step
     planned.queue.append((ResolvedJoinPairRight, {right}))
     planned.queue.append((link, PyArrowTable, PandasDataFrame))
     _add_child(planned, child, descendant, nearest_left, right)
-    _trek(planned, link, (PandasDataFrame, PyArrowTable), child.uuid)
+    trek(planned.link_trekker, link, (PandasDataFrame, PyArrowTable), child.uuid)
 
     planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
 
@@ -801,8 +780,8 @@ def test_a_real_engine_plan_carries_one_record_per_planned_join_step() -> None:
 
 def test_the_resolver_snapshots_the_frameworks_a_feature_declared_before_the_rewrite() -> None:
     link = _pair_link()
-    left = _feature("resolved_join_snapshot_left", PyArrowTable, link.left_index)
-    right = _feature("resolved_join_snapshot_right", PandasDataFrame, link.right_index)
+    left = feature("resolved_join_snapshot_left", PyArrowTable, link.left_index)
+    right = feature("resolved_join_snapshot_right", PandasDataFrame, link.right_index)
     child = Feature("resolved_join_snapshot_child")
     child.compute_frameworks = {PyArrowTable, PandasDataFrame}
 

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -1,0 +1,784 @@
+"""One record per join decision, built next to the join steps and signing the same joins they do."""
+
+import pickle  # nosec B403
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any, Callable, Iterable, NamedTuple
+from uuid import UUID
+
+import pytest
+
+from mloda.core.core.engine import Engine
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.core.prepare.resolved_join import DeclinedOrientation, JoinSide, JoinSignature, ResolvedJoin
+from mloda.core.prepare.resolved_join_builder import build_resolved_join_plan, legacy_join_signatures
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Features
+from mloda.user import Index
+from mloda.user import JoinSpec, JoinType, Link
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.helpers.probe_runner import run_probes
+
+
+PAIR_LEFT_INDEX = Index(("resolved_join_pair_left_key",))
+PAIR_RIGHT_INDEX = Index(("resolved_join_pair_right_key",))
+OTHER_LEFT_INDEX = Index(("resolved_join_other_left_key",))
+OTHER_RIGHT_INDEX = Index(("resolved_join_other_right_key",))
+STACK_LEFT_INDEX = Index(("resolved_join_stack_left_key",))
+STACK_RIGHT_INDEX = Index(("resolved_join_stack_right_key",))
+
+SELF_SIDE = "resolved_join_self_side"
+SELF_LEFT_KEY = "resolved_join_self_left_key"
+SELF_RIGHT_KEY = "resolved_join_self_right_key"
+SELF_LEFT_CANDIDATES = frozenset({PyArrowTable, PandasDataFrame})
+SELF_RIGHT_CANDIDATES = frozenset({PyArrowTable})
+
+END_LEFT_KEY = "resolved_join_end_left_key"
+END_LEFT_PAYLOAD = "resolved_join_end_left_payload"
+END_RIGHT_KEY = "resolved_join_end_right_key"
+END_RIGHT_PAYLOAD = "resolved_join_end_right_payload"
+
+_PROBE = Path(__file__).with_name("resolved_join_probe.py")
+# Each side reduces from a framework set, so a second cold interpreter is the whole cross-process signal.
+_PROBE_PROCESSES = 2
+_PROBE_EXPECTED = {
+    "declined_count": "0",
+    "depends_on_count": "0",
+    "destination_framework": "PandasDataFrame",
+    "destination_is_declared_left": "True",
+    "destination_side": "left",
+    "jointype": "inner",
+    "record_count": "1",
+    "source_framework": "PyArrowTable",
+    "source_is_declared_right": "True",
+    "trekker_left": "PandasDataFrame",
+    "trekker_right": "PyArrowTable",
+}
+
+
+class ResolvedJoinPairLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinPairRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinOtherLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinOtherRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinStackLeft(FeatureGroup):
+    pass
+
+
+class ResolvedJoinStackRight(FeatureGroup):
+    pass
+
+
+class ResolvedJoinSelfSource(FeatureGroup):
+    pass
+
+
+class ResolvedJoinUnlinked(FeatureGroup):
+    """Feeds a child of a link without being named by it."""
+
+
+class ResolvedJoinChild(FeatureGroup):
+    pass
+
+
+class ResolvedJoinEndLeft(FeatureGroup):
+    """Pinned to the framework the end to end link declares as its left side."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={END_LEFT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {END_LEFT_KEY: [1, 2], END_LEFT_PAYLOAD: ["l1", "l2"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class ResolvedJoinEndRight(FeatureGroup):
+    """Pinned to the other framework, so the join needs a transform hop."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={END_RIGHT_PAYLOAD})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {END_RIGHT_KEY: [1, 2], END_RIGHT_PAYLOAD: ["r1", "r2"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class ResolvedJoinEndChild(FeatureGroup):
+    """Takes either framework, so it keeps the declared orientation."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature(name=END_LEFT_PAYLOAD), Feature(name=END_RIGHT_PAYLOAD)}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+Orientation = tuple[type[ComputeFramework], type[ComputeFramework]]
+DeclaredFrameworks = dict[UUID, frozenset[type[ComputeFramework]]]
+
+
+class Planned(NamedTuple):
+    plan: ExecutionPlan
+    graph: Graph
+    link_trekker: LinkTrekker
+    queue: list[Any]
+
+
+class Sides(NamedTuple):
+    left_uuid: UUID
+    right_uuid: UUID
+    child_uuid: UUID
+
+
+class Built(NamedTuple):
+    plan: ExecutionPlan
+    link: Link
+    sides: Sides
+    graph: Graph
+    declared_frameworks: DeclaredFrameworks
+
+
+class Unlinked(NamedTuple):
+    plan: ExecutionPlan
+    link: Link
+    left_uuid: UUID
+    right_uuid: UUID
+    unlinked_uuid: UUID
+
+
+class Chain(NamedTuple):
+    plan: ExecutionPlan
+    producer: Link
+    consumer: Link
+
+
+def _planned() -> Planned:
+    return Planned(ExecutionPlan(), Graph(), LinkTrekker(), [])
+
+
+def _feature(
+    name: str,
+    cfw: type[ComputeFramework],
+    index: Index | None = None,
+    options: dict[str, Any] | None = None,
+) -> Feature:
+    feature = Feature(name, index=index, options=options)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _trek(planned: Planned, link: Link, orientation: Orientation, uuid: UUID) -> None:
+    """Production shares one set object between data and data_ordered, and invert_link relies on that."""
+    key = (link, orientation[0], orientation[1])
+    trekked = planned.link_trekker.data.get(key)
+    if trekked is None:
+        trekked = set()
+        planned.link_trekker.data[key] = trekked
+        planned.link_trekker.data_ordered[key] = trekked
+    trekked.add(uuid)
+
+
+def _add_parents(planned: Planned, link: Link, left: Feature, right: Feature) -> None:
+    planned.graph.add_node(left.uuid, NodeProperties(left, link.left_feature_group))
+    planned.graph.add_node(right.uuid, NodeProperties(right, link.right_feature_group))
+    planned.queue.append((link.left_feature_group, {left}))
+    planned.queue.append((link.right_feature_group, {right}))
+
+
+def _add_child(planned: Planned, child: Feature, *parents: Feature) -> None:
+    planned.graph.add_node(child.uuid, NodeProperties(child, ResolvedJoinChild))
+    for parent in parents:
+        planned.graph.adjacency_list[parent.uuid].append(child.uuid)
+    planned.graph.adjacency_list[child.uuid] = []
+    planned.graph.parent_to_children_mapping[child.uuid] = {parent.uuid for parent in parents}
+    planned.queue.append((ResolvedJoinChild, {child}))
+
+
+def _branch(
+    planned: Planned,
+    link: Link,
+    name: str,
+    *,
+    left_cfw: type[ComputeFramework] = PyArrowTable,
+    right_cfw: type[ComputeFramework] = PandasDataFrame,
+    child_cfw: type[ComputeFramework] = PyArrowTable,
+    trekked: Orientation | None = None,
+    left_options: dict[str, Any] | None = None,
+    right_options: dict[str, Any] | None = None,
+) -> Sides:
+    """Two parents joined by ``link`` plus the consumer, the smallest shape run_link accepts."""
+    left = _feature(f"{name}_left", left_cfw, link.left_index, left_options)
+    right = _feature(f"{name}_right", right_cfw, link.right_index, right_options)
+    child = _feature(f"{name}_child", child_cfw)
+
+    _add_parents(planned, link, left, right)
+    planned.queue.append((link, left_cfw, right_cfw))
+    _add_child(planned, child, left, right)
+
+    _trek(planned, link, trekked or (left_cfw, right_cfw), child.uuid)
+    return Sides(left.uuid, right.uuid, child.uuid)
+
+
+def _finish(
+    planned: Planned,
+    link: Link,
+    sides: Sides,
+    declared_frameworks: DeclaredFrameworks | None = None,
+) -> Built:
+    declared = declared_frameworks or {}
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker, declared)
+    return Built(planned.plan, link, sides, planned.graph, declared)
+
+
+def _pair_link(link_factory: Callable[[JoinSpec, JoinSpec], Link] = Link.inner) -> Link:
+    return link_factory(
+        JoinSpec(ResolvedJoinPairLeft, PAIR_LEFT_INDEX), JoinSpec(ResolvedJoinPairRight, PAIR_RIGHT_INDEX)
+    )
+
+
+def _other_link() -> Link:
+    return Link.inner(
+        JoinSpec(ResolvedJoinOtherLeft, OTHER_LEFT_INDEX), JoinSpec(ResolvedJoinOtherRight, OTHER_RIGHT_INDEX)
+    )
+
+
+def _declared_pair() -> Built:
+    planned = _planned()
+    link = _pair_link()
+    return _finish(planned, link, _branch(planned, link, "resolved_join_declared"))
+
+
+def _inverted_pair() -> Built:
+    """The queue keeps the declared orientation, so run_link rediscovers the inverted one."""
+    planned = _planned()
+    link = _pair_link()
+    sides = _branch(
+        planned, link, "resolved_join_inverted", child_cfw=PandasDataFrame, trekked=(PandasDataFrame, PyArrowTable)
+    )
+    return _finish(planned, link, sides)
+
+
+def _right_join() -> Built:
+    planned = _planned()
+    link = _pair_link(Link.right)
+    return _finish(planned, link, _branch(planned, link, "resolved_join_right", child_cfw=PandasDataFrame))
+
+
+def _inverted_left_join() -> Built:
+    planned = _planned()
+    link = _pair_link(Link.left)
+    sides = _branch(
+        planned, link, "resolved_join_left", child_cfw=PandasDataFrame, trekked=(PandasDataFrame, PyArrowTable)
+    )
+    return _finish(planned, link, sides)
+
+
+def _self_join_parts() -> tuple[Planned, Link, Sides]:
+    """One feature group on both sides, so only the discriminators tell the two parents apart."""
+    planned = _planned()
+    link = Link.left(
+        JoinSpec(ResolvedJoinSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(ResolvedJoinSelfSource, Index((SELF_RIGHT_KEY,))),
+        left_discriminator={SELF_SIDE: "left"},
+        right_discriminator={SELF_SIDE: "right"},
+    )
+    sides = _branch(
+        planned,
+        link,
+        "resolved_join_self",
+        right_cfw=PyArrowTable,
+        left_options={SELF_SIDE: "left"},
+        right_options={SELF_SIDE: "right"},
+    )
+    return planned, link, sides
+
+
+def _self_join() -> Built:
+    planned, link, sides = _self_join_parts()
+    return _finish(planned, link, sides)
+
+
+def _self_join_with_split_declarations() -> Built:
+    """The nearest subclass rule cannot split one feature group over two sides; the resolved sets separate them."""
+    planned, link, sides = _self_join_parts()
+    return _finish(
+        planned,
+        link,
+        sides,
+        {sides.left_uuid: SELF_LEFT_CANDIDATES, sides.right_uuid: SELF_RIGHT_CANDIDATES},
+    )
+
+
+def _append_pair() -> Built:
+    planned = _planned()
+    link = Link.append(
+        JoinSpec(ResolvedJoinStackLeft, STACK_LEFT_INDEX), JoinSpec(ResolvedJoinStackRight, STACK_RIGHT_INDEX)
+    )
+    return _finish(planned, link, _branch(planned, link, "resolved_join_append"))
+
+
+def _two_links() -> Built:
+    """Two links that share nothing but the plan they are planned into."""
+    planned = _planned()
+    first = _pair_link()
+    second = _other_link()
+    sides = _branch(planned, first, "resolved_join_two_first")
+    _branch(planned, second, "resolved_join_two_second")
+    return _finish(planned, first, sides)
+
+
+def _pair_with_declined_orientation() -> Built:
+    """Two children of one link, and only the PyArrow one pairs a left side up with a right side."""
+    planned = _planned()
+    link = _pair_link()
+
+    left = _feature("resolved_join_declined_left", PyArrowTable, link.left_index)
+    right = _feature("resolved_join_declined_right", PandasDataFrame, link.right_index)
+    kept = _feature("resolved_join_declined_kept_child", PyArrowTable)
+    dropped = _feature("resolved_join_declined_dropped_child", PandasDataFrame)
+
+    _add_parents(planned, link, left, right)
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    planned.queue.append((link, PandasDataFrame, PyArrowTable))
+    _add_child(planned, kept, left, right)
+    _add_child(planned, dropped, left, right)
+
+    _trek(planned, link, (PyArrowTable, PandasDataFrame), kept.uuid)
+    _trek(planned, link, (PandasDataFrame, PyArrowTable), dropped.uuid)
+
+    return _finish(planned, link, Sides(left.uuid, right.uuid, kept.uuid))
+
+
+def _link_with_an_unlinked_third_parent() -> Unlinked:
+    """A right join whose child also has a parent the link never mentions."""
+    planned = _planned()
+    link = _pair_link(Link.right)
+
+    left = _feature("resolved_join_unlinked_left", PyArrowTable, link.left_index)
+    right = _feature("resolved_join_unlinked_right", PandasDataFrame, link.right_index)
+    unlinked = _feature("resolved_join_unlinked_third", PandasDataFrame)
+    child = _feature("resolved_join_unlinked_child", PandasDataFrame)
+
+    _add_parents(planned, link, left, right)
+    planned.graph.add_node(unlinked.uuid, NodeProperties(unlinked, ResolvedJoinUnlinked))
+    planned.queue.append((ResolvedJoinUnlinked, {unlinked}))
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    _add_child(planned, child, left, right, unlinked)
+    _trek(planned, link, (PyArrowTable, PandasDataFrame), child.uuid)
+
+    declared: DeclaredFrameworks = {
+        left.uuid: frozenset({PyArrowTable}),
+        right.uuid: frozenset({PandasDataFrame}),
+        unlinked.uuid: frozenset({PandasDataFrame, PythonDictFramework}),
+    }
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker, declared)
+    return Unlinked(planned.plan, link, left.uuid, right.uuid, unlinked.uuid)
+
+
+def _ordered_chain() -> Chain:
+    planned = _planned()
+    producer = _pair_link()
+    consumer = _other_link()
+    _branch(planned, producer, "resolved_join_chain_producer")
+    _branch(planned, consumer, "resolved_join_chain_consumer")
+    # The value side of an order entry lists the links that have to wait for the key.
+    planned.link_trekker.order[producer.uuid] = {consumer.uuid}
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+    return Chain(planned.plan, producer, consumer)
+
+
+def _join_steps(plan: ExecutionPlan) -> list[JoinStep]:
+    return [step for step in plan if isinstance(step, JoinStep)]
+
+
+def _transform_steps(plan: ExecutionPlan, link: Link) -> list[TransformFrameworkStep]:
+    return [step for step in plan if isinstance(step, TransformFrameworkStep) and step.link_id == link.uuid]
+
+
+def _records(plan: ExecutionPlan, link: Link) -> tuple[ResolvedJoin, ...]:
+    return plan.resolved_join_plan.records_of_link(link.uuid)
+
+
+def _one_record(plan: ExecutionPlan, link: Link) -> ResolvedJoin:
+    records = _records(plan, link)
+    assert len(records) == 1, f"the orientation must build exactly one record; got: {records}"
+    return records[0]
+
+
+def _without_depends(signatures: Iterable[JoinSignature]) -> frozenset[JoinSignature]:
+    return frozenset(signature._replace(depends_on_links=()) for signature in signatures)
+
+
+def test_a_record_is_inverted_exactly_when_its_destination_is_the_right_side() -> None:
+    declared = _declared_pair()
+    inverted = _inverted_pair()
+
+    declared_record = _one_record(declared.plan, declared.link)
+    inverted_record = _one_record(inverted.plan, inverted.link)
+
+    assert declared_record.destination_side is JoinSide.LEFT
+    assert declared_record.inverted is False
+    assert inverted_record.destination_side is JoinSide.RIGHT
+    assert inverted_record.inverted is True
+
+
+def test_a_record_refuses_assignment_to_its_fields_and_to_inverted() -> None:
+    built = _declared_pair()
+    record = _one_record(built.plan, built.link)
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(record, "destination_side", JoinSide.RIGHT)
+
+    with pytest.raises(AttributeError):
+        setattr(record, "inverted", True)
+
+
+def test_destination_and_source_name_the_sides_the_destination_side_picks() -> None:
+    declared = _declared_pair()
+    inverted = _inverted_pair()
+
+    declared_record = _one_record(declared.plan, declared.link)
+    inverted_record = _one_record(inverted.plan, inverted.link)
+
+    assert declared_record.destination is declared_record.left
+    assert declared_record.source is declared_record.right
+    assert inverted_record.destination is inverted_record.right
+    assert inverted_record.source is inverted_record.left
+
+
+def test_a_record_survives_the_round_trip_to_a_multiprocessing_worker() -> None:
+    built = _declared_pair()
+    record = _one_record(built.plan, built.link)
+
+    restored = pickle.loads(pickle.dumps(record))  # nosec B301
+
+    assert restored == record
+
+
+def test_the_declared_orientation_of_an_inner_pair_builds_one_left_destination_record() -> None:
+    built = _declared_pair()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.link_uuid == built.link.uuid
+    assert record.jointype is JoinType.INNER
+    assert record.destination_side is JoinSide.LEFT
+    assert record.inverted is False
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination_uuids == {built.sides.left_uuid}
+    assert record.source_uuids == {built.sides.right_uuid}
+    assert record.destination_framework is PyArrowTable
+    assert record.source_framework is PandasDataFrame
+    assert record.left.feature_group is ResolvedJoinPairLeft
+    assert record.left.index == built.link.left_index
+
+
+def test_an_orientation_inverted_after_queueing_still_names_the_declared_left_side() -> None:
+    built = _inverted_pair()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.inverted is True
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination_uuids == {built.sides.right_uuid}
+    assert record.source_uuids == {built.sides.left_uuid}
+
+
+def test_a_right_join_binds_the_destination_to_the_declared_right_side() -> None:
+    built = _right_join()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.jointype is JoinType.RIGHT
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination.uuids == {built.sides.right_uuid}
+    assert record.destination_uuids == {built.sides.right_uuid}
+
+
+def test_a_parent_the_link_never_mentions_stays_out_of_the_declared_sides() -> None:
+    unlinked = _link_with_an_unlinked_third_parent()
+
+    record = _one_record(unlinked.plan, unlinked.link)
+
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.left.uuids == {unlinked.left_uuid}
+    assert record.right.uuids == {unlinked.right_uuid}
+    # The join writes into a parent that belongs to neither declared side, which a validation step should reject.
+    assert record.destination_uuids == {unlinked.right_uuid, unlinked.unlinked_uuid}
+    assert record.source_uuids == {unlinked.left_uuid}
+
+
+def test_a_declared_side_keeps_only_the_frameworks_its_own_parents_declared() -> None:
+    unlinked = _link_with_an_unlinked_third_parent()
+
+    record = _one_record(unlinked.plan, unlinked.link)
+
+    assert record.left.declared_frameworks == {PyArrowTable}
+    assert record.right.declared_frameworks == {PandasDataFrame}
+    assert PythonDictFramework not in record.left.declared_frameworks | record.right.declared_frameworks
+
+
+def test_a_self_join_gives_each_declared_side_only_its_own_parent() -> None:
+    built = _self_join_with_split_declarations()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination.uuids == record.destination_uuids
+    assert record.source.uuids == record.source_uuids
+
+
+def test_a_self_join_keeps_each_parents_framework_candidates_on_its_own_side() -> None:
+    built = _self_join_with_split_declarations()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.left.declared_frameworks == SELF_LEFT_CANDIDATES
+    assert record.right.declared_frameworks == SELF_RIGHT_CANDIDATES
+
+
+def test_a_side_keeps_the_framework_candidates_its_feature_declared_before_the_rewrite() -> None:
+    """The graph node carries the one framework the rewrite left; the snapshot carries what was declared."""
+    planned = _planned()
+    link = _pair_link()
+    sides = _branch(planned, link, "resolved_join_candidates")
+    built = _finish(
+        planned,
+        link,
+        sides,
+        {
+            sides.left_uuid: frozenset({PyArrowTable, PandasDataFrame}),
+            sides.right_uuid: frozenset({PandasDataFrame}),
+        },
+    )
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.left.declared_frameworks == {PyArrowTable, PandasDataFrame}
+    assert record.right.declared_frameworks == {PandasDataFrame}
+
+
+def test_consumers_name_the_children_the_orientation_serves() -> None:
+    built = _declared_pair()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.consumers == {built.sides.child_uuid}
+
+
+def test_a_declined_orientation_builds_no_record_and_one_declined_entry() -> None:
+    built = _pair_with_declined_orientation()
+    resolved = built.plan.resolved_join_plan
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.destination_framework is PyArrowTable
+    assert record.consumers == {built.sides.child_uuid}
+    assert resolved.declined == (DeclinedOrientation(built.link.uuid, PandasDataFrame, PyArrowTable),)
+
+
+def test_each_record_names_the_join_step_it_shadows() -> None:
+    built = _two_links()
+    step_of_link = {step.link.uuid: step.uuid for step in _join_steps(built.plan)}
+
+    records = built.plan.resolved_join_plan.records
+
+    assert len(records) == len(step_of_link)
+    for record in records:
+        assert record.shadowed_step_uuid == step_of_link[record.link_uuid]
+        assert record.shadowed_step_uuid != record.token
+
+
+@pytest.mark.parametrize(
+    "build",
+    [_declared_pair, _inverted_pair, _right_join, _inverted_left_join, _self_join, _append_pair, _two_links],
+    ids=["inner", "inverted_inner", "right", "inverted_left", "self_join", "append", "two_links"],
+)
+def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Built]) -> None:
+    built = build()
+
+    join_steps = _join_steps(built.plan)
+    resolved = built.plan.resolved_join_plan
+
+    assert join_steps, "the shape must plan at least one JoinStep for the parity to say anything"
+    assert len(resolved.records) == len(join_steps)
+    assert resolved.signatures() == built.plan.join_signatures_at_build
+
+
+def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:
+    """The signatures only agree while the record derives its destination side from the graph."""
+    built = _declared_pair()
+    join_step = _join_steps(built.plan)[0]
+
+    join_step.swap_merge_sides = not join_step.swap_merge_sides
+    rebuilt = build_resolved_join_plan(
+        built.plan.planned_orientations, built.plan.declined_orientations, built.graph, built.declared_frameworks
+    )
+
+    assert len(rebuilt.records) == len(_join_steps(built.plan)), "an empty rebuild makes the inequality meaningless"
+    assert rebuilt.signatures(), "an empty rebuild makes the inequality meaningless"
+    assert rebuilt.signatures() != legacy_join_signatures([join_step])
+
+
+def test_the_record_leaves_out_the_write_serialization_edges_add_tfs_adds() -> None:
+    built = _two_links()
+
+    recorded = built.plan.resolved_join_plan.signatures()
+    after_tfs = legacy_join_signatures(_join_steps(built.plan))
+
+    assert after_tfs != recorded, "add_tfs must add an edge here for this to say anything"
+    assert _without_depends(after_tfs) == _without_depends(recorded)
+
+
+def test_a_second_planning_pass_does_not_accumulate_records() -> None:
+    planned = _planned()
+    link = _pair_link()
+    _branch(planned, link, "resolved_join_twice")
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+    first = len(planned.plan.resolved_join_plan.records)
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+
+    assert len(planned.plan.resolved_join_plan.records) == first
+    assert len(planned.plan.resolved_join_plan.records) == len(_join_steps(planned.plan))
+
+
+def test_an_order_edge_makes_the_consumer_records_depend_on_the_producer_record_tokens() -> None:
+    chain = _ordered_chain()
+    resolved = chain.plan.resolved_join_plan
+    producer_records = resolved.records_of_link(chain.producer.uuid)
+    consumer_records = resolved.records_of_link(chain.consumer.uuid)
+    step_uuids = {step.uuid for step in _join_steps(chain.plan)}
+
+    assert producer_records, "the producer link must build a record for the edge to point at"
+    assert consumer_records, "the consumer link must build a record for the edge to hang off"
+    for record in producer_records:
+        assert not record.depends_on
+    for record in consumer_records:
+        assert record.depends_on == {produced.token for produced in producer_records}
+        assert chain.producer.uuid not in record.depends_on, "a record depends on tokens, not on link uuids"
+        assert record.depends_on.isdisjoint(step_uuids), "a record depends on tokens, not on step uuids"
+        assert record.signature(resolved.link_of_token()).depends_on_links == (str(chain.producer.uuid),)
+
+
+def test_the_record_and_the_legacy_transform_hop_name_opposite_directions() -> None:
+    built = _inverted_pair()
+
+    record = _one_record(built.plan, built.link)
+    transform_steps = _transform_steps(built.plan, built.link)
+
+    assert len(transform_steps) == 1
+    # The record binds the hop to the sides the join actually moves; a later lowering step should adopt its answer.
+    assert record.transform_from_feature_group is ResolvedJoinPairLeft
+    assert record.transform_to_feature_group is ResolvedJoinPairRight
+    assert transform_steps[0].from_feature_group is ResolvedJoinPairRight
+    assert transform_steps[0].to_feature_group is ResolvedJoinPairLeft
+
+
+def test_a_real_engine_plan_carries_one_record_per_planned_join_step() -> None:
+    link = Link.inner(
+        JoinSpec(ResolvedJoinEndLeft, Index((END_LEFT_KEY,))),
+        JoinSpec(ResolvedJoinEndRight, Index((END_RIGHT_KEY,))),
+    )
+    engine = Engine(
+        Features([Feature(name=ResolvedJoinEndChild.get_class_name())]),
+        {PyArrowTable, PandasDataFrame},
+        {link},
+        plugin_collector=PluginCollector.enabled_feature_groups(
+            {ResolvedJoinEndLeft, ResolvedJoinEndRight, ResolvedJoinEndChild}
+        ),
+    )
+
+    plan = engine.execution_planner
+    join_steps = _join_steps(plan)
+    resolved = plan.resolved_join_plan
+
+    assert len(join_steps) == 1
+    assert len(resolved.records) == len(join_steps)
+    assert resolved.signatures() == plan.join_signatures_at_build
+    for record in resolved.records:
+        assert record.destination_framework in record.destination.declared_frameworks
+
+
+def test_the_resolver_snapshots_the_frameworks_a_feature_declared_before_the_rewrite() -> None:
+    link = _pair_link()
+    left = _feature("resolved_join_snapshot_left", PyArrowTable, link.left_index)
+    right = _feature("resolved_join_snapshot_right", PandasDataFrame, link.right_index)
+    child = Feature("resolved_join_snapshot_child")
+    child.compute_frameworks = {PyArrowTable, PandasDataFrame}
+
+    link_trekker = LinkTrekker()
+    trekked = {child.uuid}
+    link_trekker.data[(link, PyArrowTable, PandasDataFrame)] = trekked
+    link_trekker.data_ordered[(link, PyArrowTable, PandasDataFrame)] = trekked
+    queue: list[Any] = [
+        (ResolvedJoinPairLeft, {left}),
+        (ResolvedJoinPairRight, {right}),
+        (link, PyArrowTable, PandasDataFrame),
+        (ResolvedJoinChild, {child}),
+    ]
+
+    resolver = ResolveComputeFrameworks(Graph())
+    resolver.links(queue, link_trekker)
+
+    assert child.compute_frameworks == {PyArrowTable}, "the rewrite has to collapse the child for this to say anything"
+    assert resolver.declared_frameworks[child.uuid] == {PyArrowTable, PandasDataFrame}
+    assert resolver.declared_frameworks[left.uuid] == {PyArrowTable}
+
+
+# Fresh interpreters are slow to start, so this one needs more than the suite-wide per-test budget.
+@pytest.mark.timeout(60)
+def test_fresh_interpreters_build_the_same_record_signature() -> None:
+    outputs = run_probes(_PROBE, _PROBE_PROCESSES)
+
+    assert len(outputs) == _PROBE_PROCESSES, f"expected {_PROBE_PROCESSES} probe results, got {len(outputs)}"
+    for position, output in enumerate(outputs):
+        assert output == _PROBE_EXPECTED, f"probe {position} signed {output}, expected {_PROBE_EXPECTED}"

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -56,7 +56,7 @@ END_RIGHT_KEY = "resolved_join_end_right_key"
 END_RIGHT_PAYLOAD = "resolved_join_end_right_payload"
 
 _PROBE = Path(__file__).with_name("resolved_join_probe.py")
-# Each side reduces from a framework set, so a second cold interpreter is the whole cross-process signal.
+# Each side reduces from a framework set, so a second cold interpreter is the cross-process signal.
 _PROBE_PROCESSES = 2
 _PROBE_EXPECTED = {
     "declined_count": "0",
@@ -353,7 +353,7 @@ def _two_links() -> Built:
 
 
 def _pair_with_declined_orientation() -> Built:
-    """Two children of one link, and only the PyArrow one pairs a left side up with a right side."""
+    """Two children of one link, and only the PyArrow one pairs a left side with a right side."""
     planned = _planned()
     link = _pair_link()
 
@@ -746,7 +746,7 @@ def test_the_record_and_the_legacy_transform_hop_name_opposite_directions() -> N
     transform_steps = _transform_steps(built.plan, built.link)
 
     assert len(transform_steps) == 1
-    # The record binds the hop to the sides the join actually moves; a later lowering step should adopt its answer.
+    # The record binds the hop to the sides the join moves; a later lowering step should adopt its answer.
     assert record.transform_from_feature_group is ResolvedJoinPairLeft
     assert record.transform_to_feature_group is ResolvedJoinPairRight
     assert transform_steps[0].from_feature_group is ResolvedJoinPairRight
@@ -804,7 +804,7 @@ def test_the_resolver_snapshots_the_frameworks_a_feature_declared_before_the_rew
     assert resolver.get_declared_frameworks()[left.uuid] == {PyArrowTable}
 
 
-# Fresh interpreters are slow to start, so this one needs more than the suite-wide per-test budget.
+# Fresh interpreters are slow to start, so this needs more than the suite-wide timeout.
 @pytest.mark.timeout(60)
 def test_fresh_interpreters_build_the_same_record_signature() -> None:
     outputs = run_probes(_PROBE, _PROBE_PROCESSES)

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -608,6 +608,33 @@ def test_a_declined_orientation_builds_no_record_and_one_declined_entry() -> Non
     assert resolved.declined == (DeclinedOrientation(built.link.uuid, PandasDataFrame, PyArrowTable),)
 
 
+def test_a_decline_reached_through_the_inversion_branch_records_the_orientation_it_attempted() -> None:
+    """The queue key finds no children, run_link flips it, and the declined entry must name the flipped key."""
+    planned = _planned()
+    link = Link.left(
+        JoinSpec(ResolvedJoinSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(ResolvedJoinSelfSource, Index((SELF_RIGHT_KEY,))),
+        left_discriminator={SELF_SIDE: "left"},
+        right_discriminator={SELF_SIDE: "right"},
+    )
+
+    left = feature("resolved_join_flip_decline_left", PyArrowTable, link.left_index, {SELF_SIDE: "left"})
+    right = feature("resolved_join_flip_decline_right", PandasDataFrame, link.right_index, {SELF_SIDE: "right"})
+    child = feature("resolved_join_flip_decline_child", PyArrowTable)
+
+    _add_parents(planned, link, left, right)
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    planned.queue.append((link, PandasDataFrame, PyArrowTable))
+    _add_child(planned, child, left, right)
+    trek(planned.link_trekker, link, (PyArrowTable, PandasDataFrame), child.uuid)
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+
+    resolved = planned.plan.resolved_join_plan
+    assert len(resolved.records) == 1, "the kept orientation must plan a record for the decline to say anything"
+    assert resolved.declined == (DeclinedOrientation(link.uuid, PyArrowTable, PandasDataFrame),)
+
+
 def test_each_record_names_the_join_step_it_shadows() -> None:
     built = _two_links()
     step_of_link = {step.link.uuid: step.uuid for step in _join_steps(built.plan)}
@@ -680,7 +707,10 @@ def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_step
 
     assert len(_join_steps(planned.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"
     assert planned.plan.resolved_join_plan.signatures() == planned.plan.join_signatures_at_build
-    assert _one_record(planned.plan, link).destination_side is JoinSide.RIGHT
+    record = _one_record(planned.plan, link)
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.destination.uuids <= record.destination_uuids
+    assert record.source.uuids <= record.source_uuids
 
 
 def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:
@@ -696,6 +726,23 @@ def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:
     assert len(rebuilt.records) == len(_join_steps(built.plan)), "an empty rebuild makes the inequality meaningless"
     assert rebuilt.signatures(), "an empty rebuild makes the inequality meaningless"
     assert rebuilt.signatures() != legacy_join_signatures([join_step])
+
+
+def test_the_parity_guard_raises_only_when_the_signatures_disagree() -> None:
+    from mloda.core.prepare.resolved_join_builder import raise_on_join_plan_divergence
+
+    built = _declared_pair()
+    join_step = _join_steps(built.plan)[0]
+
+    assert raise_on_join_plan_divergence(built.plan.resolved_join_plan, _join_steps(built.plan)) is None
+
+    join_step.swap_merge_sides = not join_step.swap_merge_sides
+    rebuilt = build_resolved_join_plan(
+        built.plan.planned_orientations, built.plan.declined_orientations, built.declared_frameworks
+    )
+
+    with pytest.raises(ValueError):
+        raise_on_join_plan_divergence(rebuilt, [join_step])
 
 
 def test_the_record_leaves_out_the_write_serialization_edges_add_tfs_adds() -> None:
@@ -714,11 +761,13 @@ def test_a_second_planning_pass_does_not_accumulate_records() -> None:
     _branch(planned, link, "resolved_join_twice")
     planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
     first = len(planned.plan.resolved_join_plan.records)
+    assert len(_transform_steps(planned.plan, link)) == 1, "the cross-framework join must plan one hop on pass one"
 
     planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
 
     assert len(planned.plan.resolved_join_plan.records) == first
     assert len(planned.plan.resolved_join_plan.records) == len(_join_steps(planned.plan))
+    assert len(_transform_steps(planned.plan, link)) == 1
 
 
 def test_an_order_edge_makes_the_consumer_records_depend_on_the_producer_record_tokens() -> None:


### PR DESCRIPTION
## What

One `ResolvedJoin` record per planned join orientation, built next to the legacy `JoinStep`s in shadow mode: nothing consumes the records yet. Each record carries the link, both declared sides, the decided destination side, the moved uuid sets, the frameworks, the consumer uuids and the join dependency tokens, and pickles to a worker.

## How the decision stays single

`run_link` derives the nearest declared sides once, in uuid space (`declared_sides.split_by_declared_side`), projects them onto frameworks for `swap_merge_sides_by_declared_side`, and threads the decided side and the split through `PlannedOrientation`. The builder materializes that decision instead of re-deriving it, so the record and the step cannot disagree, and `raise_on_join_plan_divergence` pins that invariant at plan build time.

A record's sides stay coherent with its step: self links pin the left side to the destination set, and a class split that does not align with the step's resolved sets adopts them, so `destination.uuids` never leaves `destination_uuids`.

## Also

- Replanning on one `ExecutionPlan` instance resets the step collections, so a second pass keeps its transform hop instead of deduping it against the first.
- A decline reached through the no-children inversion branch records the orientation it actually attempted.
- `ResolveComputeFrameworks` snapshots each feature's declared frameworks before the rewrite collapses them, behind a getter.
- The join-plan test fixtures are shared (`join_plan_helpers.py`), adopting the non-clobbering trekker helper.

Supersedes #1116, which derived the destination side a second time inside the builder; the two derivations disagreed when the nearest declared-left parent sat on a framework that is neither destination nor source. That shape is covered by a regression test here.
