### PR TITLE
Lower JoinStep construction from the ResolvedJoin record

### DIFF
--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -19,6 +19,7 @@ class JoinStep(Step):
         destination_framework_uuids: set[UUID],
         source_framework_uuids: set[UUID],
         swap_merge_sides: bool = False,
+        token: Optional[UUID] = None,
     ) -> None:
         self.link = link
         self.swap_merge_sides = swap_merge_sides
@@ -27,7 +28,7 @@ class JoinStep(Step):
         self.required_uuids = required_uuids
         self.destination_framework_uuids = destination_framework_uuids
         self.source_framework_uuids = source_framework_uuids
-        self.uuid = uuid4()
+        self.uuid = token if token is not None else uuid4()
         self.step_is_done = False
 
     def get_uuids(self) -> set[UUID]:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -612,8 +612,13 @@ class ExecutionPlan:
         # if len(children_uuids) > 1:
         #    raise ValueError("This is not supported yet.")
 
+        # Computed before the case-override loop below: a case helper's result is always in declared
+        # left/right order, so it needs swap_sides to know which side of the result is the destination.
+        swap_sides = self.swap_merge_sides_by_declared_side(
+            destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
+        )
+
         # This part is for handling specific join cases. Currently, we only deal with equal feature groups.
-        case_override = False
         for children_uuid in children_uuids:
             children_fw = graph.get_nodes()[children_uuid].feature.get_compute_framework()
 
@@ -626,17 +631,16 @@ class ExecutionPlan:
             elif result is True:
                 pass
             else:
-                destination_framework_uuids, source_framework_uuids = result
-                case_override = True
+                if swap_sides:
+                    source_framework_uuids, destination_framework_uuids = result
+                else:
+                    destination_framework_uuids, source_framework_uuids = result
 
         if link.jointype in (JoinType.APPEND, JoinType.UNION):
             js = self.create_joinstep_in_case_of_append_or_union(
                 link, link_fw, required_uuids, graph, pre_execution_plan
             )
         else:
-            swap_sides = self.swap_merge_sides_by_declared_side(
-                destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
-            )
             js = JoinStep(
                 link,
                 destination_framework,
@@ -647,10 +651,6 @@ class ExecutionPlan:
                 swap_sides,
             )
 
-        # create_joinstep_in_case_of_append_or_union builds its own uuids independently, so an APPEND/UNION
-        # orientation must never claim its (unused) case-override uuids are in declared order.
-        sides_in_declared_order = case_override and link.jointype not in (JoinType.APPEND, JoinType.UNION)
-
         side = JoinSide.RIGHT if js.swap_merge_sides else JoinSide.LEFT
         self.planned_orientations.append(
             (
@@ -660,7 +660,6 @@ class ExecutionPlan:
                     side,
                     split.left_uuids,
                     split.right_uuids,
-                    sides_in_declared_order=sides_in_declared_order,
                 ),
                 js,
             )

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -30,7 +30,7 @@ from mloda.core.prepare.resolved_join import (
 from mloda.core.prepare.resolved_join_builder import (
     DeclaredFrameworks,
     build_resolved_join_side,
-    legacy_join_signatures,
+    joinstep_signatures,
     raise_on_join_plan_divergence,
     wire_join_dependencies,
 )
@@ -136,7 +136,7 @@ class ExecutionPlan:
         resolved_records = wire_join_dependencies(self.planned_records, join_steps)
         declined = tuple(DeclinedOrientation(key[0].uuid, key[1], key[2]) for key in self.declined_orientations)
         self.resolved_join_plan = ResolvedJoinPlan(resolved_records, declined)
-        self.join_signatures_at_build = legacy_join_signatures(join_steps)
+        self.join_signatures_at_build = joinstep_signatures(join_steps)
         raise_on_join_plan_divergence(self.resolved_join_plan, join_steps)
         if validate:
             raise_on_orphaned_join_source(self.resolved_join_plan)
@@ -628,8 +628,8 @@ class ExecutionPlan:
         # if len(children_uuids) > 1:
         #    raise ValueError("This is not supported yet.")
 
-        # Computed before the case-override loop below: a case helper's result is always in declared
-        # left/right order, so it needs swap_sides to know which side of the result is the destination.
+        # Hoisted above the case-override loop: a case helper's result is in declared left/right
+        # order, so orienting it needs swap_sides.
         swap_sides = self.swap_merge_sides_by_declared_side(
             destination_framework, declared_left_frameworks, declared_right_frameworks, swap_merge_sides
         )
@@ -661,8 +661,7 @@ class ExecutionPlan:
             source_framework_uuids = {sides.right_uuid}
             left_uuids = frozenset({sides.left_uuid})
             right_uuids = frozenset({sides.right_uuid})
-            # Append/union never chains through the general required_uuids (order edges included); only
-            # its own two feature uuids gate the merge, matching the pre-split JoinStep's required_uuids.
+            # Append/union gates only on its own two feature uuids, not on the general required_uuids.
             join_step_required_uuids: set[UUID] = {sides.left_uuid, sides.right_uuid}
         else:
             side = JoinSide.RIGHT if swap_sides else JoinSide.LEFT
@@ -676,9 +675,8 @@ class ExecutionPlan:
             ):
                 left_uuids, right_uuids = split.left_uuids, split.right_uuids
             else:
-                # The step's sets, so a record can never name parents outside its own destination/source claim.
-                # A self link's declared sides are identical (split_by_declared_side can't split one feature
-                # group from itself), so it always lands here too.
+                # The step's own sets, so a record never names parents outside its destination/source
+                # claim. Self links land here too: their declared sides are identical.
                 left_uuids, right_uuids = resolved_left, resolved_right
             join_step_required_uuids = required_uuids
 
@@ -773,12 +771,8 @@ class ExecutionPlan:
         graph: Graph,
         pre_execution_plan: list[LinkFrameworkTrekker | FeatureGroupStep],
     ) -> AppendOrUnionSides:
