### PR TITLE
Fix JoinStepCollection.get_required_join_uuids creating ghost keys on lookup

### DIFF
--- a/mloda/core/prepare/joinstep_collection.py
+++ b/mloda/core/prepare/joinstep_collection.py
@@ -34,4 +34,4 @@ class JoinStepCollection:
         self.collection[join_step] = required_join_uuids
 
     def get_required_join_uuids(self, join_step: JoinStep) -> set[UUID]:
-        return self.collection[join_step]
+        return self.collection.get(join_step, set())

--- a/tests/test_core/test_prepare/test_joinstep_collection_no_mutation.py
+++ b/tests/test_core/test_prepare/test_joinstep_collection_no_mutation.py
@@ -1,4 +1,5 @@
 """get_required_join_uuids must not insert a new key into the collection on a cache miss."""
+
 from __future__ import annotations
 
 from mloda.core.core.step.join_step import JoinStep
@@ -7,7 +8,6 @@ from mloda.provider import FeatureGroup
 from mloda.user import Index, JoinSpec, Link
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
-
 
 _LEFT_INDEX = Index(("left_key",))
 _RIGHT_INDEX = Index(("right_key",))

--- a/tests/test_core/test_prepare/test_joinstep_collection_no_mutation.py
+++ b/tests/test_core/test_prepare/test_joinstep_collection_no_mutation.py
@@ -1,0 +1,51 @@
+"""get_required_join_uuids must not insert a new key into the collection on a cache miss."""
+from __future__ import annotations
+
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.joinstep_collection import JoinStepCollection
+from mloda.provider import FeatureGroup
+from mloda.user import Index, JoinSpec, Link
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+_LEFT_INDEX = Index(("left_key",))
+_RIGHT_INDEX = Index(("right_key",))
+
+
+class _CollLeft(FeatureGroup):
+    pass
+
+
+class _CollRight(FeatureGroup):
+    pass
+
+
+def _link() -> Link:
+    return Link.inner(JoinSpec(_CollLeft, _LEFT_INDEX), JoinSpec(_CollRight, _RIGHT_INDEX))
+
+
+def test_get_required_join_uuids_returns_empty_set_for_unregistered_step() -> None:
+    coll = JoinStepCollection()
+    link = _link()
+    step = JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+
+    result = coll.get_required_join_uuids(step)
+
+    assert result == set()
+
+
+def test_get_required_join_uuids_does_not_mutate_collection_on_miss() -> None:
+    coll = JoinStepCollection()
+    link = _link()
+    registered = JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+    unregistered = JoinStep(link, PandasDataFrame, PyArrowTable, set(), set(), set())
+
+    coll.add(registered)
+    assert len(coll.collection) == 1
+
+    coll.get_required_join_uuids(unregistered)
+
+    assert len(coll.collection) == 1, (
+        "looking up an unregistered JoinStep must not insert a new entry into the collection"
+    )


### PR DESCRIPTION
Found a subtle bug in `get_required_join_uuids`: it indexes `self.collection[join_step]` directly, and since `collection` is a `defaultdict(set)`, looking up a key that doesn't exist silently creates an empty entry. So every call with an unregistered step would leave a phantom key behind.

This matters in `similar_dependent_joins_uuids`, which iterates over all keys in the collection. A ghost entry from an inverted-orientation `JoinStep` (created during scheduling checks) could end up pulling in UUIDs from unrelated steps and causing unnecessary waits. Swapping to `self.collection.get(join_step, set())` returns the same empty set without touching the dict.

Added two tests in `test_joinstep_collection_no_mutation.py`: one checks that a miss returns an empty set, the other verifies the collection length stays the same after a failed lookup.

Fixes #1142