### PR TITLE
fix: distinguish transform hops by source, not just shape

### DIFF
--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -23,6 +23,7 @@ class TransformFrameworkStep(Step):
         to_feature_group: type[FeatureGroup],
         link_id: Optional[UUID] = None,
         source_framework_uuids: Optional[set[UUID]] = None,
+        source_uuid: Optional[UUID] = None,
     ) -> None:
         if source_framework_uuids is None:
             source_framework_uuids = set()
@@ -33,6 +34,7 @@ class TransformFrameworkStep(Step):
         self.from_feature_group = from_feature_group
         self.to_feature_group = to_feature_group
         self.link_id = link_id
+        self.source_uuid = source_uuid
         self.transformer = ComputeFrameworkTransformer()
 
         # This variable is only set, if the TFS was requested by a joinstep.
@@ -46,18 +48,28 @@ class TransformFrameworkStep(Step):
         if not isinstance(other, TransformFrameworkStep):
             return False
         # A join's hop and a plain hop of the same shape are different steps (the join looks
-        # its hop up by link_id), so link_id is part of the identity.
+        # its hop up by link_id), so link_id is part of the identity. Likewise, two plain hops
+        # of the same shape but different source features must not dedup into one hop, since
+        # execute() only ever moves one physical source's data.
         return (
             self.from_framework == other.from_framework
             and self.to_framework == other.to_framework
             and self.from_feature_group == other.from_feature_group
             and self.to_feature_group == other.to_feature_group
             and self.link_id == other.link_id
+            and self.source_uuid == other.source_uuid
         )
 
     def __hash__(self) -> int:
         return hash(
-            (self.from_framework, self.to_framework, self.from_feature_group, self.to_feature_group, self.link_id)
+            (
+                self.from_framework,
+                self.to_framework,
+                self.from_feature_group,
+                self.to_feature_group,
+                self.link_id,
+                self.source_uuid,
+            )
         )
 
     def get_uuids(self) -> set[UUID]:

--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -34,8 +34,8 @@ class TransformFrameworkStep(Step):
         self.from_feature_group = from_feature_group
         self.to_feature_group = to_feature_group
         self.link_id = link_id
-        # Exactly one of link_id (join-branch hops) or source_step_uuid (plain feature-group-branch
-        # hops) is ever set on a given instance, never both.
+        # Hops built by add_tfs carry at most one of link_id (join hops) or source_step_uuid
+        # (plain hops), never both.
         self.source_step_uuid = source_step_uuid
         self.transformer = ComputeFrameworkTransformer()
 

--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -23,7 +23,7 @@ class TransformFrameworkStep(Step):
         to_feature_group: type[FeatureGroup],
         link_id: Optional[UUID] = None,
         source_framework_uuids: Optional[set[UUID]] = None,
-        source_uuid: Optional[UUID] = None,
+        source_step_uuid: Optional[UUID] = None,
     ) -> None:
         if source_framework_uuids is None:
             source_framework_uuids = set()
@@ -34,7 +34,9 @@ class TransformFrameworkStep(Step):
         self.from_feature_group = from_feature_group
         self.to_feature_group = to_feature_group
         self.link_id = link_id
-        self.source_uuid = source_uuid
+        # Exactly one of link_id (join-branch hops) or source_step_uuid (plain feature-group-branch
+        # hops) is ever set on a given instance, never both.
+        self.source_step_uuid = source_step_uuid
         self.transformer = ComputeFrameworkTransformer()
 
         # This variable is only set, if the TFS was requested by a joinstep.
@@ -48,7 +50,7 @@ class TransformFrameworkStep(Step):
         if not isinstance(other, TransformFrameworkStep):
             return False
         # A join's hop and a plain hop of the same shape are different steps (the join looks
-        # its hop up by link_id), so link_id is part of the identity; source_uuid is included
+        # its hop up by link_id), so link_id is part of the identity; source_step_uuid is included
         # for the same reason, since execute() only ever moves one source's data per hop.
         return (
             self.from_framework == other.from_framework
@@ -56,7 +58,7 @@ class TransformFrameworkStep(Step):
             and self.from_feature_group == other.from_feature_group
             and self.to_feature_group == other.to_feature_group
             and self.link_id == other.link_id
-            and self.source_uuid == other.source_uuid
+            and self.source_step_uuid == other.source_step_uuid
         )
 
     def __hash__(self) -> int:
@@ -67,7 +69,7 @@ class TransformFrameworkStep(Step):
                 self.from_feature_group,
                 self.to_feature_group,
                 self.link_id,
-                self.source_uuid,
+                self.source_step_uuid,
             )
         )
 

