### PR TITLE
fix: keep uv.lock in sync with the release version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,10 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv
+          # Pinned: this job now writes uv.lock (via prepareCmd's `uv lock`) into an
+          # unreviewed [skip ci] commit, so an unpinned uv could silently change the
+          # lockfile format underneath that commit.
+          python -m pip install uv==0.11.8
           uv tool install tox --with tox-uv
 
       - name: Generate License Files

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -50,7 +50,7 @@ plugins:
   - [
       "@semantic-release/exec",
       {
-        "prepareCmd": 'sed -i ''s/^version = .*$/version = "${nextRelease.version}"/'' pyproject.toml',
+        "prepareCmd": 'sed -i ''s/^version = .*$/version = "${nextRelease.version}"/'' pyproject.toml && uv lock',
       },
     ]
   - [
@@ -63,6 +63,6 @@ plugins:
     ]
   - [
       "@semantic-release/git",
-      { "assets": ["pyproject.toml"] },
+      { "assets": ["pyproject.toml", "uv.lock"] },
     ]
 repositoryUrl: "https://github.com/mloda-ai/mloda"

--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -36,7 +36,7 @@
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
 | mktestdocs                             | 0.2.5           | MIT                                                |
-| mloda                                  | 0.10.0          | Apache-2.0                                         |
+| mloda                                  | 0.11.0          | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |

--- a/uv.lock
+++ b/uv.lock
@@ -1425,7 +1425,7 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Multiple branches were failing CI with:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

The 0.11.0 release commit bumped `pyproject.toml`'s version via semantic-release's exec plugin but never regenerated `uv.lock`, which embeds the local `mloda` package's own version. tox's default runner is `uv-venv-lock-runner`, which runs `uv sync --locked`, and that fails whenever the lockfile disagrees with `pyproject.toml`, including the local project's own version field. Because the release commit was pushed with `[skip ci]`, this landed silently on main and only surfaced once other branches synced against it.

## Fix

- Regenerated `uv.lock` and `attribution/ATTRIBUTION.md` so both match the current `0.11.0` version.
- `.releaserc.yaml`: the exec plugin's `prepareCmd` now runs `uv lock` right after the version bump sed, and the git plugin's asset list now includes `uv.lock`, so future releases commit the regenerated lockfile together with the version bump instead of drifting.
- `.github/workflows/release.yaml`: pinned `uv` to `0.11.8` in the release job. That job now writes `uv.lock` (it previously only read it), so an unpinned `uv` could silently change the lockfile format inside an unreviewed `[skip ci]` commit.

## Tests

Ran the full `tox` gate locally (pytest, ruff format/check, license allowlist, mypy --strict, bandit); all green except one pre-existing test that needs network access to download NLTK data, unrelated to this change and not reachable in this sandbox.