### PR TITLE
test: cover execution plan error branches

### DIFF
--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -549,6 +549,58 @@ def test_the_declared_orientation_plans_the_declared_joinstep() -> None:
     assert join_step.swap_merge_sides is False
 
 
+def test_a_link_without_a_matching_trekker_key_names_the_link() -> None:
+    planned = _pair_scenario()
+
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned, PyArrowTable, PandasDataFrame)
+
+    assert "has no matching uuids" in str(excinfo.value)
+    assert str(planned.link) in str(excinfo.value)
+
+
+def test_same_class_nodes_without_discriminators_are_rejected_as_ambiguous() -> None:
+    link = Link.inner(
+        JoinSpec(LinkPlanSelfSource, Index((SELF_LEFT_KEY,))),
+        JoinSpec(LinkPlanSelfSource, Index((SELF_RIGHT_KEY,))),
+    )
+    planned = _plan(
+        link,
+        _feature(SELF_LEFT_PAYLOAD, PyArrowTable),
+        _feature(SELF_RIGHT_PAYLOAD, PyArrowTable),
+        _feature("link_plan_self_child", PyArrowTable),
+        LinkPlanSelfSource,
+        LinkPlanSelfSource,
+        LinkPlanSelfConsumer,
+    )
+    _trek(planned, PyArrowTable, PyArrowTable)
+
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned, PyArrowTable, PyArrowTable)
+
+    message = str(excinfo.value)
+    assert "Multiple same-class FeatureGroup nodes" in message
+    assert "left_discriminator and right_discriminator" in message
+
+
+def test_multiple_cross_group_pairings_are_rejected_as_ambiguous() -> None:
+    planned = _pair_scenario()
+    second_right = _feature("link_plan_pair_second_right_payload", PandasDataFrame, PAIR_RIGHT_INDEX)
+    planned.graph.add_node(second_right.uuid, NodeProperties(second_right, LinkPlanPairRight))
+    planned.graph.adjacency_list[second_right.uuid] = [planned.child_uuid]
+    planned.graph.parent_to_children_mapping[planned.child_uuid].add(second_right.uuid)
+    planned.pre_execution_plan.insert(2, _step(LinkPlanPairRight, second_right, PandasDataFrame))
+    planned.plan.feature_set_collections.insert(2, {second_right.uuid})
+    _trek(planned, PyArrowTable, PandasDataFrame)
+
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned, PyArrowTable, PandasDataFrame)
+
+    message = str(excinfo.value)
+    assert "more than one solution for the join" in message
+    assert "links and feature group configuration" in message
+
+
 def test_an_orientation_without_a_valid_pairing_plans_no_joinstep() -> None:
     """No parent is both a left-side feature group and on the left framework, so nothing pairs up."""
     planned = _pair_scenario(child_cfw=PandasDataFrame)


### PR DESCRIPTION
## Summary

Adds focused characterization coverage for three previously untested execution-planner failures: a missing trekker match, an ambiguous same-class link without discriminators, and multiple surviving cross-group join pairings. Production behavior is unchanged.

## Related issue

Closes #1130

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [x] Other: test coverage (`test:`)

## Verification

- Changed planner characterization module: `27 passed, 2 xfailed`
- Three new tests independently: `3 passed`
- `ruff format --check` and `ruff check`: passed across the repository
- License allowlist: passed
- `mypy --strict --ignore-missing-imports .`: passed (`1002` source files)
- Bandit: passed
- Full Windows `tox -e python313` pytest phase: `9173 passed, 170 skipped, 2 xfailed`; four pre-existing Windows path-semantics failures remained, and one xdist worker termination passed when rerun serially. The changed in-memory planner tests were unaffected.

## Checklist

- [ ] `tox` passes locally (Windows-only baseline failures are documented above; every remaining gate passed)
- [x] Tests added or updated for the change (the skip count is unchanged)
- [x] Documentation updated where relevant (no documentation change is needed for characterization coverage)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)