### PR TITLE
fix: wire the surviving transform hop uuid on an add_tfs dedup

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -96,7 +96,7 @@ class Engine:
         connection_map: dict[type[ComputeFramework], Any] = {}
         if self.data_access_collection is None:
             return connection_map
-        for tfs in self.execution_planner.tfs_collection:
+        for tfs in self.execution_planner.tfs_collection.values():
             cfw_class = tfs.to_framework
             if cfw_class in connection_map:
                 continue

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -357,6 +357,8 @@ class ExecutionPlan:
                 if ep.destination_framework != ep.source_framework:
                     new_tfs = self.fill_tfs_by_joinstep(ep)
 
+                    # Safe to reuse the canonical hop here: link_id is part of its identity, so both joins
+                    # of this link re-find the hopped framework by link.uuid.
                     canonical_tfs = self.tfs_collection.get(new_tfs)
                     if canonical_tfs is None:
                         self.tfs_collection[new_tfs] = new_tfs
@@ -446,10 +448,9 @@ class ExecutionPlan:
                             self.tfs_collection[new_tfs] = new_tfs
                             new_execution_plan.append(new_tfs)
                             canonical_tfs = new_tfs
-                            ep.required_uuids.add(canonical_tfs.uuid)
+                        ep.required_uuids.add(canonical_tfs.uuid)
 
-                        # We update the any_uuid of the feature group to the uuid of the TFS.
-                        # This way we make sure that the TFS is used later.
+                        # Record the surviving hop's uuid so the step resolves its compute framework from it.
                         ep.tfs_ids.add(canonical_tfs.uuid)
 
                         need_to_upload_collector.add(parent)

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -89,7 +89,8 @@ class ExecutionPlan:
         global_filter: Optional[GlobalFilter] = None,
         api_input_data_collection: Optional[ApiInputDataCollection] = None,
     ) -> None:
-        self.tfs_collection: set[TransformFrameworkStep] = set()
+        # Maps a step to itself so a dedup hit can recover the already-inserted canonical member.
+        self.tfs_collection: dict[TransformFrameworkStep, TransformFrameworkStep] = {}
         self.joinstep_collection = JoinStepCollection()
         self.global_filter = global_filter
         self.api_input_data_collection = api_input_data_collection
@@ -122,7 +123,7 @@ class ExecutionPlan:
     ) -> None:
         self.planned_records = []
         self.declined_orientations = []
-        self.tfs_collection = set()
+        self.tfs_collection = {}
         self.joinstep_collection = JoinStepCollection()
         self.feature_set_collections = []
         self.declared_frameworks = declared_frameworks if declared_frameworks is not None else {}
@@ -356,10 +357,12 @@ class ExecutionPlan:
                 if ep.destination_framework != ep.source_framework:
                     new_tfs = self.fill_tfs_by_joinstep(ep)
 
-                    if new_tfs not in self.tfs_collection:
-                        self.tfs_collection.add(new_tfs)
+                    canonical_tfs = self.tfs_collection.get(new_tfs)
+                    if canonical_tfs is None:
+                        self.tfs_collection[new_tfs] = new_tfs
                         new_execution_plan.append(new_tfs)
-                        ep.required_uuids.add(new_tfs.uuid)
+                        canonical_tfs = new_tfs
+                    ep.required_uuids.add(canonical_tfs.uuid)
 
                     need_to_upload_collector.update(ep.source_framework_uuids)
 
@@ -438,14 +441,16 @@ class ExecutionPlan:
                             from_feature_group=parent_node_property.feature_group_class,
                             to_feature_group=ep.feature_group,
                         )
-                        if new_tfs not in self.tfs_collection:
-                            self.tfs_collection.add(new_tfs)
+                        canonical_tfs = self.tfs_collection.get(new_tfs)
+                        if canonical_tfs is None:
+                            self.tfs_collection[new_tfs] = new_tfs
                             new_execution_plan.append(new_tfs)
-                            ep.required_uuids.add(new_tfs.uuid)
+                            canonical_tfs = new_tfs
+                            ep.required_uuids.add(canonical_tfs.uuid)
 
                         # We update the any_uuid of the feature group to the uuid of the TFS.
                         # This way we make sure that the TFS is used later.