--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -48,9 +48,8 @@ class TransformFrameworkStep(Step):
         if not isinstance(other, TransformFrameworkStep):
             return False
         # A join's hop and a plain hop of the same shape are different steps (the join looks
-        # its hop up by link_id), so link_id is part of the identity. Likewise, two plain hops
-        # of the same shape but different source features must not dedup into one hop, since
-        # execute() only ever moves one physical source's data.
+        # its hop up by link_id), so link_id is part of the identity; source_uuid is included
+        # for the same reason, since execute() only ever moves one source's data per hop.
         return (
             self.from_framework == other.from_framework
             and self.to_framework == other.to_framework

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -458,8 +458,8 @@ class ExecutionPlan:
                             self.tfs_collection[new_tfs] = new_tfs
                             new_execution_plan.append(new_tfs)
                             canonical_tfs = new_tfs
-                        # Names every parent deduped onto this hop, not just the first, so the hop
-                        # gates scheduling correctly for all of them.
+                        # Records every parent the hop covers; they all share one owning step, so
+                        # this doesn't change the scheduling gate.
                         canonical_tfs.required_uuids.add(parent)
                         ep.required_uuids.add(canonical_tfs.uuid)
 

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -442,6 +442,7 @@ class ExecutionPlan:
                             required_uuids={parent},
                             from_feature_group=parent_node_property.feature_group_class,
                             to_feature_group=ep.feature_group,
+                            source_uuid=parent,
                         )
                         canonical_tfs = self.tfs_collection.get(new_tfs)
                         if canonical_tfs is None:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -352,6 +352,15 @@ class ExecutionPlan:
         left_join_frameworks: set[JoinStep] = {ep for ep in execution_plan if isinstance(ep, JoinStep)}
         need_to_upload_collector: set[UUID] = set()
 
+        # Features produced together by one FeatureGroupStep live on the same physical source cfw
+        # instance, so a hop should key on the owning step, not each member feature's own uuid.
+        owning_step_of: dict[UUID, UUID] = {
+            feature_uuid: ep.uuid
+            for ep in execution_plan
+            if isinstance(ep, FeatureGroupStep)
+            for feature_uuid in ep.get_uuids()
+        }
+
         for ep in execution_plan:
             if isinstance(ep, JoinStep):
                 if ep.destination_framework != ep.source_framework:
@@ -442,13 +451,16 @@ class ExecutionPlan:
                             required_uuids={parent},
                             from_feature_group=parent_node_property.feature_group_class,
                             to_feature_group=ep.feature_group,
-                            source_uuid=parent,
+                            source_step_uuid=owning_step_of.get(parent, parent),
                         )
                         canonical_tfs = self.tfs_collection.get(new_tfs)
                         if canonical_tfs is None:
                             self.tfs_collection[new_tfs] = new_tfs
                             new_execution_plan.append(new_tfs)
                             canonical_tfs = new_tfs
+                        # Names every parent deduped onto this hop, not just the first, so the hop
+                        # gates scheduling correctly for all of them.
+                        canonical_tfs.required_uuids.add(parent)
                         ep.required_uuids.add(canonical_tfs.uuid)
 
                         # Record the surviving hop's uuid so the step resolves its compute framework from it.

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -1,5 +1,6 @@
 """Regression coverage for add_tfs: a deduped TransformFrameworkStep must still wire its uuid
-into every consuming step, not just the one that first created it.
+into every consuming step, not just the one that first created it (Scenario A). Scenario B also
+pins that two same-shaped hops from genuinely DIFFERENT parents must NOT dedup (issue #1141).
 """
 
 from typing import NamedTuple
