### PR TITLE
fix: require every discriminator key to match, not just one

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1027,12 +1027,17 @@ class ExecutionPlan:
             )
 
     def _matches_discriminator(self, discriminator: dict[str, Any], graph: Graph, uuid: UUID) -> bool:
-        """Check if a node's feature options match the discriminator key-value pairs."""
-        for k, v in graph.nodes[uuid].feature.options.items():
-            for dk, dv in discriminator.items():
-                if k == dk and v == dv:
-                    return True
-        return False
+        """Check that every discriminator key-value pair is present in a node's feature options.
+
+        A discriminator identifies one node among several same-class FeatureGroup instances, so a
+        partial overlap is not enough: two nodes that differ on the deciding key but share another
+        one would both match.
+        """
+        options = graph.nodes[uuid].feature.options
+        for dk, dv in discriminator.items():
+            if dk not in options or options.get(dk) != dv:
+                return False
+        return True
 
     def check_pointer(
         self, pointer_dict: dict[str, Any], link_fw: LinkFrameworkTrekker, graph: Graph, uuid: UUID

--- a/tests/test_core/test_prepare/test_discriminator_disambiguation.py
+++ b/tests/test_core/test_prepare/test_discriminator_disambiguation.py
@@ -43,3 +43,31 @@ class TestMatchesDiscriminator:
         ep = ExecutionPlan()
         graph, uuid = self._make_graph_with_feature({"CsvReader": "customers.csv", "extra": "value"})
         assert ep._matches_discriminator({"CsvReader": "customers.csv"}, graph, uuid) is True
+
+    def test_multi_key_discriminator_requires_every_key(self) -> None:
+        """A discriminator with several keys must match all of them, not just one."""
+        ep = ExecutionPlan()
+        discriminator = {"reader": "file_a.csv", "region": "us"}
+
+        graph, uuid = self._make_graph_with_feature({"reader": "file_a.csv", "region": "us"})
+        assert ep._matches_discriminator(discriminator, graph, uuid) is True
+
+        # Same region, different reader: the overlap on one key must not be enough.
+        graph, uuid = self._make_graph_with_feature({"reader": "file_b.csv", "region": "us"})
+        assert ep._matches_discriminator(discriminator, graph, uuid) is False
+
+        # Same reader, different region: the mirror case.
+        graph, uuid = self._make_graph_with_feature({"reader": "file_a.csv", "region": "eu"})
+        assert ep._matches_discriminator(discriminator, graph, uuid) is False
+
+    def test_multi_key_discriminator_needs_every_key_present(self) -> None:
+        """Missing a discriminator key is a mismatch, even when the present ones agree."""
+        ep = ExecutionPlan()
+        graph, uuid = self._make_graph_with_feature({"reader": "file_a.csv"})
+        assert ep._matches_discriminator({"reader": "file_a.csv", "region": "us"}, graph, uuid) is False
+
+    def test_empty_discriminator_matches(self) -> None:
+        """An empty discriminator constrains nothing, so every node satisfies it."""
+        ep = ExecutionPlan()
+        graph, uuid = self._make_graph_with_feature({"reader": "file_a.csv"})
+        assert ep._matches_discriminator({}, graph, uuid) is True


### PR DESCRIPTION
Closes #1129.

`_matches_discriminator` returned `True` on the first overlapping key/value pair, so a discriminator meant to pick one node among several same-class `FeatureGroup` instances was satisfied by the wrong node whenever the two happened to agree on some other key. The check is now a subset test: every key in the discriminator has to be present in the node's options with the same value.

I kept it on the `Options` public API (`in` plus `get`) rather than reaching for the underlying dicts, so group and context keys stay visible exactly as the old `items()` loop saw them.

**Red first.** The three new cases in `TestMatchesDiscriminator` fail on `1665e7e` and pass after the change. The one from the issue reads:

```python
discriminator = {"reader": "file_a.csv", "region": "us"}
# same region, different reader: the overlap on one key must not be enough
graph, uuid = self._make_graph_with_feature({"reader": "file_b.csv", "region": "us"})
assert ep._matches_discriminator(discriminator, graph, uuid) is False
```

The mirror case (same reader, different region) is in the same test, plus a case where a discriminator key is missing from the node's options entirely. The five tests that were already in the file pass unchanged, which is what you want from a narrowing change: nothing that used to match a full discriminator stops matching.

**One judgement call worth your eyes.** A subset test makes an empty discriminator vacuously true, where the old loop returned `False` for it. Both call sites guard on `is not None`, so `{}` only arrives if a caller passes it explicitly, and reading it as "no constraint" seems right to me. I wrote it down as `test_empty_discriminator_matches` rather than let it slip through unnoticed. If you would rather keep the old `False` there, say so and I will add the guard.

**What I ran** on Windows with Python 3.13.7, in a venv from `pip install -e ".[test]"` plus pandas, polars and duckdb:

| suite | result |
| --- | --- |
| `tests/test_core` | 5318 passed, 2 xfailed |
| full `tests/` (`-n 8`, minus notebooks and docs) | 9090 passed, 241 skipped, 6 failed |
| same full run on unmodified `1665e7e` | 9087 passed, 241 skipped, **the same 6 failed** |

So the six are my environment, not this change, and the +3 is exactly the tests added here. They are `test_docs_fences`, the otel extender, nltk availability, a sqlite credentials check and two context-file readers that depend on POSIX path handling.

`ruff format --check` reports both touched files already formatted. `ruff check` on those two files reports the same 24 findings before and after the change, all from rule groups your pinned ruff does not enable (my local 0.16.3 has a wider default set), so nothing new comes from here. `mypy --strict --ignore-missing-imports` on the touched module is clean apart from one `unused-ignore` in `accessible_plugins.py:144`, which reproduces on unmodified `main` here and is a local mypy version difference rather than a real finding.

I could not run `tox` itself: the testenv command is a `sh` script using `flock`, so it needs a POSIX shell. Everything the gate runs, I ran by hand.