-                        ep.tfs_ids.add(new_tfs.uuid)
+                        ep.tfs_ids.add(canonical_tfs.uuid)
 
                         need_to_upload_collector.add(parent)
 

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -1,0 +1,166 @@
+"""add_tfs checks tfs_collection membership with ``not in``, a plain set, which can confirm a dedup
+but cannot hand back the equal member already stored. On the dedup path, neither branch wires the
+uuid of the TransformFrameworkStep that actually survives the dedup into the consuming step(s).
+"""
+
+from typing import NamedTuple
+from uuid import UUID
+
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.provider import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import JoinSpec
+from mloda.user import Link
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class DedupBaseFG(FeatureGroup):
+    """Unmatchable base so a leaked subclass stays invisible to feature resolution."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class DedupLeftFG(DedupBaseFG):
+    pass
+
+
+class DedupRightFG(DedupBaseFG):
+    pass
+
+
+class DedupUpstreamFG(DedupBaseFG):
+    pass
+
+
+class DedupDestFG(DedupBaseFG):
+    pass
+
+
+def _feature(name: str, cfw: type[ComputeFramework]) -> Feature:
+    feature = Feature(name)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: JoinStep branch (execution_plan.py add_tfs, ~line 356-367)
+# ---------------------------------------------------------------------------
+
+
+class JoinStepDedupScenario(NamedTuple):
+    js1: JoinStep
+    js2: JoinStep
+    graph: Graph
+
+
+def _join_step(link: Link) -> JoinStep:
+    return JoinStep(
+        link=link,
+        destination_framework=PandasDataFrame,
+        source_framework=PyArrowTable,
+        required_uuids=set(),
+        destination_framework_uuids=set(),
+        source_framework_uuids=set(),
+    )
+
+
+def _join_step_dedup_scenario() -> JoinStepDedupScenario:
+    """Two JoinSteps sharing one Link, same source/destination framework and merge orientation,
+    so ``fill_tfs_by_joinstep`` builds two ``TransformFrameworkStep``s that compare equal."""
+    link = Link.inner(JoinSpec(DedupLeftFG, "id"), JoinSpec(DedupRightFG, "id"))
+    return JoinStepDedupScenario(_join_step(link), _join_step(link), Graph())
+
+
+def test_both_joinsteps_of_a_deduped_hop_depend_on_the_surviving_transform_step() -> None:
+    scenario = _join_step_dedup_scenario()
+
+    new_plan = ExecutionPlan().add_tfs([scenario.js1, scenario.js2], scenario.graph)
+
+    tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
+    assert len(tfs_steps) == 1, f"expected the two equal hops to dedup into one, got: {tfs_steps}"
+    tfs_uuid = tfs_steps[0].uuid
+
+    assert tfs_uuid in scenario.js1.required_uuids
+    assert tfs_uuid in scenario.js2.required_uuids
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: FeatureGroupStep branch (execution_plan.py add_tfs, ~line 432-446)
+# ---------------------------------------------------------------------------
+
+
+class FeatureGroupStepDedupScenario(NamedTuple):
+    step_a: FeatureGroupStep
+    step_b: FeatureGroupStep
+    graph: Graph
+
+
+def _root_node(graph: Graph, feature: Feature, fg: type[FeatureGroup]) -> None:
+    graph.add_node(feature.uuid, NodeProperties(feature, fg))
+    graph.parent_to_children_mapping[feature.uuid] = set()
+
+
+def _dest_step(
+    fg: type[FeatureGroup],
+    dest_feature: Feature,
+    cfw: type[ComputeFramework],
+    parent_uuid: UUID,
+    graph: Graph,
+) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    feature_set.add(dest_feature)
+    graph.parent_to_children_mapping[dest_feature.uuid] = {parent_uuid}
+    return FeatureGroupStep(fg, feature_set, set(), cfw)
+
+
+def _feature_group_step_dedup_scenario() -> FeatureGroupStepDedupScenario:
+    """Two FeatureGroupSteps, each with a direct root parent of the same upstream feature group
+    class and compute framework, so the two ``TransformFrameworkStep``s built for them compare
+    equal (same from_framework, to_framework, from_feature_group, to_feature_group, link_id=None).
+    """
+    graph = Graph()
+
+    parent_a = _feature("dedup_upstream_a", PyArrowTable)
+    parent_b = _feature("dedup_upstream_b", PyArrowTable)
+    _root_node(graph, parent_a, DedupUpstreamFG)
+    _root_node(graph, parent_b, DedupUpstreamFG)
+
+    dest_feature_a = _feature("dedup_dest_a", PandasDataFrame)
+    dest_feature_b = _feature("dedup_dest_b", PandasDataFrame)
+    step_a = _dest_step(DedupDestFG, dest_feature_a, PandasDataFrame, parent_a.uuid, graph)
+    step_b = _dest_step(DedupDestFG, dest_feature_b, PandasDataFrame, parent_b.uuid, graph)
+
+    return FeatureGroupStepDedupScenario(step_a, step_b, graph)
+
+
+def test_both_feature_group_steps_of_a_deduped_hop_reference_the_surviving_transform_step() -> None:
+    scenario = _feature_group_step_dedup_scenario()
+
+    new_plan = ExecutionPlan().add_tfs([scenario.step_a, scenario.step_b], scenario.graph)
+
+    tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
+    assert len(tfs_steps) == 1, f"expected the two equal hops to dedup into one, got: {tfs_steps}"
+    tfs_uuid = tfs_steps[0].uuid
+
+    assert scenario.step_a.tfs_ids == {tfs_uuid}
+    assert scenario.step_b.tfs_ids == {tfs_uuid}

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -1,6 +1,5 @@
-"""add_tfs checks tfs_collection membership with ``not in``, a plain set, which can confirm a dedup
-but cannot hand back the equal member already stored. On the dedup path, neither branch wires the
-uuid of the TransformFrameworkStep that actually survives the dedup into the consuming step(s).
+"""Regression coverage for add_tfs: a deduped TransformFrameworkStep must still wire its uuid
+into every consuming step, not just the one that first created it.
 """
 
 from typing import NamedTuple