-        """
-        Resolve the left/right feature UUIDs and frameworks for an APPEND or UNION link.
-
-        Identifies the left and right feature UUIDs required for the join and validates the frameworks
-        and indices; append and union never invert, so the resolved sides stay in declared order.
-        """
+        """Resolve the left/right feature uuids and frameworks for an APPEND or UNION link; neither
+        inverts, so the resolved sides stay in declared order."""
 
         # Unpack link-related data
         left_index, right_index = link.left_index, link.right_index

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from copy import copy, deepcopy
-from typing import Any, Generator, Optional
-from uuid import UUID
+from typing import Any, Generator, NamedTuple, Optional
+from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.error_utils import REPORT_URL, internal_invariant_error
 from mloda.core.abstract_plugins.components.utils import safe_field
@@ -20,12 +20,19 @@ from mloda.core.prepare.joinstep_collection import JoinStepCollection
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_graph import PlannedQueue
 from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker
-from mloda.core.prepare.resolved_join import JoinSide, JoinSignature, PlannedOrientation, ResolvedJoinPlan
+from mloda.core.prepare.resolved_join import (
+    DeclinedOrientation,
+    JoinSide,
+    JoinSignature,
+    ResolvedJoin,
+    ResolvedJoinPlan,
+)
 from mloda.core.prepare.resolved_join_builder import (
     DeclaredFrameworks,
-    build_resolved_join_plan,
+    build_resolved_join_side,
     legacy_join_signatures,
     raise_on_join_plan_divergence,
+    wire_join_dependencies,
 )
 from mloda.core.prepare.validate_resolved_join import raise_on_orphaned_join_source
 from mloda.core.core.step.abstract_step import Step
@@ -67,6 +74,15 @@ def _describe_step(step: Step) -> str:
     return f"{type(step).__name__}(uuid={step.uuid})"
 
 
+class AppendOrUnionSides(NamedTuple):
+    """The left/right feature uuids and frameworks an APPEND or UNION link resolved to."""
+
+    destination_framework: type[ComputeFramework]
+    source_framework: type[ComputeFramework]
+    left_uuid: UUID
+    right_uuid: UUID
+
+
 class ExecutionPlan:
     def __init__(
         self,
@@ -84,8 +100,9 @@ class ExecutionPlan:
         # Report each divergence once, then at DEBUG.
         self.reported_unmatched: set[tuple[type[FeatureGroup], str, tuple[str, ...]]] = set()
 
-        self.planned_orientations: list[tuple[PlannedOrientation, JoinStep]] = []
+        self.planned_records: list[ResolvedJoin] = []
         self.declined_orientations: list[LinkFrameworkTrekker] = []
+        self.declared_frameworks: DeclaredFrameworks = {}
         self.resolved_join_plan = ResolvedJoinPlan((), ())
         self.join_signatures_at_build: frozenset[JoinSignature] = frozenset()
 
@@ -103,11 +120,12 @@ class ExecutionPlan:
         declared_frameworks: DeclaredFrameworks | None = None,
         validate: bool = True,
     ) -> None:
-        self.planned_orientations = []
+        self.planned_records = []
         self.declined_orientations = []
         self.tfs_collection = set()
         self.joinstep_collection = JoinStepCollection()
         self.feature_set_collections = []
+        self.declared_frameworks = declared_frameworks if declared_frameworks is not None else {}
 
         child_links = self.invert_link_trekker(link_trekker)
         pre_execution_plan = self.add_feature_group_step(queue, graph.parent_to_children_mapping, child_links)
@@ -115,11 +133,9 @@ class ExecutionPlan:
 
         # Built before add_tfs, whose write serialization edges are not part of the join decision.
         join_steps = [step for step in fw_execution_plan if isinstance(step, JoinStep)]
-        self.resolved_join_plan = build_resolved_join_plan(
-            self.planned_orientations,
-            self.declined_orientations,
-            declared_frameworks if declared_frameworks is not None else {},
-        )
+        resolved_records = wire_join_dependencies(self.planned_records, join_steps)
+        declined = tuple(DeclinedOrientation(key[0].uuid, key[1], key[2]) for key in self.declined_orientations)
+        self.resolved_join_plan = ResolvedJoinPlan(resolved_records, declined)
         self.join_signatures_at_build = legacy_join_signatures(join_steps)
         raise_on_join_plan_divergence(self.resolved_join_plan, join_steps)
         if validate:
@@ -637,33 +653,64 @@ class ExecutionPlan:
                     destination_framework_uuids, source_framework_uuids = result
 
         if link.jointype in (JoinType.APPEND, JoinType.UNION):
-            js = self.create_joinstep_in_case_of_append_or_union(
-                link, link_fw, required_uuids, graph, pre_execution_plan
-            )
+            sides = self.resolve_append_or_union_sides(link, link_fw, required_uuids, graph, pre_execution_plan)
+            destination_framework = sides.destination_framework
+            source_framework = sides.source_framework
+            side = JoinSide.LEFT
+            destination_framework_uuids = {sides.left_uuid}
+            source_framework_uuids = {sides.right_uuid}
+            left_uuids = frozenset({sides.left_uuid})
+            right_uuids = frozenset({sides.right_uuid})
+            # Append/union never chains through the general required_uuids (order edges included); only
+            # its own two feature uuids gate the merge, matching the pre-split JoinStep's required_uuids.
+            join_step_required_uuids: set[UUID] = {sides.left_uuid, sides.right_uuid}
         else:
-            js = JoinStep(
-                link,
-                destination_framework,
-                source_framework,
-                required_uuids,
-                destination_framework_uuids,
-                source_framework_uuids,
-                swap_sides,
-            )
+            side = JoinSide.RIGHT if swap_sides else JoinSide.LEFT
+            destination = frozenset(destination_framework_uuids)
+            source = frozenset(source_framework_uuids)
+            resolved_left, resolved_right = (destination, source) if side is JoinSide.LEFT else (source, destination)
+            if (
+                split.left_uuids <= resolved_left
+                and split.right_uuids <= resolved_right
+                and split.left_uuids != split.right_uuids
+            ):
+                left_uuids, right_uuids = split.left_uuids, split.right_uuids
+            else:
+                # The step's sets, so a record can never name parents outside its own destination/source claim.
+                # A self link's declared sides are identical (split_by_declared_side can't split one feature
+                # group from itself), so it always lands here too.
+                left_uuids, right_uuids = resolved_left, resolved_right
+            join_step_required_uuids = required_uuids
 
-        side = JoinSide.RIGHT if js.swap_merge_sides else JoinSide.LEFT
-        self.planned_orientations.append(
-            (
-                PlannedOrientation(
-                    link,
-                    frozenset(children_uuids),
-                    side,
-                    split.left_uuids,
-                    split.right_uuids,
-                ),
-                js,
-            )
+        record = ResolvedJoin(
+            link_uuid=link.uuid,
+            jointype=link.jointype,
+            left=build_resolved_join_side(
+                link.left_feature_group, link.left_index, left_uuids, self.declared_frameworks
+            ),
+            right=build_resolved_join_side(
+                link.right_feature_group, link.right_index, right_uuids, self.declared_frameworks
+            ),
+            destination_side=side,
+            destination_uuids=frozenset(destination_framework_uuids),
+            source_uuids=frozenset(source_framework_uuids),
+            destination_framework=destination_framework,
+            source_framework=source_framework,
+            consumers=frozenset(children_uuids),
+            depends_on=frozenset(),
+            token=uuid4(),
         )
+        js = JoinStep(
+            link,
+            record.destination_framework,
+            record.source_framework,
+            join_step_required_uuids,
+            set(record.destination_uuids),
+            set(record.source_uuids),
+            record.inverted,
+            token=record.token,
+        )
+        self.planned_records.append(record)
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
         self.joinstep_collection.add(js)
@@ -718,19 +765,19 @@ class ExecutionPlan:
             "features resolve to."
         )
 
-    def create_joinstep_in_case_of_append_or_union(
+    def resolve_append_or_union_sides(
         self,
         link: Link,
         link_fw: LinkFrameworkTrekker,
         required_uuids: set[UUID],
         graph: Graph,
         pre_execution_plan: list[LinkFrameworkTrekker | FeatureGroupStep],
-    ) -> JoinStep:
+    ) -> AppendOrUnionSides:
         """
-        Create a JoinStep for APPEND or UNION operations in the framework execution plan.
+        Resolve the left/right feature UUIDs and frameworks for an APPEND or UNION link.
 
-        This function identifies the left and right feature UUIDs required for a join operation,
-        validates the frameworks and indices, and constructs a JoinStep.
+        Identifies the left and right feature UUIDs required for the join and validates the frameworks
+        and indices; append and union never invert, so the resolved sides stay in declared order.
         """
 
         # Unpack link-related data
@@ -781,14 +828,7 @@ class ExecutionPlan:
         if link_fw[2] != source_framework:
             raise ValueError(self._append_or_union_orientation_error(link, "right", link_fw[2], source_framework))
 
-        return JoinStep(
-            link=link,
-            destination_framework=destination_framework,
-            source_framework=source_framework,
-            required_uuids={left_feature_uuid, right_feature_uuid},
-            destination_framework_uuids={left_feature_uuid},
-            source_framework_uuids={right_feature_uuid},
-        )
+        return AppendOrUnionSides(destination_framework, source_framework, left_feature_uuid, right_feature_uuid)
 
     def reduce_children_to_one_level(self, children_uuids: set[UUID], graph: Graph) -> set[UUID]:
         """

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -144,6 +144,11 @@ class ExecutionPlan:
         self.execution_plan = self.add_tfs(fw_execution_plan, graph)
         self.raise_on_step_cycle(self.execution_plan)
 
+        # Only read during add_joinstep above; ExecutionPlan gets deepcopy'd on every Engine.compute()
+        # call, so this (potentially O(#features), UUID-keyed) dict and its live reference into
+        # ResolveComputeFrameworks's own dict must not linger past the plan build that needs it.
+        self.declared_frameworks = {}
+
     def add_feature_group_step(
         self,
         queue: PlannedQueue,
@@ -647,11 +652,22 @@ class ExecutionPlan:
             elif result is True:
                 pass
             else:
-                if swap_sides:
+                # case_link_fw_is_equal_to_children_fw and case_link_equal_feature_groups both
+                # guarantee, by construction, that result[0] runs on link_fw[1] and result[1] runs
+                # on link_fw[2]; unlike the nearest-split-derived swap_sides, that framework
+                # identity cannot disagree with which side the case helper actually bound. Only
+                # fall back to swap_sides when the frameworks coincide and identity cannot decide.
+                if destination_framework != source_framework:
+                    if destination_framework == link_fw[1]:
+                        destination_framework_uuids, source_framework_uuids = result
+                    else:
+                        source_framework_uuids, destination_framework_uuids = result
+                elif swap_sides:
                     source_framework_uuids, destination_framework_uuids = result
                 else:
                     destination_framework_uuids, source_framework_uuids = result
 
+        join_step_required_uuids: set[UUID]
         if link.jointype in (JoinType.APPEND, JoinType.UNION):
             sides = self.resolve_append_or_union_sides(link, link_fw, required_uuids, graph, pre_execution_plan)
             destination_framework = sides.destination_framework
@@ -662,7 +678,7 @@ class ExecutionPlan:
             left_uuids = frozenset({sides.left_uuid})
             right_uuids = frozenset({sides.right_uuid})
             # Append/union gates only on its own two feature uuids, not on the general required_uuids.
-            join_step_required_uuids: set[UUID] = {sides.left_uuid, sides.right_uuid}
+            join_step_required_uuids = {sides.left_uuid, sides.right_uuid}
         else:
             side = JoinSide.RIGHT if swap_sides else JoinSide.LEFT
             destination = frozenset(destination_framework_uuids)
@@ -699,13 +715,13 @@ class ExecutionPlan:
             token=uuid4(),
         )
         js = JoinStep(
-            link,
-            record.destination_framework,
-            record.source_framework,
-            join_step_required_uuids,
-            set(record.destination_uuids),
-            set(record.source_uuids),
-            record.inverted,
+            link=link,
+            destination_framework=record.destination_framework,
+            source_framework=record.source_framework,
+            required_uuids=join_step_required_uuids,
+            destination_framework_uuids=set(record.destination_uuids),
+            source_framework_uuids=set(record.source_uuids),
+            swap_merge_sides=record.inverted,
             token=record.token,
         )
         self.planned_records.append(record)

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -10,7 +10,7 @@ from typing import NamedTuple
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.link import JoinType, Link
+from mloda.core.abstract_plugins.components.link import JoinType
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
@@ -33,17 +33,6 @@ class ResolvedJoinSide:
     index: Index
     uuids: frozenset[UUID]
     declared_frameworks: frozenset[type[ComputeFramework]]
-
-
-@dataclass(frozen=True)
-class PlannedOrientation:
-    """The join an orientation decided, not just the trekker key it was planned under."""
-
-    link: Link
-    consumers: frozenset[UUID]
-    destination_side: JoinSide
-    left_uuids: frozenset[UUID]
-    right_uuids: frozenset[UUID]
 
 
 @dataclass(frozen=True)
@@ -85,8 +74,6 @@ class ResolvedJoin:
     # Join dependency edges only, not the write serialization edges add_tfs adds later.
     depends_on: frozenset[UUID]
     token: UUID
-    # Correlation only, never authoritative: the join step this record shadows.
-    shadowed_step_uuid: UUID
 
     @property
     def inverted(self) -> bool:

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -1,6 +1,6 @@
-"""The materialized join decision: one record per planned join orientation.
-
-Shadow mode, nothing runs yet. Metadata only (classes, uuids, indices, scalars), so a record pickles to a worker.
+"""The materialized join decision: one record per planned join orientation, and the JoinStep that
+runs it is built from the record's own fields. Metadata only (classes, uuids, indices, scalars), so
+a record pickles to a worker.
 """
 
 from collections.abc import Iterable, Mapping

