### PR TITLE
fix: guard plugin-owned exception and Domain.name reads from escaping degraded reads

### DIFF
--- a/mloda/core/abstract_plugins/components/match_hook.py
+++ b/mloda/core/abstract_plugins/components/match_hook.py
@@ -7,7 +7,6 @@ Each keeps only its own recording and rollback now, driven by the outcome this h
 
 from __future__ import annotations
 
-import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -20,7 +19,7 @@ from mloda.core.abstract_plugins.components.match_rejection import (
     record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.utils import is_match_abort, safe_field
+from mloda.core.abstract_plugins.components.utils import is_match_abort, safe_exc_str, safe_field
 
 if TYPE_CHECKING:
     from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -92,7 +91,7 @@ def probe_match_criteria(
             # Parity with the canonical seam: the class name owns the record and the reason is str(exc);
             # the owner name is harvested by value, never by key, so a degraded name is harmless.
             owner = safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>")
-            reason = safe_field(functools.partial(str, value_rejection), type(value_rejection).__name__)
+            reason = safe_exc_str(value_rejection)
             record_match_rejection(owner, reason)
         recorded = MATCH_REJECTION_REASONS.get() or {}
         # Harvest only on a non-match; the first recorded reason wins (insertion order).

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 from typing import Any, Callable, TypeVar
 
 import logging
@@ -43,6 +42,14 @@ def is_match_abort(exc: BaseException) -> bool:
     return exc.__dict__.get(MATCH_ABORT_FLAG, False) is True
 
 
+def safe_exc_str(exc: BaseException) -> str:
+    """str(exc), guarded: a __str__ that itself raises degrades to the exception's type name."""
+    try:
+        return str(exc)
+    except Exception:  # noqa: BLE001  (the exception's own __str__ is plugin-owned and must not escape)
+        return type(exc).__name__
+
+
 def safe_field(
     read: Callable[[], T],
     fallback: T,
@@ -59,14 +66,13 @@ def safe_field(
     except catching as exc:
         if field:
             # str(exc), not exc: a retained log record must not pin the traceback, its frames and the plugin class.
-            logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, str(exc))
+            logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, safe_exc_str(exc))
         return fallback
 
 
 def contained_raise_reason(exc: BaseException) -> str:
     """Text form of a contained raise: type and message, never the exception object."""
-    # partial, not a lambda: exc binds eagerly, so no closure keeps it and its traceback alive.
-    return f"raised {type(exc).__name__}: {safe_field(functools.partial(str, exc), type(exc).__name__)}"
+    return f"raised {type(exc).__name__}: {safe_exc_str(exc)}"
 
 
 def safe_field_with_error(
@@ -78,7 +84,7 @@ def safe_field_with_error(
     try:
         return read(), None
     except catching as exc:
-        message = str(exc)
+        message = safe_exc_str(exc)
         return fallback, message if message.strip() else type(exc).__name__
 
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,4 +1,3 @@
-import functools
 import inspect
 from collections.abc import Sequence
 from copy import deepcopy
@@ -32,6 +31,7 @@ from mloda.core.abstract_plugins.components.utils import (
     as_str,
     contained_raise_log_level,
     contained_raise_reason,
+    safe_exc_str,
     safe_field,
 )
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -233,13 +233,17 @@ class IdentifyFeatureGroupClass:
         domain, error = self._domain_outcome(feature_group)
         # error, not domain, is what tells a raise apart from a malformed return: both leave domain unusable.
         if error is not None:
-            logger.warning("Degraded field '%s': %s: %s", field, type(error).__name__, str(error))
+            logger.warning("Degraded field '%s': %s", field, contained_raise_reason(error))
             return None
         if not isinstance(domain, Domain):
             # Annotated to return a Domain; a provider that returns something else costs only its own suffix.
             logger.warning("Degraded field '%s': expected Domain, got %s", field, type(domain).__name__)
             return None
-        return domain.name
+        try:
+            return domain.name
+        except Exception as exc:  # noqa: BLE001  (plugin-owned property read; same contract as the two guards above)
+            logger.warning("Degraded field '%s': %s", field, contained_raise_reason(exc))
+            return None
 
     def _declared_frameworks_of(self, feature_group: type[FeatureGroup]) -> frozenset[type[ComputeFramework]]:
         """Memoized compute_framework_definition(), which drives compute_framework_rule(): once per candidate.
@@ -361,7 +365,8 @@ class IdentifyFeatureGroupClass:
         if self._domain_name(feature_group) is None:
             # A raise leaves the gate undecided, so nothing is known and the candidate stays live. A malformed
             # return is decided: the gate compares it and drops the candidate, for every name it declares.
-            return error is None
+            # A raising Domain.name is also undecided: error is None yet domain is still a genuine Domain.
+            return error is None and not isinstance(domain, Domain)
         # The gate's own comparison, never a name one: a Domain subclass with a custom __eq__ must not pass the
         # gate and fail this retest.
         return domain != feature.domain
@@ -620,7 +625,7 @@ class IdentifyFeatureGroupClass:
                 # A plugin-owned read past the hook call's containment, so it degrades instead of escaping the seam.
                 safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
                 feature.name,
-                safe_field(functools.partial(str, exc), type(exc).__name__),
+                safe_exc_str(exc),
             )
         elif probe.matcher_error is not None:
             reason = contained_raise_reason(probe.matcher_error)
@@ -639,7 +644,7 @@ class IdentifyFeatureGroupClass:
         return probe.matched
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
-        """Decision-side domain gate: unguarded, so a raising get_domain() still fails the engine loudly."""
+        """Decision-side domain gate: unguarded, so a raising get_domain() or Domain.name fails the engine loudly."""
         if not feature.domain:
             return True
         domain, error = self._domain_outcome(feature_group)

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
@@ -176,6 +176,42 @@ class TestSafeFieldSuccessPathIsSilent:
         assert _module_messages(caplog) == []
 
 
+class TestSafeFieldSwallowsRaisingStr:
+    """A caught exception whose own __str__ raises must not escape the except block."""
+
+    def test_swallowed_read_with_raising_str_returns_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        class Bad(Exception):
+            def __str__(self) -> str:
+                raise RuntimeError("str fails")
+
+        def raises() -> str:
+            raise Bad("original message")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable", field="description")
+
+        assert result == "unavailable"
+
+    def test_swallowed_read_with_raising_str_logs_one_warning_naming_the_type(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        class Bad(Exception):
+            def __str__(self) -> str:
+                raise RuntimeError("str fails")
+
+        def raises() -> str:
+            raise Bad("original message")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            safe_field(raises, "unavailable", field="description")
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, f"Expected exactly one WARNING, got {messages}"
+        # The full format, not a substring check: "Bad" also fills the type-name slot (%s: %s: %s), so a
+        # substring check alone would pass even if the third (guarded-str) slot rendered something else.
+        assert messages[0] == "Degraded field 'description': Bad: Bad"
+
+
 class TestSafeFieldFieldLabelKeepsExistingBehavior:
     """The field label is additive: fallback and narrow-catching semantics are unchanged."""
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
@@ -1,6 +1,7 @@
-"""Failing tests pinning the safe_field_with_error helper (issue #639 follow-up).
+"""Tests pinning the safe_field_with_error helper (issue #639 follow-up).
 
-The helper does not exist yet; the import failure is the intended red failure.
+TestSbfixSafeFieldWithErrorSwallowsRaisingStr is a red-phase test: it currently fails because a
+caught exception's own str(exc) is read eagerly and escapes the guard.
 """
 
 from mloda.core.abstract_plugins.components.utils import safe_field_with_error
@@ -43,3 +44,21 @@ class TestSbfixSafeFieldWithError:
         assert value == 0
         assert error
         assert "RuntimeError" in error
+
+
+class TestSbfixSafeFieldWithErrorSwallowsRaisingStr:
+    """A caught exception whose own __str__ raises must not escape safe_field_with_error."""
+
+    def test_swallowed_read_with_raising_str_does_not_escape(self) -> None:
+        class Bad(Exception):
+            def __str__(self) -> str:
+                raise RuntimeError("str fails")
+
+        def raises() -> int:
+            raise Bad("original message")
+
+        value, error = safe_field_with_error(raises, 0)
+
+        assert value == 0
+        # Once fixed, the guarded str() degrades to the type name, same as safe_field's own guard.
+        assert error == "Bad"

--- a/tests/test_core/test_prepare/test_domain_name_degraded_read.py
+++ b/tests/test_core/test_prepare/test_domain_name_degraded_read.py
@@ -1,0 +1,136 @@
+"""Direct unit tests for IdentifyFeatureGroupClass._domain_name and _fails_domain_gate.
+
+A plugin-owned Domain read (get_domain() or the Domain.name property) must never escape either
+method, and a RAISE inside that read must leave the domain gate undecided, not decided/dead.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.helpers.plugin_stubs import StubFeatureGroup
+
+IDENTIFY_LOGGER_NAME = IdentifyFeatureGroupClass.__module__
+
+
+def _warning_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and record.name == IDENTIFY_LOGGER_NAME
+    ]
+
+
+class RaisingNameDomain(Domain):
+    """A Domain subclass that IS-A Domain but whose name property raises."""
+
+    def __init__(self) -> None:
+        pass
+
+    @property
+    def name(self) -> str:  # type: ignore[override]  # deliberate LSP violation: the test needs a raising read
+        raise RuntimeError("domain name explodes")
+
+
+class BadStrError(Exception):
+    def __str__(self) -> str:
+        raise RuntimeError("str fails")
+
+
+def _build_raising_name_domain_fg() -> type[StubFeatureGroup]:
+    """Mint a StubFeatureGroup subclass, per test, whose get_domain() returns a raising-name Domain.
+
+    Minted inside a function rather than at module level: a module-level FeatureGroup subclass stays
+    forever in FeatureGroup.__subclasses__() for the rest of the pytest-xdist worker's session.
+    """
+
+    class RaisingNameDomainFG(StubFeatureGroup):
+        @classmethod
+        def get_domain(cls) -> Domain:
+            return RaisingNameDomain()
+
+    return RaisingNameDomainFG
+
+
+def _build_raising_get_domain_fg() -> type[StubFeatureGroup]:
+    """Mint a StubFeatureGroup subclass, per test, whose get_domain() itself raises a BadStrError."""
+
+    class RaisingGetDomainFG(StubFeatureGroup):
+        @classmethod
+        def get_domain(cls) -> Domain:
+            raise BadStrError("original message")
+
+    return RaisingGetDomainFG
+
+
+class TestDomainNameSwallowsRaisingNameProperty:
+    """get_domain() returns a Domain instance whose .name property raises."""
+
+    def test_returns_none_instead_of_raising(self, caplog: pytest.LogCaptureFixture) -> None:
+        raising_name_domain_fg = _build_raising_name_domain_fg()
+
+        with caplog.at_level(logging.WARNING, logger=IDENTIFY_LOGGER_NAME):
+            result = IdentifyFeatureGroupClass()._domain_name(raising_name_domain_fg)
+
+        assert result is None
+
+    def test_logs_one_warning_naming_the_field(self, caplog: pytest.LogCaptureFixture) -> None:
+        raising_name_domain_fg = _build_raising_name_domain_fg()
+
+        with caplog.at_level(logging.WARNING, logger=IDENTIFY_LOGGER_NAME):
+            IdentifyFeatureGroupClass()._domain_name(raising_name_domain_fg)
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, f"Expected exactly one WARNING, got {messages}"
+        assert f"{raising_name_domain_fg.get_class_name()}.get_domain" in messages[0]
+
+
+class TestDomainNameSwallowsRaisingStrOnGetDomainError:
+    """get_domain() raises an exception whose own __str__ raises."""
+
+    def test_returns_none_instead_of_raising(self, caplog: pytest.LogCaptureFixture) -> None:
+        raising_get_domain_fg = _build_raising_get_domain_fg()
+
+        with caplog.at_level(logging.WARNING, logger=IDENTIFY_LOGGER_NAME):
+            result = IdentifyFeatureGroupClass()._domain_name(raising_get_domain_fg)
+
+        assert result is None
+
+    def test_logs_one_warning_naming_the_field_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        raising_get_domain_fg = _build_raising_get_domain_fg()
+
+        with caplog.at_level(logging.WARNING, logger=IDENTIFY_LOGGER_NAME):
+            IdentifyFeatureGroupClass()._domain_name(raising_get_domain_fg)
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, f"Expected exactly one WARNING, got {messages}"
+        # The full format, not two substring checks: "BadStrError" fills both the type-name slot and the
+        # guarded-str fallback slot, so a substring check alone would pass even if the guard were broken.
+        field = f"{raising_get_domain_fg.get_class_name()}.get_domain"
+        assert messages[0] == f"Degraded field '{field}': raised BadStrError: BadStrError"
+
+
+class TestFailsDomainGateSwallowsRaisingNameProperty:
+    """A candidate whose Domain.name raises must leave the domain gate undecided, not decided/dead.
+
+    _fails_domain_gate's own contract (see its docstring) is: a RAISE anywhere in reading the domain
+    leaves the gate undecided (False, candidate stays live), while a MALFORMED RETURN is decided (True,
+    candidate drops). get_domain() here returns a real Domain whose .name property raises: a RAISE, not
+    a malformed return, so the gate must return False.
+    """
+
+    def test_raising_name_property_leaves_gate_undecided(self) -> None:
+        raising_name_domain_fg = _build_raising_name_domain_fg()
+        feature = Feature("some_name", domain="some_domain")
+
+        result = IdentifyFeatureGroupClass()._fails_domain_gate(raising_name_domain_fg, feature)
+        # Dropped before the assert: a failing assert's traceback would otherwise pin this local, keeping
+        # the class reachable past teardown's gc.collect() and tripping the registry-leak fixture (#845).
+        del raising_name_domain_fg
+
+        assert result is False

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -116,7 +116,11 @@ SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
         "the guard around the marker write; failing to mark must not replace the exception being marked"
     ),
     ("mloda/core/abstract_plugins/components/utils.py", "contained_raise_reason"): (
-        "it swallows only through safe_field, whose degrade-one-field contract is declared above"
+        "it swallows only through safe_exc_str, the same guarded str(exc)-or-type-name helper safe_field uses"
+    ),
+    ("mloda/core/abstract_plugins/components/utils.py", "safe_exc_str"): (
+        "guards a single str(exc) call and degrades to the exception's type name; a plugin-owned __str__ "
+        "must not escape the seam that is rendering the exception's own message"
     ),
     ("mloda/core/abstract_plugins/components/utils.py", "get_all_subclasses"): (
         "real edge, collided verdict: it swallows nothing itself; the set.add / set.update names do"


### PR DESCRIPTION
## Summary

A degraded read's own fallback path could itself raise. `safe_field` and `safe_field_with_error` both called `str(exc)` eagerly on a caught plugin exception before logging or returning it, so an exception whose own `__str__` raises escaped the guard meant to contain it. Separately, the domain-name lookup in feature resolution read `domain.name` after only an `isinstance(domain, Domain)` check, so a `Domain` subclass with a raising `name` property could also escape.

## Changes

- Added a single guarded `str(exc)`-or-type-name helper in `mloda/core/abstract_plugins/components/utils.py` and reused it everywhere the same pattern was duplicated (`safe_field`, `safe_field_with_error`, `contained_raise_reason`, and two call sites in `identify_feature_group.py` / `match_hook.py` that previously spelled it out inline).
- Guarded the `domain.name` read in feature resolution so a raising property degrades to no domain suffix instead of aborting.
- Fixed the domain gate that decides whether a candidate is dead for suggestion purposes: a raising `Domain.name` is now correctly treated as undecided (the candidate stays live), matching how a raising `get_domain()` was already handled, instead of being misclassified as a definitive mismatch.
- Clarified that the decision-side domain gate still fails loudly on a raising `Domain.name`, by the same existing policy as a raising `get_domain()`.

## Test plan

- [x] New and updated unit tests covering a raising `__str__` through `safe_field`, `safe_field_with_error`, and `contained_raise_reason`, and a raising `Domain.name` through the domain-name lookup and the domain gate.
- [x] Full `tox` gate passes locally (tests, ruff format/check, mypy --strict, bandit).