### PR TITLE
Absorb join side selection into the resolved join record

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -613,6 +613,7 @@ class ExecutionPlan:
         #    raise ValueError("This is not supported yet.")
 
         # This part is for handling specific join cases. Currently, we only deal with equal feature groups.
+        case_override = False
         for children_uuid in children_uuids:
             children_fw = graph.get_nodes()[children_uuid].feature.get_compute_framework()
 
@@ -626,6 +627,7 @@ class ExecutionPlan:
                 pass
             else:
                 destination_framework_uuids, source_framework_uuids = result
+                case_override = True
 
         if link.jointype in (JoinType.APPEND, JoinType.UNION):
             js = self.create_joinstep_in_case_of_append_or_union(
@@ -647,7 +649,12 @@ class ExecutionPlan:
 
         side = JoinSide.RIGHT if js.swap_merge_sides else JoinSide.LEFT
         self.planned_orientations.append(
-            (PlannedOrientation(link, frozenset(children_uuids), side, split.left_uuids, split.right_uuids), js)
+            (
+                PlannedOrientation(
+                    link, frozenset(children_uuids), side, split.left_uuids, split.right_uuids, case_override
+                ),
+                js,
+            )
         )
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -647,11 +647,20 @@ class ExecutionPlan:
                 swap_sides,
             )
 