--- a/mloda/core/prepare/resolved_join.py
+++ b/mloda/core/prepare/resolved_join.py
@@ -44,8 +44,6 @@ class PlannedOrientation:
     destination_side: JoinSide
     left_uuids: frozenset[UUID]
     right_uuids: frozenset[UUID]
-    # True when destination/source uuids are already in declared left/right order (INNER/LEFT/RIGHT joins only).
-    sides_in_declared_order: bool = False
 
 
 @dataclass(frozen=True)
@@ -94,9 +92,6 @@ class ResolvedJoin:
     def inverted(self) -> bool:
         return self.destination_side is JoinSide.RIGHT
 
-    # Known gap: on a case-override orientation whose destination_side is RIGHT, destination/source below can
-    # name a different uuid set than destination_uuids/source_uuids; see
-    # test_a_case_override_right_destination_crosses_the_legacy_destination_uuids.
     @property
     def destination(self) -> ResolvedJoinSide:
         return self.right if self.inverted else self.left

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -1,6 +1,5 @@
-"""Materializes the join decision run_link made as records, and signs the legacy join steps the same way.
-
-Shadow mode: the two signature sets must agree and divergence raises; nothing here changes what the plan runs.
+"""Helpers for the ResolvedJoin record: a side builder, dependency-edge wiring, and a signature
+cross-check between a record and the JoinStep built from it. Divergence there is a construction bug.
 """
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -50,8 +49,8 @@ def wire_join_dependencies(records: Sequence[ResolvedJoin], join_steps: Iterable
     return tuple(resolved)
 
 
-def _legacy_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) -> JoinSignature:
-    """The join a legacy step names, with its destination side read off swap_merge_sides."""
+def _joinstep_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) -> JoinSignature:
+    """The join a JoinStep's own fields name, with its destination side read off swap_merge_sides."""
     side = JoinSide.RIGHT if join_step.swap_merge_sides else JoinSide.LEFT
     return JoinSignature(
         link_uuid=join_step.link.uuid,
@@ -67,21 +66,21 @@ def _legacy_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) ->
     )
 
 
-def legacy_join_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSignature]:
+def joinstep_signatures(join_steps: Iterable[JoinStep]) -> frozenset[JoinSignature]:
     steps = list(join_steps)
     link_of_step = {step.uuid: step.link.uuid for step in steps}
-    return frozenset(_legacy_signature(step, link_of_step) for step in steps)
+    return frozenset(_joinstep_signature(step, link_of_step) for step in steps)
 
 
 def raise_on_join_plan_divergence(plan: ResolvedJoinPlan, join_steps: Iterable[JoinStep]) -> object:
     """Returns None when the records and the steps sign the same joins; a divergence is a planning bug."""
     recorded = plan.signatures()