@@ -119,10 +120,14 @@ def test_both_joinsteps_of_a_deduped_hop_depend_on_the_surviving_transform_step(
 class FeatureGroupStepDedupScenario(NamedTuple):
     step_a: FeatureGroupStep
     step_b: FeatureGroupStep
+    parent_a: Feature
+    parent_b: Feature
     graph: Graph
 
 
 def _root_node(graph: Graph, feature: Feature, fg: type[FeatureGroup]) -> None:
+    if feature.uuid in graph.get_nodes():
+        return
     graph.add_node(feature.uuid, NodeProperties(feature, fg))
     graph.parent_to_children_mapping[feature.uuid] = set()
 
@@ -140,13 +145,15 @@ def _dest_step(
     return FeatureGroupStep(fg, feature_set, set(), cfw)
 
 
-def _feature_group_step_dedup_scenario() -> FeatureGroupStepDedupScenario:
-    """Two FeatureGroupSteps with a root parent from the same upstream feature group and compute
-    framework, so their built ``TransformFrameworkStep``s compare equal."""
+def _feature_group_step_dedup_scenario(same_parent: bool) -> FeatureGroupStepDedupScenario:
+    """Two FeatureGroupSteps whose built ``TransformFrameworkStep``s share the same from/to
+    framework and from/to feature-group shape. ``same_parent=True`` models a legitimate dedup (both
+    steps actually pull from the one upstream feature); ``same_parent=False`` models two genuinely
+    different upstream features (dedup must NOT collapse these)."""
     graph = Graph()
 
     parent_a = _feature("dedup_upstream_a", PyArrowTable)
-    parent_b = _feature("dedup_upstream_b", PyArrowTable)
+    parent_b = parent_a if same_parent else _feature("dedup_upstream_b", PyArrowTable)
     _root_node(graph, parent_a, DedupUpstreamFG)
     _root_node(graph, parent_b, DedupUpstreamFG)
 
@@ -155,16 +162,17 @@ def _feature_group_step_dedup_scenario() -> FeatureGroupStepDedupScenario:
     step_a = _dest_step(DedupDestFG, dest_feature_a, PandasDataFrame, parent_a.uuid, graph)
     step_b = _dest_step(DedupDestFG, dest_feature_b, PandasDataFrame, parent_b.uuid, graph)
 
-    return FeatureGroupStepDedupScenario(step_a, step_b, graph)
+    return FeatureGroupStepDedupScenario(step_a, step_b, parent_a, parent_b, graph)
 
 
-def test_both_feature_group_steps_of_a_deduped_hop_reference_the_surviving_transform_step() -> None:
-    scenario = _feature_group_step_dedup_scenario()
+def test_two_feature_group_steps_with_the_same_parent_and_shape_dedup_into_one_transform_step() -> None:
+    """Guard against an overly-broad fix: genuinely shared parents must still dedup to one hop."""
+    scenario = _feature_group_step_dedup_scenario(same_parent=True)
 
     new_plan = ExecutionPlan().add_tfs([scenario.step_a, scenario.step_b], scenario.graph)
 
     tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
-    assert len(tfs_steps) == 1, f"expected the two equal hops to dedup into one, got: {tfs_steps}"
+    assert len(tfs_steps) == 1, f"expected the two same-parent hops to dedup into one, got: {tfs_steps}"
     tfs_uuid = tfs_steps[0].uuid
 
     assert scenario.step_a.tfs_ids == {tfs_uuid}
@@ -172,3 +180,31 @@ def test_both_feature_group_steps_of_a_deduped_hop_reference_the_surviving_trans
 
     assert tfs_uuid in scenario.step_a.required_uuids
     assert tfs_uuid in scenario.step_b.required_uuids
+
+
+def test_two_feature_group_steps_with_different_parents_get_separate_transform_hops() -> None:
+    """Two FeatureGroupSteps that share a from/to-framework + from/to-feature-group shape but pull
+    from genuinely DIFFERENT parent features must each get their own TransformFrameworkStep. A hop
+    only ever moves one physical source's data (TransformFrameworkStep.execute takes a single
+    from_cfw), so collapsing two different-parent hops into one starves whichever step's uuid loses
+    the dedup of its own source data."""
+    scenario = _feature_group_step_dedup_scenario(same_parent=False)
+
+    new_plan = ExecutionPlan().add_tfs([scenario.step_a, scenario.step_b], scenario.graph)
+
+    tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
+    assert len(tfs_steps) == 2, (
+        f"two feature-group steps with genuinely different parents must NOT collapse into one "
+        f"transform hop, got: {[(s.uuid, s.required_uuids) for s in tfs_steps]}"
+    )
+
+    hop_a = next(step for step in tfs_steps if scenario.parent_a.uuid in step.required_uuids)
+    hop_b = next(step for step in tfs_steps if scenario.parent_b.uuid in step.required_uuids)
+    assert hop_a.uuid != hop_b.uuid
+    assert hop_a.required_uuids == {scenario.parent_a.uuid}
+    assert hop_b.required_uuids == {scenario.parent_b.uuid}
+
+    assert scenario.step_a.tfs_ids == {hop_a.uuid}
+    assert scenario.step_b.tfs_ids == {hop_b.uuid}
+    assert scenario.step_a.required_uuids == {hop_a.uuid}
+    assert scenario.step_b.required_uuids == {hop_b.uuid}

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -1,6 +1,6 @@
 """Regression coverage for add_tfs: a deduped TransformFrameworkStep must still wire its uuid
-into every consuming step, not just the one that first created it (Scenario A). Scenario B also
-pins that two same-shaped hops from genuinely DIFFERENT parents must NOT dedup (issue #1141).
+into every consuming step, not just the one that first created it (Scenario A), and that two
+same-shaped hops from genuinely different parents must not dedup into one (Scenario B).
 """
 
 from typing import NamedTuple
@@ -146,10 +146,9 @@ def _dest_step(
 
 
 def _feature_group_step_dedup_scenario(same_parent: bool) -> FeatureGroupStepDedupScenario:
-    """Two FeatureGroupSteps whose built ``TransformFrameworkStep``s share the same from/to
-    framework and from/to feature-group shape. ``same_parent=True`` models a legitimate dedup (both
-    steps actually pull from the one upstream feature); ``same_parent=False`` models two genuinely
-    different upstream features (dedup must NOT collapse these)."""
+    """Two FeatureGroupSteps whose built ``TransformFrameworkStep``s share from/to framework and
+    feature-group shape. ``same_parent=True`` pulls both from the same upstream feature (must
+    dedup); ``same_parent=False`` pulls from different upstream features (must not dedup)."""
     graph = Graph()
 
     parent_a = _feature("dedup_upstream_a", PyArrowTable)
@@ -183,11 +182,9 @@ def test_two_feature_group_steps_with_the_same_parent_and_shape_dedup_into_one_t
 
 
 def test_two_feature_group_steps_with_different_parents_get_separate_transform_hops() -> None:
-    """Two FeatureGroupSteps that share a from/to-framework + from/to-feature-group shape but pull
-    from genuinely DIFFERENT parent features must each get their own TransformFrameworkStep. A hop
-    only ever moves one physical source's data (TransformFrameworkStep.execute takes a single
-    from_cfw), so collapsing two different-parent hops into one starves whichever step's uuid loses
-    the dedup of its own source data."""
+    """A hop only ever moves one physical source's data (execute() takes a single from_cfw), so
+    collapsing two different-parent hops into one would starve whichever step's uuid lost the
+    dedup of its own source data."""
     scenario = _feature_group_step_dedup_scenario(same_parent=False)
 
     new_plan = ExecutionPlan().add_tfs([scenario.step_a, scenario.step_b], scenario.graph)

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -122,6 +122,7 @@ class FeatureGroupStepDedupScenario(NamedTuple):
     step_b: FeatureGroupStep
     parent_a: Feature
     parent_b: Feature
+    producers: list[FeatureGroupStep]
     graph: Graph
 
 
@@ -145,10 +146,19 @@ def _dest_step(
     return FeatureGroupStep(fg, feature_set, set(), cfw)
 
 
+def _producer_step(fg: type[FeatureGroup], feature: Feature, cfw: type[ComputeFramework]) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    feature_set.add(feature)
+    return FeatureGroupStep(fg, feature_set, set(), cfw)
+
+
 def _feature_group_step_dedup_scenario(same_parent: bool) -> FeatureGroupStepDedupScenario:
     """Two FeatureGroupSteps whose built ``TransformFrameworkStep``s share from/to framework and
     feature-group shape. ``same_parent=True`` pulls both from the same upstream feature (must
-    dedup); ``same_parent=False`` pulls from different upstream features (must not dedup)."""
+    dedup); ``same_parent=False`` pulls from different upstream features (must not dedup).
+
+    Each parent is also produced by a ``FeatureGroupStep`` (``producers``), so the built hops key
+    on ``owning_step_of`` for real instead of falling back to the raw parent uuid."""
     graph = Graph()
 
     parent_a = _feature("dedup_upstream_a", PyArrowTable)
@@ -156,19 +166,23 @@ def _feature_group_step_dedup_scenario(same_parent: bool) -> FeatureGroupStepDed
     _root_node(graph, parent_a, DedupUpstreamFG)
     _root_node(graph, parent_b, DedupUpstreamFG)
 
+    producer_a = _producer_step(DedupUpstreamFG, parent_a, PyArrowTable)
+    producer_b = producer_a if same_parent else _producer_step(DedupUpstreamFG, parent_b, PyArrowTable)
+    producers = [producer_a] if same_parent else [producer_a, producer_b]
+
     dest_feature_a = _feature("dedup_dest_a", PandasDataFrame)
     dest_feature_b = _feature("dedup_dest_b", PandasDataFrame)
     step_a = _dest_step(DedupDestFG, dest_feature_a, PandasDataFrame, parent_a.uuid, graph)
     step_b = _dest_step(DedupDestFG, dest_feature_b, PandasDataFrame, parent_b.uuid, graph)
 
-    return FeatureGroupStepDedupScenario(step_a, step_b, parent_a, parent_b, graph)
+    return FeatureGroupStepDedupScenario(step_a, step_b, parent_a, parent_b, producers, graph)
 
 
 def test_two_feature_group_steps_with_the_same_parent_and_shape_dedup_into_one_transform_step() -> None:
     """Guard against an overly-broad fix: genuinely shared parents must still dedup to one hop."""
     scenario = _feature_group_step_dedup_scenario(same_parent=True)
 
-    new_plan = ExecutionPlan().add_tfs([scenario.step_a, scenario.step_b], scenario.graph)
+    new_plan = ExecutionPlan().add_tfs([*scenario.producers, scenario.step_a, scenario.step_b], scenario.graph)
 
     tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
     assert len(tfs_steps) == 1, f"expected the two same-parent hops to dedup into one, got: {tfs_steps}"
@@ -186,8 +200,9 @@ def test_two_feature_group_steps_with_different_parents_get_separate_transform_h
     collapsing two different-parent hops into one would starve whichever step's uuid lost the
     dedup of its own source data."""
     scenario = _feature_group_step_dedup_scenario(same_parent=False)
+    producer_a, producer_b = scenario.producers
 
-    new_plan = ExecutionPlan().add_tfs([scenario.step_a, scenario.step_b], scenario.graph)
+    new_plan = ExecutionPlan().add_tfs([*scenario.producers, scenario.step_a, scenario.step_b], scenario.graph)
 
     tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
     assert len(tfs_steps) == 2, (
@@ -200,6 +215,11 @@ def test_two_feature_group_steps_with_different_parents_get_separate_transform_h
     assert hop_a.uuid != hop_b.uuid
     assert hop_a.required_uuids == {scenario.parent_a.uuid}
     assert hop_b.required_uuids == {scenario.parent_b.uuid}
+
+    # Pins the owning-step keying itself, not just its fallback: each hop's source_step_uuid is
+    # the producing FeatureGroupStep's uuid, not the raw parent uuid.
+    assert hop_a.source_step_uuid == producer_a.uuid
+    assert hop_b.source_step_uuid == producer_b.uuid
 
     assert scenario.step_a.tfs_ids == {hop_a.uuid}
     assert scenario.step_b.tfs_ids == {hop_b.uuid}

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -126,8 +126,8 @@ class FeatureGroupStepDedupScenario(NamedTuple):
 
 
 def _root_node(graph: Graph, feature: Feature, fg: type[FeatureGroup]) -> None:
-    if feature.uuid in graph.get_nodes():
-        return
+    # Graph.add_node is a plain dict assignment and this reset always assigns the same value, so
+    # calling this twice for the same feature (the same_parent=True scenario below) is harmless.
     graph.add_node(feature.uuid, NodeProperties(feature, fg))
     graph.parent_to_children_mapping[feature.uuid] = set()
 

--- a/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
@@ -1,0 +1,147 @@
+"""End-to-end regression for issue #1141: add_tfs must not collapse two Pandas->PyArrow
+transform hops that share a from/to-framework + from/to-feature-group shape but pull from
+genuinely different parent features. Before the fix this either crashes at runtime
+(AttributeError on the starved hop's destination) or silently serves one request the other's data.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Options, PluginCollector, mloda, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+# ---------------------------------------------------------------------------
+# Fixture feature groups
+# ---------------------------------------------------------------------------
+
+
+class DedupParentsRootFG(FeatureGroup):
+    """Pandas root exposing two distinct columns."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"dedup_col_x", "dedup_col_y"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        # Only the requested column(s), matching the convention that a compute framework's
+        # data holds what was asked for, not every name DataCreator could produce.
+        values = {"dedup_col_x": [1, 2, 3], "dedup_col_y": [100, 200, 300]}
+        return pd.DataFrame({name: values[name] for name in features.get_all_names()})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class DedupParentsConsumerFG(FeatureGroup):
+    """PyArrow consumer with two Options-gated requests, each pulling a DIFFERENT Pandas column
+    as its own single parent, forcing two same-shaped Pandas->PyArrow transform hops."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        variant = options.get("dedup_variant")
+        if variant == "x":
+            return {Feature("dedup_col_x")}
+        if variant == "y":
+            return {Feature("dedup_col_y")}
+        return None
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if "dedup_col_x" in data.column_names:
+            return data.append_column("dedup_result", data["dedup_col_x"])
+        if "dedup_col_y" in data.column_names:
+            return data.append_column("dedup_result", data["dedup_col_y"])
+        raise ValueError(f"Neither dedup_col_x nor dedup_col_y present in {data.column_names}")
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        # is_root() is False for both variant requests (input_features declares a parent),
+        # so the DataCreator root-match path does not apply; name it here.
+        return {"dedup_result"}
+
+
+_PLUGINS = PluginCollector.enabled_feature_groups({DedupParentsRootFG, DedupParentsConsumerFG})
+
+
+def _prepare_session() -> mlodaAPI:
+    return mloda.prepare(
+        [
+            Feature("dedup_result", options=Options({"dedup_variant": "x"})),
+            Feature("dedup_result", options=Options({"dedup_variant": "y"})),
+        ],
+        compute_frameworks={PandasDataFrame, PyArrowTable},
+        plugin_collector=_PLUGINS,
+    )
+
+
+def _transform_steps(session: mlodaAPI) -> list[TransformFrameworkStep]:
+    assert session.engine is not None
+    return [step for step in session.engine.execution_planner if isinstance(step, TransformFrameworkStep)]
+
+
+# ---------------------------------------------------------------------------
+# Planning-time: the two hops must not collapse into one
+# ---------------------------------------------------------------------------
+
+
+def test_two_same_shaped_hops_from_different_parents_stay_distinct_in_the_plan() -> None:
+    session = _prepare_session()
+
+    plain_hops = [
+        step
+        for step in _transform_steps(session)
+        if step.from_feature_group is DedupParentsRootFG and step.to_feature_group is DedupParentsConsumerFG
+    ]
+    assert len(plain_hops) == 2, (
+        f"expected two separate transform hops for the two genuinely different parents "
+        f"(dedup_col_x vs dedup_col_y), got: {[(s.uuid, s.required_uuids) for s in plain_hops]}"
+    )
+
+    required_uuid_sets = [frozenset(step.required_uuids) for step in plain_hops]
+    assert required_uuid_sets[0] != required_uuid_sets[1], (
+        f"the two hops must not share required_uuids (i.e. must not have collapsed into one hop "
+        f"that only ever moves one physical source's data); got: {required_uuid_sets}"
+    )
+
+    assert session.engine is not None
+    consumer_steps = [
+        step
+        for step in session.engine.execution_planner
+        if isinstance(step, FeatureGroupStep) and step.feature_group is DedupParentsConsumerFG
+    ]
+    assert len(consumer_steps) == 2
+    for consumer_step in consumer_steps:
+        assert len(consumer_step.tfs_ids) == 1, (
+            f"each consumer step must depend on exactly its own hop, not a hop shared with the "
+            f"other variant; got tfs_ids={consumer_step.tfs_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run-time: no crash, no cross-contaminated data
+# ---------------------------------------------------------------------------
+
+
+def test_running_the_plan_does_not_crash_and_each_result_carries_its_own_source_column() -> None:
+    session = _prepare_session()
+    results = session.run()
+
+    dedup_results = [result for result in results if "dedup_result" in result.column_names]
+    assert len(dedup_results) == 2, f"expected two distinct 'dedup_result' results, got: {results}"
+
+    value_tuples = sorted(tuple(result["dedup_result"].to_pylist()) for result in dedup_results)
+    assert value_tuples == [(1, 2, 3), (100, 200, 300)], (
+        f"each request must carry its OWN correctly-transformed source column's values, not "
+        f"empty/None, and not the other request's data; got: {value_tuples}"
+    )

--- a/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
@@ -50,11 +50,7 @@ class DedupParentsConsumerFG(FeatureGroup):
             return {Feature("dedup_col_x")}
         if variant == "y":
             return {Feature("dedup_col_y")}
-        raise ValueError(
-            f"DedupParentsConsumerFG requires options={{'dedup_variant': 'x' | 'y'}}, got "
-            f"dedup_variant={variant!r}. Returning None here would let the request wrongly "
-            f"resolve as a root and fail later with an opaque error in calculate_feature."
-        )
+        raise ValueError(f"DedupParentsConsumerFG requires options={{'dedup_variant': 'x' | 'y'}}, got {variant!r}")
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
@@ -1,7 +1,7 @@
-"""End-to-end regression for issue #1141: add_tfs must not collapse two Pandas->PyArrow
-transform hops that share a from/to-framework + from/to-feature-group shape but pull from
-genuinely different parent features. Before the fix this either crashes at runtime
-(AttributeError on the starved hop's destination) or silently serves one request the other's data.
+"""End-to-end regression: add_tfs must not collapse two Pandas->PyArrow transform hops that
+share a from/to-framework + from/to-feature-group shape but pull from genuinely different parent
+features. Before the fix this either crashes at runtime or silently serves one request the
+other's data.
 """
 
 from typing import Any, Optional
@@ -30,8 +30,8 @@ class DedupParentsRootFG(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        # Only the requested column(s), matching the convention that a compute framework's
-        # data holds what was asked for, not every name DataCreator could produce.
+        # Return only the requested column(s): a compute framework's data holds what was
+        # asked for, not everything DataCreator could produce.
         values = {"dedup_col_x": [1, 2, 3], "dedup_col_y": [100, 200, 300]}
         return pd.DataFrame({name: values[name] for name in features.get_all_names()})
 

--- a/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
@@ -50,7 +50,11 @@ class DedupParentsConsumerFG(FeatureGroup):
             return {Feature("dedup_col_x")}
         if variant == "y":
             return {Feature("dedup_col_y")}
-        return None
+        raise ValueError(
+            f"DedupParentsConsumerFG requires options={{'dedup_variant': 'x' | 'y'}}, got "
+            f"dedup_variant={variant!r}. Returning None here would let the request wrongly "
+            f"resolve as a root and fail later with an opaque error in calculate_feature."
+        )
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/tests/test_core/test_prepare/test_tfs_shared_source_step_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_shared_source_step_e2e.py
@@ -1,0 +1,116 @@
+"""End-to-end regression: add_tfs must collapse two Pandas->PyArrow transform hops that share a
+from/to-framework + from/to-feature-group shape AND come from parents produced together by the
+SAME owning FeatureGroupStep into ONE hop. Before the fix (keying the hop by the raw parent
+feature uuid instead of the owning step's uuid), this builds a separate hop per feature even
+though both physically live on the same source compute framework instance, leaking an orphaned
+destination compute framework and, under multiprocessing, downloading the same table twice.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+import pyarrow.compute as pc
+
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Options, PluginCollector, mloda, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+# ---------------------------------------------------------------------------
+# Fixture feature groups
+# ---------------------------------------------------------------------------
+
+
+class SharedSourceRootFG(FeatureGroup):
+    """Pandas root exposing two columns that are always computed TOGETHER by one step."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"twocol_a", "twocol_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        values = {"twocol_a": [1, 2, 3], "twocol_b": [10, 20, 30]}
+        return pd.DataFrame({name: values[name] for name in features.get_all_names()})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SharedSourceConsumerFG(FeatureGroup):
+    """PyArrow consumer pulling BOTH root columns in a single request, forcing one
+    FeatureGroupStep on the root that produces both columns together."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("twocol_a"), Feature("twocol_b")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        total = pc.add(data["twocol_a"], data["twocol_b"])
+        return data.append_column("shared_result", total)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        # is_root() is False (input_features declares parents), so the DataCreator root-match
+        # path does not apply; name it here.
+        return {"shared_result"}
+
+
+_PLUGINS = PluginCollector.enabled_feature_groups({SharedSourceRootFG, SharedSourceConsumerFG})
+
+
+def _prepare_session() -> mlodaAPI:
+    return mloda.prepare(
+        ["shared_result"],
+        compute_frameworks={PandasDataFrame, PyArrowTable},
+        plugin_collector=_PLUGINS,
+    )
+
+
+def _transform_steps(session: mlodaAPI) -> list[TransformFrameworkStep]:
+    assert session.engine is not None
+    return [step for step in session.engine.execution_planner if isinstance(step, TransformFrameworkStep)]
+
+
+# ---------------------------------------------------------------------------
+# Planning-time: the two parents from ONE owning step must share ONE hop
+# ---------------------------------------------------------------------------
+
+
+def test_two_parents_from_the_same_owning_step_share_one_transform_hop() -> None:
+    session = _prepare_session()
+
+    hops = [
+        step
+        for step in _transform_steps(session)
+        if step.from_feature_group is SharedSourceRootFG and step.to_feature_group is SharedSourceConsumerFG
+    ]
+    assert len(hops) == 1, (
+        f"expected one shared transform hop for twocol_a and twocol_b, which are produced together "
+        f"by the same owning FeatureGroupStep (same physical source compute framework instance), "
+        f"got: {[(s.uuid, s.required_uuids) for s in hops]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run-time: no crash, correct combined result
+# ---------------------------------------------------------------------------
+
+
+def test_running_the_plan_produces_the_correct_combined_result() -> None:
+    session = _prepare_session()
+    results = session.run()
+
+    shared_results = [result for result in results if "shared_result" in result.column_names]
+    assert len(shared_results) == 1, f"expected exactly one 'shared_result' result, got: {results}"
+
+    assert shared_results[0]["shared_result"].to_pylist() == [11, 22, 33], (
+        f"expected twocol_a + twocol_b element-wise, got: {shared_results[0]['shared_result'].to_pylist()}"
+    )

--- a/tests/test_core/test_prepare/test_transform_hop_identity.py
+++ b/tests/test_core/test_prepare/test_transform_hop_identity.py
@@ -247,3 +247,58 @@ class TestTransformFrameworkStepIdentityIncludesLinkId:
 
         assert first == second
         assert hash(first) == hash(second)
+
+
+class TestTransformFrameworkStepIdentityIncludesSourceStepUuid:
+    """Two hops of the same shape must key on the owning FeatureGroupStep's uuid
+    (``source_step_uuid``), not collide across different owning steps, and not collide with a
+    join hop of the same shape either."""
+
+    @staticmethod
+    def _step(source_step_uuid: Optional[UUID]) -> TransformFrameworkStep:
+        return TransformFrameworkStep(
+            from_framework=PandasDataFrame,
+            to_framework=PyArrowTable,
+            required_uuids=set(),
+            from_feature_group=HopIdA,
+            to_feature_group=HopIdB,
+            source_step_uuid=source_step_uuid,
+        )
+
+    def test_two_hops_with_different_source_step_uuids_compare_unequal(self) -> None:
+        first = self._step(uuid4())
+        second = self._step(uuid4())
+
+        assert first != second
+        assert hash(first) != hash(second)
+
+    def test_two_hops_with_the_same_source_step_uuid_compare_equal(self) -> None:
+        source_step_uuid = uuid4()
+        first = self._step(source_step_uuid)
+        second = self._step(source_step_uuid)
+
+        assert first == second
+        assert hash(first) == hash(second)
+
+    def test_a_join_hop_and_a_plain_hop_of_the_same_shape_compare_unequal(self) -> None:
+        join_hop = TransformFrameworkStep(
+            from_framework=PandasDataFrame,
+            to_framework=PyArrowTable,
+            required_uuids=set(),
+            from_feature_group=HopIdA,
+            to_feature_group=HopIdB,
+            link_id=uuid4(),
+            source_step_uuid=None,
+        )
+        plain_hop = TransformFrameworkStep(
+            from_framework=PandasDataFrame,
+            to_framework=PyArrowTable,
+            required_uuids=set(),
+            from_feature_group=HopIdA,
+            to_feature_group=HopIdB,
+            link_id=None,
+            source_step_uuid=uuid4(),
+        )
+
+        assert join_hop != plain_hop
+        assert hash(join_hop) != hash(plain_hop)

--- a/tests/test_core/test_prepare/test_transform_hop_identity.py
+++ b/tests/test_core/test_prepare/test_transform_hop_identity.py
@@ -250,9 +250,7 @@ class TestTransformFrameworkStepIdentityIncludesLinkId:
 
 
 class TestTransformFrameworkStepIdentityIncludesSourceStepUuid:
-    """Two hops of the same shape must key on the owning FeatureGroupStep's uuid
-    (``source_step_uuid``), not collide across different owning steps, and not collide with a
-    join hop of the same shape either."""
+    """Hops of the same shape must key on source_step_uuid: different owning steps, or a join hop, must not collide."""
 
     @staticmethod
     def _step(source_step_uuid: Optional[UUID]) -> TransformFrameworkStep:


### PR DESCRIPTION
Closes #1141

## Summary

`ExecutionPlan.add_tfs`'s FeatureGroupStep branch could collapse two transform hops built for genuinely different source parents into one shared `TransformFrameworkStep`, because the dedup key only compared framework/feature-group shape, not which parent the hop actually transforms. A hop only ever moves one physical source's data, so the starved consumer ended up wired to a hop that never transformed its own source, crashing (or silently resolving to the wrong data), nondeterministically depending on set iteration order during planning.

## Fix

`TransformFrameworkStep` gains a `source_step_uuid` field, included in its identity (`__eq__`/`__hash__`) alongside the existing `link_id`. In `add_tfs`'s FeatureGroupStep branch it is set to the uuid of the `FeatureGroupStep` that actually produces the parent feature (the physical source compute framework instance), not the raw parent feature uuid. Two parents produced by the same owning step (the same physical source) still correctly share one hop; two parents produced by different owning steps never do. The JoinStep branch never sets this field, so its existing `link_id`-based hop sharing is unaffected.

A dedup hit also unions the surviving hop's `required_uuids` with every parent that dedups onto it, so the hop names every source it covers.

## Tests

Unit coverage drives `ExecutionPlan.add_tfs` directly with hand-built steps for both the legitimate-sharing case (same owning step) and the must-not-share case (different owning steps), plus end-to-end regression tests through the public `mloda.prepare`/`mlodaAPI` surface that reproduce the original crash and the corrected behavior.