+        # create_joinstep_in_case_of_append_or_union builds its own uuids independently, so an APPEND/UNION
+        # orientation must never claim its (unused) case-override uuids are in declared order.
+        sides_in_declared_order = case_override and link.jointype not in (JoinType.APPEND, JoinType.UNION)
+
         side = JoinSide.RIGHT if js.swap_merge_sides else JoinSide.LEFT
         self.planned_orientations.append(
             (
                 PlannedOrientation(
-                    link, frozenset(children_uuids), side, split.left_uuids, split.right_uuids, case_override
+                    link,
+                    frozenset(children_uuids),
+                    side,
+                    split.left_uuids,
+                    split.right_uuids,
+                    sides_in_declared_order=sides_in_declared_order,
                 ),
                 js,
             )

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -44,6 +44,9 @@ class PlannedOrientation:
     destination_side: JoinSide
     left_uuids: frozenset[UUID]
     right_uuids: frozenset[UUID]
+    # True when is_valid_join_step's case helper (not the generic framework partition) resolved
+    # destination/source: those uuids are already declared left/right, unlike the generic partition.
+    case_override: bool = False
 
 
 @dataclass(frozen=True)

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -44,8 +44,8 @@ class PlannedOrientation:
     destination_side: JoinSide
     left_uuids: frozenset[UUID]
     right_uuids: frozenset[UUID]
-    # True when is_valid_join_step's case helper resolved destination/source in declared left/right order.
-    case_override: bool = False
+    # True when destination/source uuids are already in declared left/right order (INNER/LEFT/RIGHT joins only).
+    sides_in_declared_order: bool = False
 
 
 @dataclass(frozen=True)
@@ -94,6 +94,9 @@ class ResolvedJoin:
     def inverted(self) -> bool:
         return self.destination_side is JoinSide.RIGHT
 
+    # Known gap: on a case-override orientation whose destination_side is RIGHT, destination/source below can
+    # name a different uuid set than destination_uuids/source_uuids; see
+    # test_a_case_override_right_destination_crosses_the_legacy_destination_uuids.
     @property
     def destination(self) -> ResolvedJoinSide:
         return self.right if self.inverted else self.left

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -44,8 +44,7 @@ class PlannedOrientation:
     destination_side: JoinSide
     left_uuids: frozenset[UUID]
     right_uuids: frozenset[UUID]
-    # True when is_valid_join_step's case helper (not the generic framework partition) resolved
-    # destination/source: those uuids are already declared left/right, unlike the generic partition.
+    # True when is_valid_join_step's case helper resolved destination/source in declared left/right order.
     case_override: bool = False
 
 

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -55,7 +55,11 @@ def build_resolved_join_plan(
         side = orientation.destination_side
         destination = frozenset(join_step.destination_framework_uuids)
         source = frozenset(join_step.source_framework_uuids)
-        resolved_left, resolved_right = (destination, source) if side is JoinSide.LEFT else (source, destination)
+        # A case-override orientation already resolved destination/source against declared left/right;
+        # only the generic framework partition needs the side-based remap to recover declared order.
+        resolved_left, resolved_right = (
+            (destination, source) if side is JoinSide.LEFT or orientation.case_override else (source, destination)
+        )
         if link.left_feature_group == link.right_feature_group:
             # run_link resolves a self link's left-discriminated parents into the destination set unconditionally.
             left_uuids, right_uuids = destination, source

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -55,14 +55,14 @@ def build_resolved_join_plan(
         side = orientation.destination_side
         destination = frozenset(join_step.destination_framework_uuids)
         source = frozenset(join_step.source_framework_uuids)
-        # The generic framework partition needs the side to recover declared order; a case override already has it.
+        # The generic framework partition needs the side to recover declared order; sides_in_declared_order
+        # already has it.
         resolved_left, resolved_right = (
-            (destination, source) if side is JoinSide.LEFT or orientation.case_override else (source, destination)
+            (destination, source)
+            if side is JoinSide.LEFT or orientation.sides_in_declared_order
+            else (source, destination)
         )
-        if link.left_feature_group == link.right_feature_group:
-            # run_link resolves a self link's left-discriminated parents into the destination set unconditionally.
-            left_uuids, right_uuids = destination, source
-        elif (
+        if (
             orientation.left_uuids <= resolved_left
             and orientation.right_uuids <= resolved_right
             and orientation.left_uuids != orientation.right_uuids
@@ -70,6 +70,8 @@ def build_resolved_join_plan(
             left_uuids, right_uuids = orientation.left_uuids, orientation.right_uuids
         else:
             # The step's sets, so a record can never name parents outside its own destination/source claim.
+            # A self link's declared sides are identical (split_by_declared_side can't split one feature group
+            # from itself), so it always lands here too.
             left_uuids, right_uuids = resolved_left, resolved_right
 
         record = ResolvedJoin(

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -55,8 +55,7 @@ def build_resolved_join_plan(
         side = orientation.destination_side
         destination = frozenset(join_step.destination_framework_uuids)
         source = frozenset(join_step.source_framework_uuids)
-        # A case-override orientation already resolved destination/source against declared left/right;
-        # only the generic framework partition needs the side-based remap to recover declared order.
+        # The generic framework partition needs the side to recover declared order; a case override already has it.
         resolved_left, resolved_right = (
             (destination, source) if side is JoinSide.LEFT or orientation.case_override else (source, destination)
         )

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -85,10 +85,6 @@ class ResolvedJoinPairLeftDescendant(ResolvedJoinPairLeft):
     """Matches the declared left side polymorphically, at inheritance distance one."""
 
 
-class ResolvedJoinPairLeftTiedDescendant(ResolvedJoinPairLeft):
-    """A second subclass, tied with ResolvedJoinPairLeftDescendant at inheritance distance one."""
-
-
 class ResolvedJoinOtherLeft(FeatureGroup):
     pass
 
@@ -417,29 +413,38 @@ def _ordered_chain() -> Chain:
     return Chain(planned.plan, producer, consumer)
 
 
-def _tied_left_subclasses_inverted() -> Built:
-    """Two subclasses tie at distance one; only left_winner sits on the trekker key's declared-left framework,
-    so case_link_fw_is_equal_to_children_fw's framework filter alone picks it."""
+def _case_override_inverted() -> Built:
+    """The queue keeps the declared orientation, so run_link rediscovers the inverted one; the child sits on the
+    declared left framework too, so is_valid_join_step's case helper resolves left/right before the remap runs."""
+    planned = _planned()
+    link = _pair_link()
+    sides = _branch(planned, link, "resolved_join_case_override", trekked=(PandasDataFrame, PyArrowTable))
+    return _finish(planned, link, sides)
+
+
+def _case_override_beats_nearer_wrong_framework_left() -> Built:
+    """far_left is farther than nearest_left but is the only one on the framework the join needs; the case helper
+    filters candidates by framework, not distance. destination_side turns RIGHT via that check here, not inversion."""
     planned = _planned()
     link = _pair_link()
 
-    left_winner = feature("resolved_join_tied_left_winner", PyArrowTable, link.left_index)
-    left_loser = feature("resolved_join_tied_left_loser", PandasDataFrame, link.left_index)
-    right = feature("resolved_join_tied_right", PandasDataFrame, link.right_index)
-    child = feature("resolved_join_tied_child", PyArrowTable)
+    nearest_left = feature("resolved_join_nearer_wrong_fw_left", PandasDataFrame, link.left_index)
+    far_left = feature("resolved_join_nearer_wrong_fw_far_left", PyArrowTable, link.left_index)
+    right = feature("resolved_join_nearer_wrong_fw_right", PyArrowTable, link.right_index)
+    child = feature("resolved_join_nearer_wrong_fw_child", PyArrowTable)
 
-    planned.graph.add_node(left_winner.uuid, NodeProperties(left_winner, ResolvedJoinPairLeftDescendant))
-    planned.graph.add_node(left_loser.uuid, NodeProperties(left_loser, ResolvedJoinPairLeftTiedDescendant))
+    planned.graph.add_node(nearest_left.uuid, NodeProperties(nearest_left, ResolvedJoinPairLeft))
+    planned.graph.add_node(far_left.uuid, NodeProperties(far_left, ResolvedJoinPairLeftDescendant))
     planned.graph.add_node(right.uuid, NodeProperties(right, ResolvedJoinPairRight))
-    planned.queue.append((ResolvedJoinPairLeftDescendant, {left_winner}))
-    planned.queue.append((ResolvedJoinPairLeftTiedDescendant, {left_loser}))
+    planned.queue.append((ResolvedJoinPairLeft, {nearest_left}))
+    planned.queue.append((ResolvedJoinPairLeftDescendant, {far_left}))
     planned.queue.append((ResolvedJoinPairRight, {right}))
-    planned.queue.append((link, PyArrowTable, PandasDataFrame))
-    _add_child(planned, child, left_winner, left_loser, right)
-    # Queue keeps the declared orientation, so run_link rediscovers the inverted one.
-    trek(planned.link_trekker, link, (PandasDataFrame, PyArrowTable), child.uuid)
+    planned.queue.append((link, PyArrowTable, PyArrowTable))
+    _add_child(planned, child, nearest_left, far_left, right)
+    # The trekker key matches the queued key directly, so run_link never inverts here.
+    trek(planned.link_trekker, link, (PyArrowTable, PyArrowTable), child.uuid)
 
-    return _finish(planned, link, Sides(left_winner.uuid, right.uuid, child.uuid))
+    return _finish(planned, link, Sides(far_left.uuid, right.uuid, child.uuid))
 
 
 def _join_steps(plan: ExecutionPlan) -> list[JoinStep]:
@@ -688,7 +693,8 @@ def test_each_record_names_the_join_step_it_shadows() -> None:
         _append_pair,
         _two_links,
         _link_with_an_unlinked_third_parent,
-        _tied_left_subclasses_inverted,
+        _case_override_inverted,
+        _case_override_beats_nearer_wrong_framework_left,
     ],
     ids=[
         "inner",
@@ -700,7 +706,8 @@ def test_each_record_names_the_join_step_it_shadows() -> None:
         "append",
         "two_links",
         "unlinked_third_parent",
-        "tied_left_subclasses_inverted",
+        "case_override_inverted",
+        "case_override_beats_nearer_wrong_framework_left",
     ],
 )
 def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Any]) -> None:
@@ -744,16 +751,40 @@ def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_step
     assert record.source.uuids <= record.source_uuids
 
 
-def test_a_framework_disambiguated_left_winner_lands_on_the_wrong_side_once_inverted() -> None:
-    """left_winner wins the distance tie on framework alone; that win must land on record.left, not be
-    relabeled as record.right by the inversion."""
-    built = _tied_left_subclasses_inverted()
+def test_a_case_override_survives_a_right_destination_side() -> None:
+    """is_valid_join_step's case helper already resolves left/right in declared order; the inversion remap must
+    not re-swap them once destination_side comes out RIGHT."""
+    built = _case_override_inverted()
 
     assert len(_join_steps(built.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"
     record = _one_record(built.plan, built.link)
     assert record.destination_side is JoinSide.RIGHT
     assert record.left.uuids == {built.sides.left_uuid}
     assert record.right.uuids == {built.sides.right_uuid}
+
+
+def test_a_case_override_beats_a_nearer_wrong_framework_left() -> None:
+    """split_by_declared_side's nearest-by-distance rule alone would pick nearest_left; the case helper's
+    framework filter must override it and keep far_left, the correct-framework parent, on record.left."""
+    built = _case_override_beats_nearer_wrong_framework_left()
+
+    assert len(_join_steps(built.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"
+    record = _one_record(built.plan, built.link)
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
+
+
+def test_a_case_override_right_destination_crosses_the_legacy_destination_uuids() -> None:
+    """Known, accepted gap: destination (case-helper order) and destination_uuids (legacy mirror) diverge once a
+    case override lands on a RIGHT destination side; left open for a later epic step, not chased further here."""
+    built = _case_override_inverted()
+
+    record = _one_record(built.plan, built.link)
+
+    assert record.destination_side is JoinSide.RIGHT
+    assert not (record.destination.uuids <= record.destination_uuids)
+    assert not (record.source.uuids <= record.source_uuids)
 
 
 def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -85,6 +85,10 @@ class ResolvedJoinPairLeftDescendant(ResolvedJoinPairLeft):
     """Matches the declared left side polymorphically, at inheritance distance one."""
 
 
+class ResolvedJoinPairLeftTiedDescendant(ResolvedJoinPairLeft):
+    """A second subclass at the same inheritance distance as ResolvedJoinPairLeftDescendant, on another framework."""
+
+
 class ResolvedJoinOtherLeft(FeatureGroup):
     pass
 
@@ -413,6 +417,32 @@ def _ordered_chain() -> Chain:
     return Chain(planned.plan, producer, consumer)
 
 
+def _tied_left_subclasses_inverted() -> Built:
+    """Two ResolvedJoinPairLeft subclasses tie at distance one; only left_winner sits on the trekker key's
+    declared-left framework, so case_link_fw_is_equal_to_children_fw's framework filter alone must pick it."""
+    planned = _planned()
+    link = _pair_link()
+
+    left_winner = feature("resolved_join_tied_left_winner", PyArrowTable, link.left_index)
+    left_loser = feature("resolved_join_tied_left_loser", PandasDataFrame, link.left_index)
+    right = feature("resolved_join_tied_right", PandasDataFrame, link.right_index)
+    child = feature("resolved_join_tied_child", PyArrowTable)
+
+    planned.graph.add_node(left_winner.uuid, NodeProperties(left_winner, ResolvedJoinPairLeftDescendant))
+    planned.graph.add_node(left_loser.uuid, NodeProperties(left_loser, ResolvedJoinPairLeftTiedDescendant))
+    planned.graph.add_node(right.uuid, NodeProperties(right, ResolvedJoinPairRight))
+    planned.queue.append((ResolvedJoinPairLeftDescendant, {left_winner}))
+    planned.queue.append((ResolvedJoinPairLeftTiedDescendant, {left_loser}))
+    planned.queue.append((ResolvedJoinPairRight, {right}))
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    _add_child(planned, child, left_winner, left_loser, right)
+    # Queue keeps the declared orientation; the trekker records the swapped pair, inverting via run_link's
+    # empty-children branch, the same technique _inverted_pair/_inverted_left_join use.
+    trek(planned.link_trekker, link, (PandasDataFrame, PyArrowTable), child.uuid)
+
+    return _finish(planned, link, Sides(left_winner.uuid, right.uuid, child.uuid))
+
+
 def _join_steps(plan: ExecutionPlan) -> list[JoinStep]:
     return [step for step in plan if isinstance(step, JoinStep)]
 
@@ -659,6 +689,7 @@ def test_each_record_names_the_join_step_it_shadows() -> None:
         _append_pair,
         _two_links,
         _link_with_an_unlinked_third_parent,
+        _tied_left_subclasses_inverted,
     ],
     ids=[
         "inner",
@@ -670,6 +701,7 @@ def test_each_record_names_the_join_step_it_shadows() -> None:
         "append",
         "two_links",
         "unlinked_third_parent",
+        "tied_left_subclasses_inverted",
     ],
 )
 def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Any]) -> None:
@@ -711,6 +743,18 @@ def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_step
     assert record.destination_side is JoinSide.RIGHT
     assert record.destination.uuids <= record.destination_uuids
     assert record.source.uuids <= record.source_uuids
+
+
+def test_a_framework_disambiguated_left_winner_lands_on_the_wrong_side_once_inverted() -> None:
+    """left_winner alone sits on the trekker key's declared-left framework, so it must win the distance tie over
+    left_loser; the win should land on record.left, not get relabeled as record.right by the inversion."""
+    built = _tied_left_subclasses_inverted()
+
+    assert len(_join_steps(built.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"
+    record = _one_record(built.plan, built.link)
+    assert record.destination_side is JoinSide.RIGHT
+    assert record.left.uuids == {built.sides.left_uuid}
+    assert record.right.uuids == {built.sides.right_uuid}
 
 
 def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -86,7 +86,7 @@ class ResolvedJoinPairLeftDescendant(ResolvedJoinPairLeft):
 
 
 class ResolvedJoinPairLeftTiedDescendant(ResolvedJoinPairLeft):
-    """A second subclass at the same inheritance distance as ResolvedJoinPairLeftDescendant, on another framework."""
+    """A second subclass, tied with ResolvedJoinPairLeftDescendant at inheritance distance one."""
 
 
 class ResolvedJoinOtherLeft(FeatureGroup):
@@ -418,8 +418,8 @@ def _ordered_chain() -> Chain:
 
 
 def _tied_left_subclasses_inverted() -> Built:
-    """Two ResolvedJoinPairLeft subclasses tie at distance one; only left_winner sits on the trekker key's
-    declared-left framework, so case_link_fw_is_equal_to_children_fw's framework filter alone must pick it."""
+    """Two subclasses tie at distance one; only left_winner sits on the trekker key's declared-left framework,
+    so case_link_fw_is_equal_to_children_fw's framework filter alone picks it."""
     planned = _planned()
     link = _pair_link()
 
@@ -436,8 +436,7 @@ def _tied_left_subclasses_inverted() -> Built:
     planned.queue.append((ResolvedJoinPairRight, {right}))
     planned.queue.append((link, PyArrowTable, PandasDataFrame))
     _add_child(planned, child, left_winner, left_loser, right)
-    # Queue keeps the declared orientation; the trekker records the swapped pair, inverting via run_link's
-    # empty-children branch, the same technique _inverted_pair/_inverted_left_join use.
+    # Queue keeps the declared orientation, so run_link rediscovers the inverted one.
     trek(planned.link_trekker, link, (PandasDataFrame, PyArrowTable), child.uuid)
 
     return _finish(planned, link, Sides(left_winner.uuid, right.uuid, child.uuid))
@@ -746,8 +745,8 @@ def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_step
 
 
 def test_a_framework_disambiguated_left_winner_lands_on_the_wrong_side_once_inverted() -> None:
-    """left_winner alone sits on the trekker key's declared-left framework, so it must win the distance tie over
-    left_loser; the win should land on record.left, not get relabeled as record.right by the inversion."""
+    """left_winner wins the distance tie on framework alone; that win must land on record.left, not be
+    relabeled as record.right by the inversion."""
     built = _tied_left_subclasses_inverted()
 
     assert len(_join_steps(built.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"


### PR DESCRIPTION
## Summary

The resolved join record's declared left/right uuid selection now uses the same framework- and discriminator-aware disambiguation that `is_valid_join_step` already computes for the legacy join step, instead of a cruder inheritance-distance-only heuristic. Two distinct subclasses of one declared side, on different compute frameworks, could previously leave the record's declared side ambiguous or wrong even when the legacy step itself had already resolved it correctly.

This is record-only: nothing about what actually executes changes, and the existing shadow-mode parity check (the record and the legacy join step must sign the same join) stays green throughout.

Known, deliberately deferred gap: for an orientation where the case-helper resolution and an inverted destination side combine, `ResolvedJoin.destination`/`.source` (which follow the declared side) can name a different uuid set than `destination_uuids`/`source_uuids` (which mirror the legacy step exactly, for parity). Both are documented and pinned by a test; reconciling them depends on later work in this area and isn't chased down here.

## Test plan

- [x] New coverage for a case-resolved side surviving a RIGHT destination side, reached both via orientation inversion and via the framework-membership swap decision
- [x] Existing resolved-join-record suite green
- [x] Full tox green (tests, ruff, mypy --strict, bandit, license check)