@@ -64,7 +63,7 @@ def _feature(name: str, cfw: type[ComputeFramework]) -> Feature:
 
 
 # ---------------------------------------------------------------------------
-# Scenario A: JoinStep branch (execution_plan.py add_tfs, ~line 356-367)
+# Scenario A: add_tfs's JoinStep branch
 # ---------------------------------------------------------------------------
 
 
@@ -86,8 +85,8 @@ def _join_step(link: Link) -> JoinStep:
 
 
 def _join_step_dedup_scenario() -> JoinStepDedupScenario:
-    """Two JoinSteps sharing one Link, same source/destination framework and merge orientation,
-    so ``fill_tfs_by_joinstep`` builds two ``TransformFrameworkStep``s that compare equal."""
+    """Two JoinSteps over the same link, frameworks, and orientation, so ``fill_tfs_by_joinstep``
+    builds two equal ``TransformFrameworkStep``s."""
     link = Link.inner(JoinSpec(DedupLeftFG, "id"), JoinSpec(DedupRightFG, "id"))
     return JoinStepDedupScenario(_join_step(link), _join_step(link), Graph())
 
@@ -106,7 +105,7 @@ def test_both_joinsteps_of_a_deduped_hop_depend_on_the_surviving_transform_step(
 
 
 # ---------------------------------------------------------------------------
-# Scenario B: FeatureGroupStep branch (execution_plan.py add_tfs, ~line 432-446)
+# Scenario B: add_tfs's FeatureGroupStep branch
 # ---------------------------------------------------------------------------
 
 
@@ -135,10 +134,8 @@ def _dest_step(
 
 
 def _feature_group_step_dedup_scenario() -> FeatureGroupStepDedupScenario:
-    """Two FeatureGroupSteps, each with a direct root parent of the same upstream feature group
-    class and compute framework, so the two ``TransformFrameworkStep``s built for them compare
-    equal (same from_framework, to_framework, from_feature_group, to_feature_group, link_id=None).
-    """
+    """Two FeatureGroupSteps with a root parent from the same upstream feature group and compute
+    framework, so their built ``TransformFrameworkStep``s compare equal."""
     graph = Graph()
 
     parent_a = _feature("dedup_upstream_a", PyArrowTable)

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -6,6 +6,7 @@ uuid of the TransformFrameworkStep that actually survives the dedup into the con
 from typing import NamedTuple
 from uuid import UUID
 
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
@@ -32,7 +33,7 @@ class DedupBaseFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: None = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -3,7 +3,7 @@ into every consuming step, not just the one that first created it.
 """
 
 from typing import NamedTuple
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
@@ -73,22 +73,25 @@ class JoinStepDedupScenario(NamedTuple):
     graph: Graph
 
 
-def _join_step(link: Link) -> JoinStep:
+def _join_step(link: Link, source_framework_uuid: UUID, destination_framework_uuid: UUID) -> JoinStep:
     return JoinStep(
         link=link,
         destination_framework=PandasDataFrame,
         source_framework=PyArrowTable,
         required_uuids=set(),
-        destination_framework_uuids=set(),
-        source_framework_uuids=set(),
+        destination_framework_uuids={destination_framework_uuid},
+        source_framework_uuids={source_framework_uuid},
     )
 
 
 def _join_step_dedup_scenario() -> JoinStepDedupScenario:
     """Two JoinSteps over the same link, frameworks, and orientation, so ``fill_tfs_by_joinstep``
-    builds two equal ``TransformFrameworkStep``s."""
+    builds two equal ``TransformFrameworkStep``s. Each carries its own distinct, non-empty
+    source/destination framework uuids, as real JoinSteps do."""
     link = Link.inner(JoinSpec(DedupLeftFG, "id"), JoinSpec(DedupRightFG, "id"))
-    return JoinStepDedupScenario(_join_step(link), _join_step(link), Graph())
+    js1 = _join_step(link, uuid4(), uuid4())
+    js2 = _join_step(link, uuid4(), uuid4())
+    return JoinStepDedupScenario(js1, js2, Graph())
 
 
 def test_both_joinsteps_of_a_deduped_hop_depend_on_the_surviving_transform_step() -> None:
@@ -102,6 +105,10 @@ def test_both_joinsteps_of_a_deduped_hop_depend_on_the_surviving_transform_step(
 
     assert tfs_uuid in scenario.js1.required_uuids
     assert tfs_uuid in scenario.js2.required_uuids
+
+    # Pins current dedup behavior: the survivor is js1's hop verbatim (first-inserted wins),
+    # not a blend of both JoinSteps' source_framework_uuids.
+    assert tfs_steps[0].source_framework_uuid == next(iter(scenario.js1.source_framework_uuids))
 
 
 # ---------------------------------------------------------------------------
@@ -162,3 +169,6 @@ def test_both_feature_group_steps_of_a_deduped_hop_reference_the_surviving_trans
 
     assert scenario.step_a.tfs_ids == {tfs_uuid}
     assert scenario.step_b.tfs_ids == {tfs_uuid}
+
+    assert tfs_uuid in scenario.step_a.required_uuids
+    assert tfs_uuid in scenario.step_b.required_uuids


### PR DESCRIPTION
Closes #1136

## Summary

`ExecutionPlan.add_tfs` tracked planned transform hops in a plain `set[TransformFrameworkStep]`, checked only with membership (`if new_tfs not in self.tfs_collection`). A set can confirm a duplicate exists but cannot hand back the equal member already stored. On a dedup hit, two places needed that stored member's uuid and mishandled it:

- In the JoinStep branch, the dependency edge on the transform hop was only added when the hop was newly inserted, so a JoinStep whose hop deduped against an already-planned one got no dependency on it.
- In the FeatureGroupStep branch, the step's `tfs_ids` was pointed at the surviving hop, but the `required_uuids` ordering edge was only added on first insert, so a deduped step could be scheduled to run before its transform hop actually completed.

## Fix

`tfs_collection` is now a self-mapping `dict[TransformFrameworkStep, TransformFrameworkStep]`, so a dedup hit can recover the canonical already-inserted step via lookup. Both branches now wire that canonical step's uuid into the consuming step's `required_uuids` (and `tfs_ids` for the FeatureGroupStep branch) unconditionally, not only on first insert.

The JoinStep-branch half is defensive hardening for a shape not currently reached by real plans (two JoinSteps of the same link, source/destination framework, and merge orientation). The FeatureGroupStep-branch half fixes a gap that real plans do reach today.

## Tests

Unit tests drive `ExecutionPlan.add_tfs` directly with hand-built steps, covering both branches' dedup paths and pinning which framework uuids the surviving hop carries.