### PR TITLE
Validate the join plan before it runs

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -122,8 +122,7 @@ class ExecutionPlan:
         self.join_signatures_at_build = legacy_join_signatures(join_steps)
         raise_on_join_plan_divergence(self.resolved_join_plan, join_steps)
         if declared_frameworks is not None:
-            # declared_frameworks is only ever supplied by the real resolution pipeline (Engine); a
-            # hand-built plan omits it and is exercised against this guard directly in its own tests.
+            # Only the Engine supplies declared_frameworks; hand-built plans call the guard directly in tests.
             raise_on_orphaned_join_source(self.resolved_join_plan)
 
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
@@ -687,15 +686,13 @@ class ExecutionPlan:
         queued_framework: type[ComputeFramework],
         resolved_framework: type[ComputeFramework],
     ) -> str:
-        """An APPEND/UNION link scheduled in an inverted orientation is a configuration problem, not a bug."""
         return (
             f"{link.jointype.value} link {link} cannot run in an inverted orientation.\n"
-            f"The {side} side was queued to run on {queued_framework.get_class_name()}, but the link's declared "
-            f"{side} index feature resolves to {resolved_framework.get_class_name()}: this link got scheduled "
-            "inverted/reversed.\n"
-            "Unlike INNER/LEFT/RIGHT links, APPEND and UNION links do not support an inverted orientation.\n"
-            "Resolution: do not schedule this link inverted; keep its declared left/right sides aligned with the "
-            "compute frameworks its features resolve to."
+            f"The {side} side was queued on {queued_framework.get_class_name()}, but the link's declared {side} "
+            f"index feature resolves to {resolved_framework.get_class_name()}, so this link got scheduled inverted.\n"
+            "Unlike INNER/LEFT/RIGHT links, APPEND and UNION links do not support inversion.\n"
+            "Resolution: keep the link's declared left/right sides aligned with the compute frameworks its "
+            "features resolve to."
         )
 
     def create_joinstep_in_case_of_append_or_union(

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -101,6 +101,7 @@ class ExecutionPlan:
         graph: Graph,
         link_trekker: LinkTrekker,
         declared_frameworks: DeclaredFrameworks | None = None,
+        validate: bool = True,
     ) -> None:
         self.planned_orientations = []
         self.declined_orientations = []
@@ -121,8 +122,7 @@ class ExecutionPlan:
         )
         self.join_signatures_at_build = legacy_join_signatures(join_steps)
         raise_on_join_plan_divergence(self.resolved_join_plan, join_steps)
-        if declared_frameworks is not None:
-            # Only the Engine supplies declared_frameworks; hand-built plans call the guard directly in tests.
+        if validate:
             raise_on_orphaned_join_source(self.resolved_join_plan)
 
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
@@ -687,10 +687,11 @@ class ExecutionPlan:
         resolved_framework: type[ComputeFramework],
     ) -> str:
         return (
-            f"{link.jointype.value} link {link} cannot run in an inverted orientation.\n"
-            f"The {side} side was queued on {queued_framework.get_class_name()}, but the link's declared {side} "
-            f"index feature resolves to {resolved_framework.get_class_name()}, so this link got scheduled inverted.\n"
-            "Unlike INNER/LEFT/RIGHT links, APPEND and UNION links do not support inversion.\n"
+            f"{link.jointype.value} link {link} cannot run: the {side} side was queued on "
+            f"{queued_framework.get_class_name()}, but the link's declared {side} index feature resolves to "
+            f"{resolved_framework.get_class_name()}.\n"
+            "One possible cause is that the link got scheduled in an inverted orientation; unlike INNER/LEFT/RIGHT "
+            "links, APPEND and UNION links do not support inversion.\n"
             "Resolution: keep the link's declared left/right sides aligned with the compute frameworks its "
             "features resolve to."
         )

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -27,6 +27,7 @@ from mloda.core.prepare.resolved_join_builder import (
     legacy_join_signatures,
     raise_on_join_plan_divergence,
 )
+from mloda.core.prepare.validate_resolved_join import raise_on_orphaned_join_source
 from mloda.core.core.step.abstract_step import Step
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
@@ -120,6 +121,10 @@ class ExecutionPlan:
         )
         self.join_signatures_at_build = legacy_join_signatures(join_steps)
         raise_on_join_plan_divergence(self.resolved_join_plan, join_steps)
+        if declared_frameworks is not None:
+            # declared_frameworks is only ever supplied by the real resolution pipeline (Engine); a
+            # hand-built plan omits it and is exercised against this guard directly in its own tests.
+            raise_on_orphaned_join_source(self.resolved_join_plan)
 
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
         self.raise_on_step_cycle(self.execution_plan)
@@ -675,6 +680,24 @@ class ExecutionPlan:
                     return element.feature_group
         raise ValueError(f"Feature group for UUID {uuid} not found.")
 
+    @staticmethod
+    def _append_or_union_orientation_error(
+        link: Link,
+        side: str,
+        queued_framework: type[ComputeFramework],
+        resolved_framework: type[ComputeFramework],
+    ) -> str:
+        """An APPEND/UNION link scheduled in an inverted orientation is a configuration problem, not a bug."""
+        return (
+            f"{link.jointype.value} link {link} cannot run in an inverted orientation.\n"
+            f"The {side} side was queued to run on {queued_framework.get_class_name()}, but the link's declared "
+            f"{side} index feature resolves to {resolved_framework.get_class_name()}: this link got scheduled "
+            "inverted/reversed.\n"
+            "Unlike INNER/LEFT/RIGHT links, APPEND and UNION links do not support an inverted orientation.\n"
+            "Resolution: do not schedule this link inverted; keep its declared left/right sides aligned with the "
+            "compute frameworks its features resolve to."
+        )
+
     def create_joinstep_in_case_of_append_or_union(
         self,
         link: Link,
@@ -733,22 +756,10 @@ class ExecutionPlan:
             )
 
         if link_fw[1] != destination_framework:
-            raise ValueError(
-                internal_invariant_error(
-                    "APPEND/UNION left link framework must match the framework of the left index feature.",
-                    f"link={link}, left_link_framework={link_fw[1].get_class_name()}, "
-                    f"left_feature_framework={destination_framework.get_class_name()}",
-                )
-            )
+            raise ValueError(self._append_or_union_orientation_error(link, "left", link_fw[1], destination_framework))
 
         if link_fw[2] != source_framework:
-            raise ValueError(
-                internal_invariant_error(
-                    "APPEND/UNION right link framework must match the framework of the right index feature.",
-                    f"link={link}, right_link_framework={link_fw[2].get_class_name()}, "
-                    f"right_feature_framework={source_framework.get_class_name()}",
-                )
-            )
+            raise ValueError(self._append_or_union_orientation_error(link, "right", link_fw[2], source_framework))
 
         return JoinStep(
             link=link,

--- a/mloda/core/prepare/validate_resolved_join.py
+++ b/mloda/core/prepare/validate_resolved_join.py
@@ -1,0 +1,71 @@
+"""Guards a resolved join plan against the confirmed silent-data-loss shape: two joins that both
+read one parent's data as their source, with neither writing its result back into that parent's
+slot, and both feeding a consumer that needs them together.
+"""
+
+from collections import defaultdict
+from itertools import combinations
+from uuid import UUID
+
+from mloda.core.prepare.resolved_join import ResolvedJoin, ResolvedJoinPlan
+
+
+def _side_feature_group_name(record: ResolvedJoin, uuid: UUID) -> str | None:
+    if uuid in record.left.uuids:
+        return record.left.feature_group.get_class_name()
+    if uuid in record.right.uuids:
+        return record.right.feature_group.get_class_name()
+    return None
+
+
+def _shared_feature_group_name(records: tuple[ResolvedJoin, ...], uuid: UUID) -> str:
+    """The class of the contested parent, read off whichever record declares it on a side."""
+    for record in records:
+        name = _side_feature_group_name(record, uuid)
+        if name is not None:
+            return name
+    return str(uuid)
+
+
+def _competing_join_label(record: ResolvedJoin, shared_uuid: UUID) -> str:
+    """The record's declared side opposite the shared parent, or its link uuid if neither side matches."""
+    if shared_uuid in record.left.uuids:
+        return record.right.feature_group.get_class_name()
+    if shared_uuid in record.right.uuids:
+        return record.left.feature_group.get_class_name()
+    return str(record.link_uuid)
+
+
+def _orphaned_join_source_error(
+    shared_uuid: UUID, records: tuple[ResolvedJoin, ...], first: ResolvedJoin, second: ResolvedJoin
+) -> str:
+    shared_name = _shared_feature_group_name(records, shared_uuid)
+    first_label = _competing_join_label(first, shared_uuid)
+    second_label = _competing_join_label(second, shared_uuid)
+    return (
+        f"{shared_name}'s data is read as the join source by two joins ({first_label} and {second_label}), and "
+        f"neither writes its result back into {shared_name}'s slot: the two branches can never reunite, so a "
+        "consumer needing both loses whichever the runtime does not happen to expose to it.\n"
+        f"Resolution: chain the joins so one of them writes its result back into {shared_name}'s slot, instead "
+        "of both draining it independently."
+    )
+
+
+def raise_on_orphaned_join_source(plan: ResolvedJoinPlan) -> None:
+    """Raise when two joins share a source parent that no join writes back into and share a consumer:
+    the branches can never reunite, so whichever the runtime does not expose is silently dropped."""
+    all_destination_uuids: set[UUID] = set()
+    for record in plan.records:
+        all_destination_uuids |= record.destination_uuids
+
+    readers_of: dict[UUID, list[ResolvedJoin]] = defaultdict(list)
+    for record in plan.records:
+        for uuid in record.source_uuids:
+            readers_of[uuid].append(record)
+
+    for uuid, readers in readers_of.items():
+        if len(readers) < 2 or uuid in all_destination_uuids:
+            continue
+        for first, second in combinations(readers, 2):
+            if first.consumers & second.consumers:
+                raise ValueError(_orphaned_join_source_error(uuid, plan.records, first, second))

--- a/mloda/core/prepare/validate_resolved_join.py
+++ b/mloda/core/prepare/validate_resolved_join.py
@@ -1,7 +1,4 @@
-"""Guards a resolved join plan against the confirmed silent-data-loss shape: two joins that both
-read one parent's data as their source, with neither writing its result back into that parent's
-slot, and both feeding a consumer that needs them together.
-"""
+"""Guards a resolved join plan against two joins draining a shared parent that no join writes back into."""
 
 from collections import defaultdict
 from itertools import combinations
@@ -19,7 +16,7 @@ def _side_feature_group_name(record: ResolvedJoin, uuid: UUID) -> str | None:
 
 
 def _shared_feature_group_name(records: tuple[ResolvedJoin, ...], uuid: UUID) -> str:
-    """The class of the contested parent, read off whichever record declares it on a side."""
+    """The contested parent's class, read off whichever record declares it on a side."""
     for record in records:
         name = _side_feature_group_name(record, uuid)
         if name is not None:
@@ -28,7 +25,7 @@ def _shared_feature_group_name(records: tuple[ResolvedJoin, ...], uuid: UUID) ->
 
 
 def _competing_join_label(record: ResolvedJoin, shared_uuid: UUID) -> str:
-    """The record's declared side opposite the shared parent, or its link uuid if neither side matches."""
+    """The declared side opposite the shared parent, falling back to the link uuid."""
     if shared_uuid in record.left.uuids:
         return record.right.feature_group.get_class_name()
     if shared_uuid in record.right.uuids:
@@ -43,17 +40,15 @@ def _orphaned_join_source_error(
     first_label = _competing_join_label(first, shared_uuid)
     second_label = _competing_join_label(second, shared_uuid)
     return (
-        f"{shared_name}'s data is read as the join source by two joins ({first_label} and {second_label}), and "
-        f"neither writes its result back into {shared_name}'s slot: the two branches can never reunite, so a "
-        "consumer needing both loses whichever the runtime does not happen to expose to it.\n"
-        f"Resolution: chain the joins so one of them writes its result back into {shared_name}'s slot, instead "
-        "of both draining it independently."
+        f"{shared_name} is read as the join source by two joins ({first_label} and {second_label}), and neither "
+        f"writes its result back into {shared_name}: the two branches can never reunite, so a consumer needing "
+        "both loses one of them.\n"
+        f"Resolution: chain the joins so that one of them writes its result back into {shared_name}."
     )
 
 
 def raise_on_orphaned_join_source(plan: ResolvedJoinPlan) -> None:
-    """Raise when two joins share a source parent that no join writes back into and share a consumer:
-    the branches can never reunite, so whichever the runtime does not expose is silently dropped."""
+    """Raise when two joins share both a consumer and a source parent that no join writes back into."""
     all_destination_uuids: set[UUID] = set()
     for record in plan.records:
         all_destination_uuids |= record.destination_uuids

--- a/mloda/core/prepare/validate_resolved_join.py
+++ b/mloda/core/prepare/validate_resolved_join.py
@@ -1,4 +1,5 @@
-"""Guards a resolved join plan against two joins draining a shared parent that no join writes back into."""
+"""Guards a resolved join plan against two joins draining a shared parent that no join writes
+back into for the consumer(s) the two joins actually share."""
 
 from collections import defaultdict
 from itertools import combinations
@@ -7,38 +8,23 @@ from uuid import UUID
 from mloda.core.prepare.resolved_join import ResolvedJoin, ResolvedJoinPlan
 
 
-def _side_feature_group_name(record: ResolvedJoin, uuid: UUID) -> str | None:
-    if uuid in record.left.uuids:
-        return record.left.feature_group.get_class_name()
-    if uuid in record.right.uuids:
-        return record.right.feature_group.get_class_name()
-    return None
+def _stays_in_source_framework(record: ResolvedJoin) -> bool:
+    """Same-framework joins reunite through add_tfs's children_if_root bookkeeping, not uuid-slot rewriting."""
+    return record.destination_framework is record.source_framework
 
 
-def _shared_feature_group_name(records: tuple[ResolvedJoin, ...], uuid: UUID) -> str:
-    """The contested parent's class, read off whichever record declares it on a side."""
-    for record in records:
-        name = _side_feature_group_name(record, uuid)
-        if name is not None:
-            return name
-    return str(uuid)
+def _shared_consumer_writes_back(
+    records: tuple[ResolvedJoin, ...], uuid: UUID, shared_consumers: frozenset[UUID]
+) -> bool:
+    """True iff some record writes uuid back for a consumer the competing pair actually shares."""
+    return any(uuid in record.destination_uuids and record.consumers & shared_consumers for record in records)
 
 
-def _competing_join_label(record: ResolvedJoin, shared_uuid: UUID) -> str:
-    """The declared side opposite the shared parent, falling back to the link uuid."""
-    if shared_uuid in record.left.uuids:
-        return record.right.feature_group.get_class_name()
-    if shared_uuid in record.right.uuids:
-        return record.left.feature_group.get_class_name()
-    return str(record.link_uuid)
-
-
-def _orphaned_join_source_error(
-    shared_uuid: UUID, records: tuple[ResolvedJoin, ...], first: ResolvedJoin, second: ResolvedJoin
-) -> str:
-    shared_name = _shared_feature_group_name(records, shared_uuid)
-    first_label = _competing_join_label(first, shared_uuid)
-    second_label = _competing_join_label(second, shared_uuid)
+def _orphaned_join_source_error(first: ResolvedJoin, second: ResolvedJoin) -> str:
+    """Both records read the shared uuid as their source, so `.source`/`.destination` name it directly."""
+    shared_name = first.source.feature_group.get_class_name()
+    first_label = first.destination.feature_group.get_class_name()
+    second_label = second.destination.feature_group.get_class_name()
     return (
         f"{shared_name} is read as the join source by two joins ({first_label} and {second_label}), and neither "
         f"writes its result back into {shared_name}: the two branches can never reunite, so a consumer needing "
@@ -48,19 +34,21 @@ def _orphaned_join_source_error(
 
 
 def raise_on_orphaned_join_source(plan: ResolvedJoinPlan) -> None:
-    """Raise when two joins share both a consumer and a source parent that no join writes back into."""
-    all_destination_uuids: set[UUID] = set()
-    for record in plan.records:
-        all_destination_uuids |= record.destination_uuids
-
+    """Raise when two joins share both a consumer and a source parent that no join writes back into for it."""
     readers_of: dict[UUID, list[ResolvedJoin]] = defaultdict(list)
     for record in plan.records:
         for uuid in record.source_uuids:
             readers_of[uuid].append(record)
 
     for uuid, readers in readers_of.items():
-        if len(readers) < 2 or uuid in all_destination_uuids:
+        if len(readers) < 2:
             continue
         for first, second in combinations(readers, 2):
-            if first.consumers & second.consumers:
-                raise ValueError(_orphaned_join_source_error(uuid, plan.records, first, second))
+            shared_consumers = first.consumers & second.consumers
+            if not shared_consumers:
+                continue
+            if _stays_in_source_framework(first) and _stays_in_source_framework(second):
+                continue
+            if _shared_consumer_writes_back(plan.records, uuid, shared_consumers):
+                continue
+            raise ValueError(_orphaned_join_source_error(first, second))

--- a/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
+++ b/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
@@ -1,5 +1,4 @@
-"""An APPEND/UNION link scheduled in an inverted orientation is a user configuration error:
-neither jointype supports running inverted, unlike INNER/LEFT/RIGHT links.
+"""An APPEND/UNION link scheduled in an inverted orientation is a configuration error, not an internal bug.
 
 Frameworks that agree still plan a JoinStep.
 """
@@ -30,8 +29,7 @@ RIGHT_INDEX = Index(("stack_right_key",))
 
 STACK_LINK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link.union]
 
-# Substance a message must show to count as the new, plainly-worded configuration error:
-# it must name the concept (orientation/inversion) and say plainly that it is not supported.
+# The message must name the orientation concept and say that it is not supported.
 ORIENTATION_WORDS = ("invert", "revers", "swap", "orientation")
 UNSUPPORTED_WORDS = ("not support", "unsupported", "cannot", "can't", "not allowed")
 
@@ -116,7 +114,7 @@ def _run(planned: Planned) -> JoinStep | None:
 
 
 def _assert_is_orientation_configuration_error(message: str, link: Link) -> None:
-    """The new error reads as a plain config problem, not an internal bug report."""
+    """The error reads as a configuration problem, not an internal bug report."""
     assert not message.startswith("Internal error:")
     assert "report this issue" not in message.lower()
     assert "sanity check" not in message

--- a/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
+++ b/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
@@ -130,10 +130,12 @@ def _assert_is_orientation_configuration_error(message: str, link: Link) -> None
 def test_left_framework_mismatch_is_rejected_as_a_configuration_error(
     link_factory: Callable[[JoinSpec, JoinSpec], Link],
 ) -> None:
-    with pytest.raises(ValueError) as excinfo:
-        _run(_plan_link(link_factory))
+    planned = _plan_link(link_factory)
 
-    assert not str(excinfo.value).startswith("Internal error:")
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned)
+
+    _assert_is_orientation_configuration_error(str(excinfo.value), planned.link_fw[0])
 
 
 @pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)

--- a/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
+++ b/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
@@ -1,4 +1,5 @@
-"""An APPEND/UNION link framework that disagrees with its index feature violates a planning invariant.
+"""An APPEND/UNION link scheduled in an inverted orientation is a user configuration error:
+neither jointype supports running inverted, unlike INNER/LEFT/RIGHT links.
 
 Frameworks that agree still plan a JoinStep.
 """
@@ -29,8 +30,10 @@ RIGHT_INDEX = Index(("stack_right_key",))
 
 STACK_LINK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link.union]
 
-LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
-RIGHT_FRAMEWORK_INVARIANT = "APPEND/UNION right link framework must match"
+# Substance a message must show to count as the new, plainly-worded configuration error:
+# it must name the concept (orientation/inversion) and say plainly that it is not supported.
+ORIENTATION_WORDS = ("invert", "revers", "swap", "orientation")
+UNSUPPORTED_WORDS = ("not support", "unsupported", "cannot", "can't", "not allowed")
 
 
 class StackSource(FeatureGroup):
@@ -112,15 +115,27 @@ def _run(planned: Planned) -> JoinStep | None:
     return planned.plan.run_link(planned.link_fw, planned.link_trekker, planned.graph, planned.pre_execution_plan)
 
 
+def _assert_is_orientation_configuration_error(message: str, link: Link) -> None:
+    """The new error reads as a plain config problem, not an internal bug report."""
+    assert not message.startswith("Internal error:")
+    assert "report this issue" not in message.lower()
+    assert "sanity check" not in message
+    assert str(link) in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
+    assert link.jointype.value in message.lower()
+    assert any(word in message.lower() for word in ORIENTATION_WORDS)
+    assert any(word in message.lower() for word in UNSUPPORTED_WORDS)
+
+
 @pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
-def test_left_framework_mismatch_is_rejected_by_the_joinstep_builder(
+def test_left_framework_mismatch_is_rejected_as_a_configuration_error(
     link_factory: Callable[[JoinSpec, JoinSpec], Link],
 ) -> None:
     with pytest.raises(ValueError) as excinfo:
         _run(_plan_link(link_factory))
 
-    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
-    assert LEFT_FRAMEWORK_INVARIANT in str(excinfo.value)
+    assert not str(excinfo.value).startswith("Internal error:")
 
 
 @pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
@@ -132,12 +147,7 @@ def test_left_framework_mismatch_names_the_link_and_both_frameworks(
     with pytest.raises(ValueError) as excinfo:
         _run(planned)
 
-    message = str(excinfo.value)
-    assert message.startswith("Internal error:")
-    assert "sanity check" not in message
-    assert str(planned.link_fw[0]) in message
-    assert PyArrowTable.get_class_name() in message
-    assert PandasDataFrame.get_class_name() in message
+    _assert_is_orientation_configuration_error(str(excinfo.value), planned.link_fw[0])
 
 
 @pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
@@ -153,15 +163,7 @@ def test_right_framework_mismatch_names_the_link_and_both_frameworks(
     with pytest.raises(ValueError) as excinfo:
         _run(planned)
 
-    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
-
-    message = str(excinfo.value)
-    assert RIGHT_FRAMEWORK_INVARIANT in message
-    assert message.startswith("Internal error:")
-    assert "sanity check" not in message
-    assert str(planned.link_fw[0]) in message
-    assert PyArrowTable.get_class_name() in message
-    assert PandasDataFrame.get_class_name() in message
+    _assert_is_orientation_configuration_error(str(excinfo.value), planned.link_fw[0])
 
 
 @pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -50,7 +50,6 @@ PAIR_LEFT_INDEX = Index(("link_plan_pair_left_key",))
 PAIR_RIGHT_INDEX = Index(("link_plan_pair_right_key",))
 
 STACK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link.union]
-LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
 
 STACK_INVERSION_REASON = (
     "the inverted orientation is dropped before the JoinStep is built; a fix has to move the left-framework "
@@ -525,10 +524,15 @@ def test_an_inverted_self_group_stack_link_is_rejected_naming_link_and_framework
         _run(planned, PandasDataFrame, PyArrowTable)
 
     message = str(excinfo.value)
-    assert LEFT_FRAMEWORK_INVARIANT in message
+    assert not message.startswith("Internal error:")
+    assert "report this issue" not in message.lower()
+    assert "sanity check" not in message
     assert str(planned.link) in message
     assert PyArrowTable.get_class_name() in message
     assert PandasDataFrame.get_class_name() in message
+    assert planned.link.jointype.value in message.lower()
+    assert any(word in message.lower() for word in ("invert", "revers", "swap", "orientation"))
+    assert any(word in message.lower() for word in ("not support", "unsupported", "cannot", "can't", "not allowed"))
 
 
 def test_the_declared_orientation_plans_the_declared_joinstep() -> None:

--- a/tests/test_core/test_prepare/test_multi_link_group_resolution.py
+++ b/tests/test_core/test_prepare/test_multi_link_group_resolution.py
@@ -174,7 +174,7 @@ def test_link_joining_across_distinct_frameworks_delivers_every_parent_column() 
 
 def test_link_joining_across_distinct_frameworks_with_the_shared_parent_swapped_must_raise() -> None:
     """Same shape as the test above with the A-B link's sides swapped: no join writes back into
-    the shared parent A, so the branches never reunite (today this silently drops mlg_bd)."""
+    the shared parent A, so the branches never reunite."""
     links = {
         Link.inner(JoinSpec(MultiLinkRootBDistinct, MLG_INDEX), JoinSpec(MultiLinkRootA, MLG_INDEX)),
         Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootC, MLG_INDEX)),

--- a/tests/test_core/test_prepare/test_multi_link_group_resolution.py
+++ b/tests/test_core/test_prepare/test_multi_link_group_resolution.py
@@ -124,11 +124,73 @@ class MultiLinkChildDistinct(FeatureGroup):
         return {PandasDataFrame}
 
 
+class SameFrameworkSharedParent(FeatureGroup):
+    """Read as the join source by both spokes below; every feature group here stays on one framework."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"sfw_p"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"sfw_p": [1, 2, 3], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SameFrameworkSpokeD1(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"sfw_d1"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"sfw_d1": [10, 20, 30], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SameFrameworkSpokeD2(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"sfw_d2"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"sfw_d2": [100, 200, 300], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SameFrameworkConsumer(FeatureGroup):
+    """Needs the shared parent through both spokes; all four feature groups share one framework."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature("sfw_p"), Feature("sfw_d1"), Feature("sfw_d2")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [_joined_columns(data, {"sfw_p", "sfw_d1", "sfw_d2"})] * len(data)}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
 _ENABLED_SAME = PluginCollector.enabled_feature_groups(
     {MultiLinkRootA, MultiLinkRootBSame, MultiLinkRootC, MultiLinkChildSame}
 )
 _ENABLED_DISTINCT = PluginCollector.enabled_feature_groups(
     {MultiLinkRootA, MultiLinkRootBDistinct, MultiLinkRootC, MultiLinkChildDistinct}
+)
+_ENABLED_SAME_FRAMEWORK = PluginCollector.enabled_feature_groups(
+    {SameFrameworkSharedParent, SameFrameworkSpokeD1, SameFrameworkSpokeD2, SameFrameworkConsumer}
 )
 
 
@@ -180,7 +242,7 @@ def test_link_joining_across_distinct_frameworks_with_the_shared_parent_swapped_
         Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootC, MLG_INDEX)),
     }
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="is read as the join source"):
         mloda.run_all(
             [Feature(MultiLinkChildDistinct.get_class_name())],
             links=links,
@@ -188,3 +250,24 @@ def test_link_joining_across_distinct_frameworks_with_the_shared_parent_swapped_
             parallelization_modes={ParallelizationMode.SYNC},
             plugin_collector=_ENABLED_DISTINCT,
         )
+
+
+def test_link_joining_a_shared_parent_twice_within_one_framework_must_not_raise() -> None:
+    """The shared parent and both spokes all stay on PandasDataFrame: add_tfs reunites the two
+    joins through add_value_to_children_if_root bookkeeping, not uuid-slot rewriting, so the
+    orphaned-join-source guard must not treat the shared parent as lost."""
+    links = {
+        Link.inner(JoinSpec(SameFrameworkSpokeD1, MLG_INDEX), JoinSpec(SameFrameworkSharedParent, MLG_INDEX)),
+        Link.inner(JoinSpec(SameFrameworkSpokeD2, MLG_INDEX), JoinSpec(SameFrameworkSharedParent, MLG_INDEX)),
+    }
+
+    results = mloda.run_all(
+        [Feature(SameFrameworkConsumer.get_class_name())],
+        links=links,
+        compute_frameworks={PandasDataFrame},
+        parallelization_modes={ParallelizationMode.SYNC},
+        plugin_collector=_ENABLED_SAME_FRAMEWORK,
+    )
+
+    seen = {value for result in results for value in result[SameFrameworkConsumer.get_class_name()]}
+    assert seen == {"sfw_d1|sfw_d2|sfw_p"}

--- a/tests/test_core/test_prepare/test_multi_link_group_resolution.py
+++ b/tests/test_core/test_prepare/test_multi_link_group_resolution.py
@@ -170,3 +170,21 @@ def test_link_joining_across_distinct_frameworks_delivers_every_parent_column() 
 
     seen = {value for result in results for value in result[MultiLinkChildDistinct.get_class_name()]}
     assert seen == {"mlg_a|mlg_bd|mlg_c"}
+
+
+def test_link_joining_across_distinct_frameworks_with_the_shared_parent_swapped_must_raise() -> None:
+    """Same shape as the test above with the A-B link's sides swapped: no join writes back into
+    the shared parent A, so the branches never reunite (today this silently drops mlg_bd)."""
+    links = {
+        Link.inner(JoinSpec(MultiLinkRootBDistinct, MLG_INDEX), JoinSpec(MultiLinkRootA, MLG_INDEX)),
+        Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootC, MLG_INDEX)),
+    }
+
+    with pytest.raises(ValueError):
+        mloda.run_all(
+            [Feature(MultiLinkChildDistinct.get_class_name())],
+            links=links,
+            compute_frameworks={PyArrowTable, PandasDataFrame, SecondCfw},
+            parallelization_modes={ParallelizationMode.SYNC},
+            plugin_collector=_ENABLED_DISTINCT,
+        )

--- a/tests/test_core/test_prepare/test_resolve_cfw_right_inversion_unsupported.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_right_inversion_unsupported.py
@@ -40,7 +40,7 @@ def _make_right_trekker(trekked_uuids: set[UUID]) -> tuple[LinkTrekker, Any]:
 
 
 def test_right_join_inversion_onto_undeclared_framework_raises() -> None:
-    """Member declares only left_cfw; the RIGHT-branch inversion still resolves it to right_cfw."""
+    """The feature declares only PandasDataFrame, but the RIGHT-branch inversion resolves it to PyArrowTable."""
     feature = Feature("right_inversion_feature")
     feature.compute_frameworks = {PandasDataFrame}
 

--- a/tests/test_core/test_prepare/test_resolve_cfw_right_inversion_unsupported.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_right_inversion_unsupported.py
@@ -1,0 +1,56 @@
+"""RIGHT-jointype inversion must not resolve a feature onto a framework it never declared."""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class RightInversionLeftFG(FeatureGroup):
+    pass
+
+
+class RightInversionRightFG(FeatureGroup):
+    pass
+
+
+class RightInversionChildFG(FeatureGroup):
+    pass
+
+
+def _make_right_trekker(trekked_uuids: set[UUID]) -> tuple[LinkTrekker, Any]:
+    link = Link.right(JoinSpec(RightInversionLeftFG, "idx"), JoinSpec(RightInversionRightFG, "idx"))
+    trekker = (link, PandasDataFrame, PyArrowTable)
+
+    link_trekker = LinkTrekker()
+    # Production shares one set object between data and data_ordered, and invert_link relies on that.
+    shared_uuids = set(trekked_uuids)
+    link_trekker.data[trekker] = shared_uuids
+    link_trekker.data_ordered[trekker] = shared_uuids
+    return link_trekker, trekker
+
+
+def test_right_join_inversion_onto_undeclared_framework_raises() -> None:
+    """Member declares only left_cfw; the RIGHT-branch inversion still resolves it to right_cfw."""
+    feature = Feature("right_inversion_feature")
+    feature.compute_frameworks = {PandasDataFrame}
+
+    link_trekker, _ = _make_right_trekker({feature.uuid})
+    planned_queue: list[Any] = [(RightInversionChildFG, {feature})]
+
+    with pytest.raises(ValueError, match="declares the compute framework") as excinfo:
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    message = str(excinfo.value)
+    assert str(feature.name) in message, message
+    assert PandasDataFrame.get_class_name() in message, message
+    assert PyArrowTable.get_class_name() in message, message

--- a/tests/test_core/test_prepare/test_resolved_join_plan_validation.py
+++ b/tests/test_core/test_prepare/test_resolved_join_plan_validation.py
@@ -1,6 +1,5 @@
-"""A parent's data read as the source of two joins that share a consumer, with no join in the
-plan writing back into that parent, is the confirmed silent-data-loss shape: two branches that
-can never reunite. `raise_on_orphaned_join_source` does not exist yet; this module fails to import."""
+"""A parent read as the source of two joins that share a consumer, with no join writing back into
+that parent, leaves two branches that can never reunite."""
 
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -56,8 +55,7 @@ class Built(NamedTuple):
 
 
 def _build_orphaned_source_plan() -> Built:
-    """Both joins read the shared parent as their source and write to distinct destinations:
-    the confirmed silent-data-loss shape, reproduced by hand instead of through the full engine."""
+    """Both joins read the shared parent as their source and write to distinct destinations."""
     source = feature("orphan_source", SOURCE_CFW, SHARED_INDEX)
     first_destination = feature("orphan_first_destination", FIRST_DESTINATION_CFW, SHARED_INDEX)
     second_destination = feature("orphan_second_destination", SECOND_DESTINATION_CFW, SHARED_INDEX)
@@ -82,8 +80,8 @@ def _build_orphaned_source_plan() -> Built:
     link_trekker = LinkTrekker()
     # Natural key (declared left, declared right): first_link needs no inversion.
     trek(link_trekker, first_link, (FIRST_DESTINATION_CFW, SOURCE_CFW), consumer.uuid)
-    # Flipped key: second_link's queue entry below is the declared (source, second_destination)
-    # order, so run_link finds nothing there and inverts onto (second_destination, source).
+    # Flipped key: second_link's queue entry below uses the declared order, so run_link finds
+    # nothing there and inverts onto (second_destination, source).
     trek(link_trekker, second_link, (SECOND_DESTINATION_CFW, SOURCE_CFW), consumer.uuid)
 
     queue: list[Any] = [
@@ -141,5 +139,5 @@ def test_raise_on_orphaned_join_source_raises_naming_the_dropped_feature_group()
 
 
 def test_raise_on_orphaned_join_source_accepts_a_plan_with_no_records() -> None:
-    """An empty plan has no source to lose, so the guard must not require records to exist."""
+    """An empty plan has no source to lose."""
     raise_on_orphaned_join_source(ExecutionPlan().resolved_join_plan)

--- a/tests/test_core/test_prepare/test_resolved_join_plan_validation.py
+++ b/tests/test_core/test_prepare/test_resolved_join_plan_validation.py
@@ -19,13 +19,17 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
     PythonDictFramework,
 )
 from tests.test_core.test_prepare.join_plan_helpers import feature, trek
+from tests.test_plugins.compute_framework.test_tooling.shared_compute_frameworks import SecondCfw, ThirdCfw
 
 
 SHARED_INDEX = Index(("orphan_source_idx",))
+UNRELATED_INDEX = Index(("unrelated_writeback_idx",))
 
 SOURCE_CFW = PyArrowTable
 FIRST_DESTINATION_CFW = PythonDictFramework
 SECOND_DESTINATION_CFW = PandasDataFrame
+UNRELATED_SOURCE_CFW = SecondCfw
+UNRELATED_CONSUMER_CFW = ThirdCfw
 
 
 class OrphanSourceParent(FeatureGroup):
@@ -42,6 +46,14 @@ class OrphanSecondDestination(FeatureGroup):
 
 class OrphanConsumer(FeatureGroup):
     """Needs all three parents, through both joins."""
+
+
+class UnrelatedWritebackSource(FeatureGroup):
+    """Joined with the shared parent for a consumer that has nothing to do with OrphanConsumer."""
+
+
+class UnrelatedWritebackConsumer(FeatureGroup):
+    """Needs only the shared parent and the unrelated source, never OrphanConsumer's destinations."""
 
 
 class Built(NamedTuple):
@@ -94,10 +106,75 @@ def _build_orphaned_source_plan() -> Built:
     ]
 
     plan = ExecutionPlan()
-    plan.create_execution_plan(queue, graph, link_trekker)
+    plan.create_execution_plan(queue, graph, link_trekker, validate=False)
     return Built(
         plan, source.uuid, first_destination.uuid, second_destination.uuid, consumer.uuid, first_link, second_link
     )
+
+
+class BuiltWithUnrelatedWriteback(NamedTuple):
+    plan: ExecutionPlan
+    source_uuid: UUID
+    consumer_uuid: UUID
+    unrelated_consumer_uuid: UUID
+
+
+def _build_orphaned_source_plan_with_unrelated_writeback() -> BuiltWithUnrelatedWriteback:
+    """Same orphaned pair as _build_orphaned_source_plan, plus a third join for an unrelated
+    consumer that writes its result back into the shared parent's uuid."""
+    source = feature("orphan_source", SOURCE_CFW, SHARED_INDEX)
+    first_destination = feature("orphan_first_destination", FIRST_DESTINATION_CFW, SHARED_INDEX)
+    second_destination = feature("orphan_second_destination", SECOND_DESTINATION_CFW, SHARED_INDEX)
+    consumer = feature("orphan_consumer", SECOND_DESTINATION_CFW)
+    unrelated_source = feature("unrelated_writeback_source", UNRELATED_SOURCE_CFW, UNRELATED_INDEX)
+    unrelated_consumer = feature("unrelated_writeback_consumer", UNRELATED_CONSUMER_CFW)
+
+    first_link = Link.inner(JoinSpec(OrphanFirstDestination, SHARED_INDEX), JoinSpec(OrphanSourceParent, SHARED_INDEX))
+    second_link = Link.inner(
+        JoinSpec(OrphanSourceParent, SHARED_INDEX), JoinSpec(OrphanSecondDestination, SHARED_INDEX)
+    )
+    # Natural order (shared parent declared left): the shared parent is this join's destination.
+    unrelated_link = Link.inner(
+        JoinSpec(OrphanSourceParent, SHARED_INDEX), JoinSpec(UnrelatedWritebackSource, UNRELATED_INDEX)
+    )
+
+    graph = Graph()
+    graph.add_node(source.uuid, NodeProperties(source, OrphanSourceParent))
+    graph.add_node(first_destination.uuid, NodeProperties(first_destination, OrphanFirstDestination))
+    graph.add_node(second_destination.uuid, NodeProperties(second_destination, OrphanSecondDestination))
+    graph.add_node(consumer.uuid, NodeProperties(consumer, OrphanConsumer))
+    graph.add_node(unrelated_source.uuid, NodeProperties(unrelated_source, UnrelatedWritebackSource))
+    graph.add_node(unrelated_consumer.uuid, NodeProperties(unrelated_consumer, UnrelatedWritebackConsumer))
+    graph.adjacency_list[source.uuid].append(consumer.uuid)
+    graph.adjacency_list[source.uuid].append(unrelated_consumer.uuid)
+    graph.adjacency_list[first_destination.uuid].append(consumer.uuid)
+    graph.adjacency_list[second_destination.uuid].append(consumer.uuid)
+    graph.adjacency_list[unrelated_source.uuid].append(unrelated_consumer.uuid)
+    graph.adjacency_list[consumer.uuid] = []
+    graph.adjacency_list[unrelated_consumer.uuid] = []
+    graph.parent_to_children_mapping[consumer.uuid] = {source.uuid, first_destination.uuid, second_destination.uuid}
+    graph.parent_to_children_mapping[unrelated_consumer.uuid] = {source.uuid, unrelated_source.uuid}
+
+    link_trekker = LinkTrekker()
+    trek(link_trekker, first_link, (FIRST_DESTINATION_CFW, SOURCE_CFW), consumer.uuid)
+    trek(link_trekker, second_link, (SECOND_DESTINATION_CFW, SOURCE_CFW), consumer.uuid)
+    trek(link_trekker, unrelated_link, (SOURCE_CFW, UNRELATED_SOURCE_CFW), unrelated_consumer.uuid)
+
+    queue: list[Any] = [
+        (OrphanSourceParent, {source}),
+        (OrphanFirstDestination, {first_destination}),
+        (OrphanSecondDestination, {second_destination}),
+        (UnrelatedWritebackSource, {unrelated_source}),
+        (first_link, FIRST_DESTINATION_CFW, SOURCE_CFW),
+        (second_link, SOURCE_CFW, SECOND_DESTINATION_CFW),
+        (unrelated_link, SOURCE_CFW, UNRELATED_SOURCE_CFW),
+        (OrphanConsumer, {consumer}),
+        (UnrelatedWritebackConsumer, {unrelated_consumer}),
+    ]
+
+    plan = ExecutionPlan()
+    plan.create_execution_plan(queue, graph, link_trekker, validate=False)
+    return BuiltWithUnrelatedWriteback(plan, source.uuid, consumer.uuid, unrelated_consumer.uuid)
 
 
 def test_the_fixture_reads_the_shared_source_twice_and_writes_back_to_neither_join() -> None:
@@ -130,12 +207,47 @@ def test_raise_on_orphaned_join_source_raises_naming_the_dropped_feature_group()
 
     message = str(excinfo.value)
     assert OrphanSourceParent.get_class_name() in message, f"the dropped side must be named; got: {message}"
-    assert OrphanFirstDestination.get_class_name() in message or str(built.first_link.uuid) in message, (
+    assert OrphanFirstDestination.get_class_name() in message, (
         f"one competing join must be identifiable; got: {message}"
     )
-    assert OrphanSecondDestination.get_class_name() in message or str(built.second_link.uuid) in message, (
+    assert OrphanSecondDestination.get_class_name() in message, (
         f"the other competing join must be identifiable; got: {message}"
     )
+
+
+def test_the_unrelated_writeback_fixture_writes_into_the_shared_parent_for_a_different_consumer() -> None:
+    """Pins the shape: the orphaned pair for OrphanConsumer is unchanged, and a third, unrelated
+    join writes the shared parent's own uuid into its destination_uuids for UnrelatedConsumer."""
+    built = _build_orphaned_source_plan_with_unrelated_writeback()
+    resolved = built.plan.resolved_join_plan
+
+    assert not resolved.declined
+    assert len(resolved.records) == 3
+
+    all_destination_uuids: set[UUID] = set()
+    orphaned_pair = []
+    for record in resolved.records:
+        all_destination_uuids |= record.destination_uuids
+        if built.source_uuid in record.source_uuids:
+            orphaned_pair.append(record)
+
+    assert built.source_uuid in all_destination_uuids, (
+        "the unrelated join must write back into the shared parent for this to test the right scope"
+    )
+    assert len(orphaned_pair) == 2, "the two joins reading the shared parent as their source are unchanged"
+    assert orphaned_pair[0].consumers & orphaned_pair[1].consumers == {built.consumer_uuid}
+    assert built.unrelated_consumer_uuid not in (orphaned_pair[0].consumers | orphaned_pair[1].consumers), (
+        "the write-back's consumer must share nothing with the orphaned pair's consumer"
+    )
+
+
+def test_raise_on_orphaned_join_source_still_raises_despite_an_unrelated_writeback() -> None:
+    """An unrelated join writing back into the shared parent for a different consumer must not
+    silence the check for the pair that actually shares a consumer and never reunites."""
+    built = _build_orphaned_source_plan_with_unrelated_writeback()
+
+    with pytest.raises(ValueError, match="is read as the join source"):
+        raise_on_orphaned_join_source(built.plan.resolved_join_plan)
 
 
 def test_raise_on_orphaned_join_source_accepts_a_plan_with_no_records() -> None:

--- a/tests/test_core/test_prepare/test_resolved_join_plan_validation.py
+++ b/tests/test_core/test_prepare/test_resolved_join_plan_validation.py
@@ -1,0 +1,145 @@
+"""A parent's data read as the source of two joins that share a consumer, with no join in the
+plan writing back into that parent, is the confirmed silent-data-loss shape: two branches that
+can never reunite. `raise_on_orphaned_join_source` does not exist yet; this module fails to import."""
+
+from typing import Any, NamedTuple
+from uuid import UUID
+
+import pytest
+
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.core.prepare.validate_resolved_join import raise_on_orphaned_join_source
+from mloda.provider import FeatureGroup
+from mloda.user import Index, JoinSpec, Link
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from tests.test_core.test_prepare.join_plan_helpers import feature, trek
+
+
+SHARED_INDEX = Index(("orphan_source_idx",))
+
+SOURCE_CFW = PyArrowTable
+FIRST_DESTINATION_CFW = PythonDictFramework
+SECOND_DESTINATION_CFW = PandasDataFrame
+
+
+class OrphanSourceParent(FeatureGroup):
+    """The parent whose original data two joins both read but neither writes back into."""
+
+
+class OrphanFirstDestination(FeatureGroup):
+    """Declared left of the first link; the first join's destination."""
+
+
+class OrphanSecondDestination(FeatureGroup):
+    """Declared right of the second link; the child's framework, so this join inverts onto it."""
+
+
+class OrphanConsumer(FeatureGroup):
+    """Needs all three parents, through both joins."""
+
+
+class Built(NamedTuple):
+    plan: ExecutionPlan
+    source_uuid: UUID
+    first_destination_uuid: UUID
+    second_destination_uuid: UUID
+    consumer_uuid: UUID
+    first_link: Link
+    second_link: Link
+
+
+def _build_orphaned_source_plan() -> Built:
+    """Both joins read the shared parent as their source and write to distinct destinations:
+    the confirmed silent-data-loss shape, reproduced by hand instead of through the full engine."""
+    source = feature("orphan_source", SOURCE_CFW, SHARED_INDEX)
+    first_destination = feature("orphan_first_destination", FIRST_DESTINATION_CFW, SHARED_INDEX)
+    second_destination = feature("orphan_second_destination", SECOND_DESTINATION_CFW, SHARED_INDEX)
+    consumer = feature("orphan_consumer", SECOND_DESTINATION_CFW)
+
+    first_link = Link.inner(JoinSpec(OrphanFirstDestination, SHARED_INDEX), JoinSpec(OrphanSourceParent, SHARED_INDEX))
+    second_link = Link.inner(
+        JoinSpec(OrphanSourceParent, SHARED_INDEX), JoinSpec(OrphanSecondDestination, SHARED_INDEX)
+    )
+
+    graph = Graph()
+    graph.add_node(source.uuid, NodeProperties(source, OrphanSourceParent))
+    graph.add_node(first_destination.uuid, NodeProperties(first_destination, OrphanFirstDestination))
+    graph.add_node(second_destination.uuid, NodeProperties(second_destination, OrphanSecondDestination))
+    graph.add_node(consumer.uuid, NodeProperties(consumer, OrphanConsumer))
+    graph.adjacency_list[source.uuid].append(consumer.uuid)
+    graph.adjacency_list[first_destination.uuid].append(consumer.uuid)
+    graph.adjacency_list[second_destination.uuid].append(consumer.uuid)
+    graph.adjacency_list[consumer.uuid] = []
+    graph.parent_to_children_mapping[consumer.uuid] = {source.uuid, first_destination.uuid, second_destination.uuid}
+
+    link_trekker = LinkTrekker()
+    # Natural key (declared left, declared right): first_link needs no inversion.
+    trek(link_trekker, first_link, (FIRST_DESTINATION_CFW, SOURCE_CFW), consumer.uuid)
+    # Flipped key: second_link's queue entry below is the declared (source, second_destination)
+    # order, so run_link finds nothing there and inverts onto (second_destination, source).
+    trek(link_trekker, second_link, (SECOND_DESTINATION_CFW, SOURCE_CFW), consumer.uuid)
+
+    queue: list[Any] = [
+        (OrphanSourceParent, {source}),
+        (OrphanFirstDestination, {first_destination}),
+        (OrphanSecondDestination, {second_destination}),
+        (first_link, FIRST_DESTINATION_CFW, SOURCE_CFW),
+        (second_link, SOURCE_CFW, SECOND_DESTINATION_CFW),
+        (OrphanConsumer, {consumer}),
+    ]
+
+    plan = ExecutionPlan()
+    plan.create_execution_plan(queue, graph, link_trekker)
+    return Built(
+        plan, source.uuid, first_destination.uuid, second_destination.uuid, consumer.uuid, first_link, second_link
+    )
+
+
+def test_the_fixture_reads_the_shared_source_twice_and_writes_back_to_neither_join() -> None:
+    """Pins the shape the check is meant to catch, independently of the check itself."""
+    built = _build_orphaned_source_plan()
+    resolved = built.plan.resolved_join_plan
+
+    assert not resolved.declined
+    assert len(resolved.records) == 2
+
+    all_destination_uuids: set[UUID] = set()
+    records_sourcing_the_shared_parent = []
+    for record in resolved.records:
+        all_destination_uuids |= record.destination_uuids
+        if built.source_uuid in record.source_uuids:
+            records_sourcing_the_shared_parent.append(record)
+
+    assert len(records_sourcing_the_shared_parent) == 2, "both joins must read the shared parent as their source"
+    assert built.source_uuid not in all_destination_uuids, "no join may write back into the shared parent"
+    assert records_sourcing_the_shared_parent[0].consumers & records_sourcing_the_shared_parent[1].consumers == {
+        built.consumer_uuid
+    }
+
+
+def test_raise_on_orphaned_join_source_raises_naming_the_dropped_feature_group() -> None:
+    built = _build_orphaned_source_plan()
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_orphaned_join_source(built.plan.resolved_join_plan)
+
+    message = str(excinfo.value)
+    assert OrphanSourceParent.get_class_name() in message, f"the dropped side must be named; got: {message}"
+    assert OrphanFirstDestination.get_class_name() in message or str(built.first_link.uuid) in message, (
+        f"one competing join must be identifiable; got: {message}"
+    )
+    assert OrphanSecondDestination.get_class_name() in message or str(built.second_link.uuid) in message, (
+        f"the other competing join must be identifiable; got: {message}"
+    )
+
+
+def test_raise_on_orphaned_join_source_accepts_a_plan_with_no_records() -> None:
+    """An empty plan has no source to lose, so the guard must not require records to exist."""
+    raise_on_orphaned_join_source(ExecutionPlan().resolved_join_plan)

--- a/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
@@ -120,10 +120,12 @@ def _plan_append(link: Link, consumers: list[type[FeatureGroup]]) -> None:
 
 
 def test_consumer_framework_mismatch_is_rejected_while_building_the_joinstep() -> None:
-    with pytest.raises(ValueError) as excinfo:
-        _plan_append(_append_link(), [SharedAppendPandasConsumer])
+    link = _append_link()
 
-    assert not str(excinfo.value).startswith("Internal error:")
+    with pytest.raises(ValueError) as excinfo:
+        _plan_append(link, [SharedAppendPandasConsumer])
+
+    _assert_is_orientation_configuration_error(str(excinfo.value), link)
 
 
 def test_consumer_framework_mismatch_names_the_link_and_both_frameworks() -> None:
@@ -136,7 +138,9 @@ def test_consumer_framework_mismatch_names_the_link_and_both_frameworks() -> Non
 
 
 def test_a_second_consumer_of_the_same_link_raises_the_same_error() -> None:
-    with pytest.raises(ValueError) as excinfo:
-        _plan_append(_append_link(), [SharedAppendPandasConsumer, SharedAppendFlexibleConsumer])
+    link = _append_link()
 
-    assert not str(excinfo.value).startswith("Internal error:")
+    with pytest.raises(ValueError) as excinfo:
+        _plan_append(link, [SharedAppendPandasConsumer, SharedAppendFlexibleConsumer])
+
+    _assert_is_orientation_configuration_error(str(excinfo.value), link)

--- a/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
@@ -1,4 +1,4 @@
-"""An APPEND consumer resolving to a different framework than the left index feature hits a planning invariant.
+"""An APPEND consumer resolving to a different framework than the left index feature is a configuration error.
 
 A second consumer sharing the same link does not change that outcome.
 """
@@ -24,14 +24,13 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 
-# Substance a message must show to count as the plainly-worded configuration error: it must name
-# the concept (orientation/inversion) and say plainly that it is not supported.
+# The message must name the orientation concept and say that it is not supported.
 ORIENTATION_WORDS = ("invert", "revers", "swap", "orientation")
 UNSUPPORTED_WORDS = ("not support", "unsupported", "cannot", "can't", "not allowed")
 
 
 def _assert_is_orientation_configuration_error(message: str, link: Link) -> None:
-    """The error reads as a plain config problem, not an internal bug report."""
+    """The error reads as a configuration problem, not an internal bug report."""
     assert not message.startswith("Internal error:")
     assert "report this issue" not in message.lower()
     assert "sanity check" not in message

--- a/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
@@ -24,7 +24,23 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 
-LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
+# Substance a message must show to count as the plainly-worded configuration error: it must name
+# the concept (orientation/inversion) and say plainly that it is not supported.
+ORIENTATION_WORDS = ("invert", "revers", "swap", "orientation")
+UNSUPPORTED_WORDS = ("not support", "unsupported", "cannot", "can't", "not allowed")
+
+
+def _assert_is_orientation_configuration_error(message: str, link: Link) -> None:
+    """The error reads as a plain config problem, not an internal bug report."""
+    assert not message.startswith("Internal error:")
+    assert "report this issue" not in message.lower()
+    assert "sanity check" not in message
+    assert str(link) in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
+    assert link.jointype.value in message.lower()
+    assert any(word in message.lower() for word in ORIENTATION_WORDS)
+    assert any(word in message.lower() for word in UNSUPPORTED_WORDS)
 
 
 class SharedAppendSource(FeatureGroup):
@@ -108,8 +124,7 @@ def test_consumer_framework_mismatch_is_rejected_while_building_the_joinstep() -
     with pytest.raises(ValueError) as excinfo:
         _plan_append(_append_link(), [SharedAppendPandasConsumer])
 
-    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
-    assert LEFT_FRAMEWORK_INVARIANT in str(excinfo.value)
+    assert not str(excinfo.value).startswith("Internal error:")
 
 
 def test_consumer_framework_mismatch_names_the_link_and_both_frameworks() -> None:
@@ -118,17 +133,11 @@ def test_consumer_framework_mismatch_names_the_link_and_both_frameworks() -> Non
     with pytest.raises(ValueError) as excinfo:
         _plan_append(link, [SharedAppendPandasConsumer])
 
-    message = str(excinfo.value)
-    assert message.startswith("Internal error:")
-    assert "sanity check" not in message
-    assert str(link) in message
-    assert PyArrowTable.get_class_name() in message
-    assert PandasDataFrame.get_class_name() in message
+    _assert_is_orientation_configuration_error(str(excinfo.value), link)
 
 
 def test_a_second_consumer_of_the_same_link_raises_the_same_error() -> None:
     with pytest.raises(ValueError) as excinfo:
         _plan_append(_append_link(), [SharedAppendPandasConsumer, SharedAppendFlexibleConsumer])
 
-    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
-    assert LEFT_FRAMEWORK_INVARIANT in str(excinfo.value)
+    assert not str(excinfo.value).startswith("Internal error:")


### PR DESCRIPTION
## Summary

One validation pass over the resolved join plan, raising user-facing errors at planning time instead of either silently returning an incomplete result or misclassifying a configuration problem as an internal bug.

- Reject a plan where a shared parent feature group's data is read as the source of two or more joins, and no join in the plan writes its result back into that parent's own slot for the consumer(s) those joins share. Without this, the plan builds successfully and silently drops one branch's columns from the final result, depending on which the runtime happens to expose. Joins that stay within a single compute framework are exempt: they reunite through the runtime's own bookkeeping rather than a rewritten destination uuid, so the check only fires on genuinely unreconciled cross-framework forks.
- Reclassify an APPEND or UNION link scheduled in an inverted orientation (neither jointype supports running inverted, unlike INNER/LEFT/RIGHT) as a plain configuration error naming the link, its declared sides, and both frameworks involved, replacing an internal-invariant-violation message.
- Add regression coverage proving a trekked feature cannot silently end up assigned a compute framework it never declared through the RIGHT-jointype inversion path.

## Details

The join planner already materializes a `ResolvedJoin` record per planned join orientation (declared sides, destination/source framework and uuids, consumers, dependency edges). This adds the first pass that actually reads those records to decide something, rather than only using them for shadow-mode parity checking against the legacy join steps.

`create_execution_plan` gained an explicit `validate: bool = True` parameter controlling whether the new check runs, instead of an implicit side effect of whether a `declared_frameworks` map was supplied.

## Test plan

- `tox` green: 9172 passed, 170 skipped, 2 xfailed, plus ruff format/check, mypy --strict, bandit, and the license allowlist check.
- New coverage for the orphaned-source rejection at both the hand-built plan level and through a full `mloda.run_all` run, including a same-framework case that must not raise and a case where an unrelated join's write-back for a different consumer must not silence a real rejection.
- New coverage for the APPEND/UNION reclassification, and for the trekked RIGHT-branch framework assignment guard.
- Existing chained-join and cross-framework test suites verified unmodified and passing, guarding against over-rejection.