-    legacy = legacy_join_signatures(join_steps)
-    if recorded == legacy:
+    from_steps = joinstep_signatures(join_steps)
+    if recorded == from_steps:
         return None
     raise ValueError(
         internal_invariant_error(
             "the resolved join records and the planned join steps sign different joins.",
-            f"only_in_records={sorted(recorded - legacy)}, only_in_steps={sorted(legacy - recorded)}",
+            f"only_in_records={sorted(recorded - from_steps)}, only_in_steps={sorted(from_steps - recorded)}",
         )
     )

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -41,10 +41,19 @@ def wire_join_dependencies(records: Sequence[ResolvedJoin], join_steps: Iterable
     """Fill in each record's depends_on: which other records' tokens its own JoinStep waits for."""
     steps_by_uuid = {step.uuid: step for step in join_steps}
     all_tokens = {record.token for record in records}
+    if all_tokens != set(steps_by_uuid):
+        raise ValueError(
+            internal_invariant_error(
+                "every resolved join record must have a matching planned JoinStep.",
+                f"record_tokens={sorted(str(token) for token in all_tokens)}, "
+                f"join_step_uuids={sorted(str(uuid) for uuid in steps_by_uuid)}",
+            )
+        )
     resolved = []
     for record in records:
         join_step = steps_by_uuid[record.token]
-        depends_on = frozenset(uuid for uuid in join_step.required_uuids if uuid in all_tokens and uuid != record.token)
+        # A step never waits for its own token: expand_link_tokens already excludes it (expanded - step.get_uuids()).
+        depends_on = frozenset(uuid for uuid in join_step.required_uuids if uuid in all_tokens)
         resolved.append(replace(record, depends_on=depends_on))
     return tuple(resolved)
 

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -55,13 +55,7 @@ def build_resolved_join_plan(
         side = orientation.destination_side
         destination = frozenset(join_step.destination_framework_uuids)
         source = frozenset(join_step.source_framework_uuids)
-        # The generic framework partition needs the side to recover declared order; sides_in_declared_order
-        # already has it.
-        resolved_left, resolved_right = (
-            (destination, source)
-            if side is JoinSide.LEFT or orientation.sides_in_declared_order
-            else (source, destination)
-        )
+        resolved_left, resolved_right = (destination, source) if side is JoinSide.LEFT else (source, destination)
         if (
             orientation.left_uuids <= resolved_left
             and orientation.right_uuids <= resolved_right

--- a/mloda/core/prepare/resolved_join_builder.py
+++ b/mloda/core/prepare/resolved_join_builder.py
@@ -5,19 +5,16 @@ Shadow mode: the two signature sets must agree and divergence raises; nothing he
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import replace
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.core.step.join_step import JoinStep
-from mloda.core.prepare.resolve_links import LinkFrameworkTrekker
 from mloda.core.prepare.resolved_join import (
-    DeclinedOrientation,
     JoinSide,
     JoinSignature,
-    PlannedOrientation,
     ResolvedJoin,
     ResolvedJoinPlan,
     ResolvedJoinSide,
@@ -28,7 +25,7 @@ from mloda.core.prepare.resolved_join import (
 DeclaredFrameworks = Mapping[UUID, frozenset[type[ComputeFramework]]]
 
 
-def _side(
+def build_resolved_join_side(
     feature_group: type[FeatureGroup],
     index: Index,
     uuids: frozenset[UUID],
@@ -41,60 +38,16 @@ def _side(
     return ResolvedJoinSide(feature_group, index, uuids, frozenset(frameworks))
 
 
-def build_resolved_join_plan(
-    planned: Sequence[tuple[PlannedOrientation, JoinStep]],
-    declined: Sequence[LinkFrameworkTrekker],
-    declared_frameworks: DeclaredFrameworks,
-) -> ResolvedJoinPlan:
-    """One record per planned orientation, ordered as the orientations were planned."""
-    records: list[ResolvedJoin] = []
-    token_by_step: dict[UUID, UUID] = {}
-
-    for orientation, join_step in planned:
-        link = orientation.link
-        side = orientation.destination_side
-        destination = frozenset(join_step.destination_framework_uuids)
-        source = frozenset(join_step.source_framework_uuids)
-        resolved_left, resolved_right = (destination, source) if side is JoinSide.LEFT else (source, destination)
-        if (
-            orientation.left_uuids <= resolved_left
-            and orientation.right_uuids <= resolved_right
-            and orientation.left_uuids != orientation.right_uuids
-        ):
-            left_uuids, right_uuids = orientation.left_uuids, orientation.right_uuids
-        else:
-            # The step's sets, so a record can never name parents outside its own destination/source claim.
-            # A self link's declared sides are identical (split_by_declared_side can't split one feature group
-            # from itself), so it always lands here too.
-            left_uuids, right_uuids = resolved_left, resolved_right
-
-        record = ResolvedJoin(
-            link_uuid=link.uuid,
-            jointype=link.jointype,
-            left=_side(link.left_feature_group, link.left_index, left_uuids, declared_frameworks),
-            right=_side(link.right_feature_group, link.right_index, right_uuids, declared_frameworks),
-            destination_side=side,
-            destination_uuids=destination,
-            source_uuids=source,
-            destination_framework=join_step.destination_framework,
-            source_framework=join_step.source_framework,
-            consumers=orientation.consumers,
-            depends_on=frozenset(),
-            token=uuid4(),
-            shadowed_step_uuid=join_step.uuid,
-        )
-        records.append(record)
-        token_by_step[join_step.uuid] = record.token
-
-    # An order edge is keyed by link uuid, so a producer fans its tokens over every record it built.
-    resolved = tuple(
-        replace(
-            record,
-            depends_on=frozenset(token_by_step[uuid] for uuid in step.required_uuids if uuid in token_by_step),
-        )
-        for record, (_, step) in zip(records, planned)
-    )
-    return ResolvedJoinPlan(resolved, tuple(DeclinedOrientation(key[0].uuid, key[1], key[2]) for key in declined))
+def wire_join_dependencies(records: Sequence[ResolvedJoin], join_steps: Iterable[JoinStep]) -> tuple[ResolvedJoin, ...]:
+    """Fill in each record's depends_on: which other records' tokens its own JoinStep waits for."""
+    steps_by_uuid = {step.uuid: step for step in join_steps}
+    all_tokens = {record.token for record in records}
+    resolved = []
+    for record in records:
+        join_step = steps_by_uuid[record.token]
+        depends_on = frozenset(uuid for uuid in join_step.required_uuids if uuid in all_tokens and uuid != record.token)
+        resolved.append(replace(record, depends_on=depends_on))
+    return tuple(resolved)
 
 
 def _legacy_signature(join_step: JoinStep, link_of_step: Mapping[UUID, UUID]) -> JoinSignature:

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -53,7 +53,7 @@ STACK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link
 
 STACK_INVERSION_REASON = (
     "the inverted orientation is dropped before the JoinStep is built; a fix has to move the left-framework "
-    "invariant in create_joinstep_in_case_of_append_or_union with it, since neither append nor union commutes"
+    "invariant in resolve_append_or_union_sides with it, since neither append nor union commutes"
 )
 
 MODES = pytest.mark.parametrize("modes", [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}])

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -625,9 +625,8 @@ def test_a_trekker_inverted_after_queueing_swaps_the_merge_sides() -> None:
 
 
 def test_a_hand_built_inconsistent_trekker_key_yields_a_consistent_joinstep() -> None:
-    """This trekker key contradicts the graph, so create_link_trekker_key never reaches this state; run_link still
-    orients the case-override result by the destination side, so destination_framework_uuids runs on
-    destination_framework."""
+    """This trekker key contradicts the graph, so create_link_trekker_key never reaches this state; run_link
+    still orients the case-override result by the destination side."""
     planned = _pair_scenario()
     _trek(planned, PandasDataFrame, PyArrowTable)
 

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -624,19 +624,19 @@ def test_a_trekker_inverted_after_queueing_swaps_the_merge_sides() -> None:
     assert join_step.swap_merge_sides is True
 
 
-def test_a_hand_built_inconsistent_trekker_key_yields_an_inconsistent_joinstep() -> None:
-    """This trekker key contradicts the graph, so create_link_trekker_key never reaches this state."""
+def test_a_hand_built_inconsistent_trekker_key_yields_a_consistent_joinstep() -> None:
+    """This trekker key contradicts the graph, so create_link_trekker_key never reaches this state; run_link still
+    orients the case-override result by the destination side, so destination_framework_uuids runs on
+    destination_framework."""
     planned = _pair_scenario()
     _trek(planned, PandasDataFrame, PyArrowTable)
 
     join_step = _run(planned, PyArrowTable, PandasDataFrame)
 
-    # The frameworks and the uuid sets disagree: the destination is Pandas while its uuid runs in PyArrow.
-    # A rewrite that carries one record per join decision is free to answer differently here.
     assert isinstance(join_step, JoinStep)
     assert join_step.destination_framework is PandasDataFrame
-    assert join_step.destination_framework_uuids == {planned.left_uuid}
-    assert join_step.source_framework_uuids == {planned.right_uuid}
+    assert join_step.destination_framework_uuids == {planned.right_uuid}
+    assert join_step.source_framework_uuids == {planned.left_uuid}
     assert join_step.swap_merge_sides is True
 
 

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -85,6 +85,10 @@ class ResolvedJoinPairLeftDescendant(ResolvedJoinPairLeft):
     """Matches the declared left side polymorphically, at inheritance distance one."""
 
 
+class ResolvedJoinPairRightDescendant(ResolvedJoinPairRight):
+    """Matches the declared right side polymorphically, at inheritance distance one."""
+
+
 class ResolvedJoinOtherLeft(FeatureGroup):
     pass
 
@@ -447,6 +451,36 @@ def _case_override_beats_nearer_wrong_framework_left() -> Built:
     return _finish(planned, link, Sides(far_left.uuid, right.uuid, child.uuid))
 
 
+def _case_override_disagrees_with_the_nearest_split() -> Built:
+    """Both sides have a nearer, wrong-framework sibling and a farther, correct-framework one; the case helper
+    selects the farther pair on both sides. destination_framework and source_framework differ here (unlike
+    _case_override_beats_nearer_wrong_framework_left's shared framework), so a swap decision based on the
+    nearest split's frameworks (which never sees the case-selected, farther parents) can disagree with the
+    framework the case helper actually bound to each side."""
+    planned = _planned()
+    link = _pair_link()
+
+    nearest_left = feature("resolved_join_split_disagree_nearest_left", PythonDictFramework, link.left_index)
+    far_left = feature("resolved_join_split_disagree_far_left", PyArrowTable, link.left_index)
+    nearest_right = feature("resolved_join_split_disagree_nearest_right", PyArrowTable, link.right_index)
+    far_right = feature("resolved_join_split_disagree_far_right", PandasDataFrame, link.right_index)
+    child = feature("resolved_join_split_disagree_child", PyArrowTable)
+
+    planned.graph.add_node(nearest_left.uuid, NodeProperties(nearest_left, ResolvedJoinPairLeft))
+    planned.graph.add_node(far_left.uuid, NodeProperties(far_left, ResolvedJoinPairLeftDescendant))
+    planned.graph.add_node(nearest_right.uuid, NodeProperties(nearest_right, ResolvedJoinPairRight))
+    planned.graph.add_node(far_right.uuid, NodeProperties(far_right, ResolvedJoinPairRightDescendant))
+    planned.queue.append((ResolvedJoinPairLeft, {nearest_left}))
+    planned.queue.append((ResolvedJoinPairLeftDescendant, {far_left}))
+    planned.queue.append((ResolvedJoinPairRight, {nearest_right}))
+    planned.queue.append((ResolvedJoinPairRightDescendant, {far_right}))
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    _add_child(planned, child, nearest_left, far_left, nearest_right, far_right)
+    trek(planned.link_trekker, link, (PyArrowTable, PandasDataFrame), child.uuid)
+
+    return _finish(planned, link, Sides(far_left.uuid, far_right.uuid, child.uuid))
+
+
 def _join_steps(plan: ExecutionPlan) -> list[JoinStep]:
     return [step for step in plan if isinstance(step, JoinStep)]
 
@@ -683,6 +717,7 @@ def test_a_decline_reached_through_the_inversion_branch_records_the_orientation_
         _link_with_an_unlinked_third_parent,
         _case_override_inverted,
         _case_override_beats_nearer_wrong_framework_left,
+        _case_override_disagrees_with_the_nearest_split,
     ],
     ids=[
         "inner",
@@ -696,9 +731,10 @@ def test_a_decline_reached_through_the_inversion_branch_records_the_orientation_
         "unlinked_third_parent",
         "case_override_inverted",
         "case_override_beats_nearer_wrong_framework_left",
+        "case_override_disagrees_with_nearest_split",
     ],
 )
-def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[], Any]) -> None:
+def test_the_records_sign_the_joins_the_join_steps_sign(build: Callable[[], Any]) -> None:
     built = build()
 
     join_steps = _join_steps(built.plan)
@@ -708,6 +744,20 @@ def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[
     assert len(resolved.records) == len(join_steps)
     assert resolved.signatures() == built.plan.join_signatures_at_build
     assert {record.token for record in resolved.records} == {step.uuid for step in join_steps}
+
+
+def test_raise_on_join_plan_divergence_raises_on_a_mutated_step() -> None:
+    from mloda.core.prepare.resolved_join_builder import raise_on_join_plan_divergence
+
+    built = _declared_pair()
+    join_steps = _join_steps(built.plan)
+
+    assert raise_on_join_plan_divergence(built.plan.resolved_join_plan, join_steps) is None
+
+    join_steps[0].swap_merge_sides = not join_steps[0].swap_merge_sides
+
+    with pytest.raises(ValueError):
+        raise_on_join_plan_divergence(built.plan.resolved_join_plan, join_steps)
 
 
 def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_steps_side() -> None:
@@ -777,6 +827,18 @@ def test_a_case_override_right_destination_matches_the_destination_uuids() -> No
     assert record.source.uuids <= record.source_uuids
 
 
+def test_a_case_override_disagreeing_with_the_nearest_split_still_binds_the_selected_framework() -> None:
+    built = _case_override_disagrees_with_the_nearest_split()
+
+    assert len(_join_steps(built.plan)) == 1, "the shape must plan exactly one JoinStep for this to say anything"
+    record = _one_record(built.plan, built.link)
+    assert record.destination_framework is PyArrowTable
+    assert record.destination_uuids == {built.sides.left_uuid}
+    assert record.source_uuids == {built.sides.right_uuid}
+    assert record.destination.uuids <= record.destination_uuids
+    assert record.source.uuids <= record.source_uuids
+
+
 def test_the_record_leaves_out_the_write_serialization_edges_add_tfs_adds() -> None:
     built = _two_links()
 
@@ -818,7 +880,7 @@ def test_an_order_edge_makes_the_consumer_records_depend_on_the_producer_record_
         assert record.signature(resolved.link_of_token()).depends_on_links == (str(chain.producer.uuid),)
 
 
-def test_the_record_and_the_legacy_transform_hop_name_opposite_directions() -> None:
+def test_the_record_and_the_transform_hop_name_opposite_directions() -> None:
     built = _inverted_pair()
 
     record = _one_record(built.plan, built.link)

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -773,18 +773,19 @@ def test_a_case_override_beats_a_nearer_wrong_framework_left() -> None:
     assert record.destination_side is JoinSide.RIGHT
     assert record.left.uuids == {built.sides.left_uuid}
     assert record.right.uuids == {built.sides.right_uuid}
+    assert record.destination.uuids <= record.destination_uuids
+    assert record.source.uuids <= record.source_uuids
 
 
-def test_a_case_override_right_destination_crosses_the_legacy_destination_uuids() -> None:
-    """Known, accepted gap: destination (case-helper order) and destination_uuids (legacy mirror) diverge once a
-    case override lands on a RIGHT destination side; left open for a later epic step, not chased further here."""
+def test_a_case_override_right_destination_matches_the_destination_uuids() -> None:
+    """A RIGHT-destination case override must keep destination_uuids in step with destination, not crossed."""
     built = _case_override_inverted()
 
     record = _one_record(built.plan, built.link)
 
     assert record.destination_side is JoinSide.RIGHT
-    assert not (record.destination.uuids <= record.destination_uuids)
-    assert not (record.source.uuids <= record.source_uuids)
+    assert record.destination.uuids <= record.destination_uuids
+    assert record.source.uuids <= record.source_uuids
 
 
 def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -17,7 +17,7 @@ from mloda.core.prepare.graph.properties import NodeProperties
 from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
 from mloda.core.prepare.resolve_links import LinkTrekker
 from mloda.core.prepare.resolved_join import DeclinedOrientation, JoinSide, JoinSignature, ResolvedJoin
-from mloda.core.prepare.resolved_join_builder import legacy_join_signatures
+from mloda.core.prepare.resolved_join_builder import joinstep_signatures
 from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
 from mloda.provider import DataCreator
@@ -767,7 +767,7 @@ def test_a_case_override_beats_a_nearer_wrong_framework_left() -> None:
 
 
 def test_a_case_override_right_destination_matches_the_destination_uuids() -> None:
-    """A RIGHT-destination case override must keep destination_uuids in step with destination, not crossed."""
+    """A RIGHT-destination case override keeps destination_uuids in step with destination."""
     built = _case_override_inverted()
 
     record = _one_record(built.plan, built.link)
@@ -781,7 +781,7 @@ def test_the_record_leaves_out_the_write_serialization_edges_add_tfs_adds() -> N
     built = _two_links()
 
     recorded = built.plan.resolved_join_plan.signatures()
-    after_tfs = legacy_join_signatures(_join_steps(built.plan))
+    after_tfs = joinstep_signatures(_join_steps(built.plan))
 
     assert after_tfs != recorded, "add_tfs must add an edge here for this to say anything"
     assert _without_depends(after_tfs) == _without_depends(recorded)

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -17,7 +17,7 @@ from mloda.core.prepare.graph.properties import NodeProperties
 from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
 from mloda.core.prepare.resolve_links import LinkTrekker
 from mloda.core.prepare.resolved_join import DeclinedOrientation, JoinSide, JoinSignature, ResolvedJoin
-from mloda.core.prepare.resolved_join_builder import build_resolved_join_plan, legacy_join_signatures
+from mloda.core.prepare.resolved_join_builder import legacy_join_signatures
 from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
 from mloda.provider import DataCreator
@@ -669,18 +669,6 @@ def test_a_decline_reached_through_the_inversion_branch_records_the_orientation_
     assert resolved.declined == (DeclinedOrientation(link.uuid, PyArrowTable, PandasDataFrame),)
 
 
-def test_each_record_names_the_join_step_it_shadows() -> None:
-    built = _two_links()
-    step_of_link = {step.link.uuid: step.uuid for step in _join_steps(built.plan)}
-
-    records = built.plan.resolved_join_plan.records
-
-    assert len(records) == len(step_of_link)
-    for record in records:
-        assert record.shadowed_step_uuid == step_of_link[record.link_uuid]
-        assert record.shadowed_step_uuid != record.token
-
-
 @pytest.mark.parametrize(
     "build",
     [
@@ -719,6 +707,7 @@ def test_the_records_sign_the_joins_the_legacy_join_steps_sign(build: Callable[[
     assert join_steps, "the shape must plan at least one JoinStep for the parity to say anything"
     assert len(resolved.records) == len(join_steps)
     assert resolved.signatures() == built.plan.join_signatures_at_build
+    assert {record.token for record in resolved.records} == {step.uuid for step in join_steps}
 
 
 def test_a_nearest_left_parent_on_a_third_framework_keeps_the_record_on_the_steps_side() -> None:
@@ -788,38 +777,6 @@ def test_a_case_override_right_destination_matches_the_destination_uuids() -> No
     assert record.source.uuids <= record.source_uuids
 
 
-def test_flipping_the_merge_sides_of_a_join_step_breaks_the_parity() -> None:
-    """The signatures only agree while the record derives its destination side from the planned orientation."""
-    built = _declared_pair()
-    join_step = _join_steps(built.plan)[0]
-
-    join_step.swap_merge_sides = not join_step.swap_merge_sides
-    rebuilt = build_resolved_join_plan(
-        built.plan.planned_orientations, built.plan.declined_orientations, built.declared_frameworks
-    )
-
-    assert len(rebuilt.records) == len(_join_steps(built.plan)), "an empty rebuild makes the inequality meaningless"
-    assert rebuilt.signatures(), "an empty rebuild makes the inequality meaningless"
-    assert rebuilt.signatures() != legacy_join_signatures([join_step])
-
-
-def test_the_parity_guard_raises_only_when_the_signatures_disagree() -> None:
-    from mloda.core.prepare.resolved_join_builder import raise_on_join_plan_divergence
-
-    built = _declared_pair()
-    join_step = _join_steps(built.plan)[0]
-
-    assert raise_on_join_plan_divergence(built.plan.resolved_join_plan, _join_steps(built.plan)) is None
-
-    join_step.swap_merge_sides = not join_step.swap_merge_sides
-    rebuilt = build_resolved_join_plan(
-        built.plan.planned_orientations, built.plan.declined_orientations, built.declared_frameworks
-    )
-
-    with pytest.raises(ValueError):
-        raise_on_join_plan_divergence(rebuilt, [join_step])
-
-
 def test_the_record_leaves_out_the_write_serialization_edges_add_tfs_adds() -> None:
     built = _two_links()
 
@@ -850,7 +807,6 @@ def test_an_order_edge_makes_the_consumer_records_depend_on_the_producer_record_
     resolved = chain.plan.resolved_join_plan
     producer_records = resolved.records_of_link(chain.producer.uuid)
     consumer_records = resolved.records_of_link(chain.consumer.uuid)
-    step_uuids = {step.uuid for step in _join_steps(chain.plan)}
 
     assert producer_records, "the producer link must build a record for the edge to point at"
     assert consumer_records, "the consumer link must build a record for the edge to hang off"
@@ -859,7 +815,6 @@ def test_an_order_edge_makes_the_consumer_records_depend_on_the_producer_record_
     for record in consumer_records:
         assert record.depends_on == {produced.token for produced in producer_records}
         assert chain.producer.uuid not in record.depends_on, "a record depends on tokens, not on link uuids"
-        assert record.depends_on.isdisjoint(step_uuids), "a record depends on tokens, not on step uuids"
         assert record.signature(resolved.link_of_token()).depends_on_links == (str(chain.producer.uuid),)
 
 


### PR DESCRIPTION
## Summary

- Builds the `ResolvedJoin` record directly during join planning, then constructs `JoinStep` from the record's own fields, instead of building `JoinStep` first and reconstructing a record from it afterward.
- The record's token becomes `JoinStep`'s own completion token end to end (SYNC, THREADING, MULTIPROCESSING), so the scheduler, worker completion signaling, and the dependency-edge wiring between joins all key off one identity instead of two independently-generated ones.
- Fixes a case where a case-overridden join orientation could bind uuids to the wrong side of the destination/source split: when the orientation a case helper actually selects differs from the one nearest-parent distance alone would pick, a swap decision based only on the nearest split could disagree with the framework the case helper bound to each side, leaving `destination_framework_uuids` naming a uuid that runs on the *source* framework instead.

## Details

- `run_link` now orients a case helper's result by which declared side actually holds the destination framework, not by the nearest-parent split's frameworks; the two only diverge when a case override selects farther-than-nearest parents, but the divergence is silent (it produces a validly-shaped but wrong binding, not an error) so it needed a dedicated fix rather than a side effect of the reordering below.
- The append/union join path resolves its sides the same way and constructs its `JoinStep` from a record too, instead of building a `JoinStep` directly and having it separately shadowed afterward.
- `JoinStep` takes an optional token argument (defaults to a fresh one, so existing direct construction is unaffected) that the planner now always supplies from the record it built.
- The dependency-edge wiring between joins collapses to a direct token lookup now that a record's token and its step's uuid are the same value by construction, with an explicit check for the invariant instead of a lookup that would otherwise fail unhelpfully if it were ever violated.
- The record's own left/right side identity and the `destination`/`source` properties that follow the destination side are now always consistent with each other, closing a gap where they could name different uuid sets for one specific case-override shape.

No behavior change to non-case-override joins.