### PR TITLE
fix: normalize Windows path handling in read_context_files and its tests

### DIFF
--- a/mloda_plugins/feature_group/input_data/read_context_files.py
+++ b/mloda_plugins/feature_group/input_data/read_context_files.py
@@ -193,6 +193,6 @@ def find_file_paths(
             file_paths.add(str(file_path.resolve()))
 
     if not file_paths:
-        raise ValueError(f"No files found in the root directory: {root_directory}.")
+        raise ValueError(f"No files found in the root directory: {', '.join(str(p) for p in root_directory)}.")
 
     return list(file_paths)

--- a/tests/test_docs_fences.py
+++ b/tests/test_docs_fences.py
@@ -209,7 +209,7 @@ def test_illustrative_py_blocks_match_allowlist() -> None:
     errors: list[str] = []
     for path in _doc_files():
         actual = sum(1 for fence in _iter_fence_openings(path) if fence.info.strip() == ILLUSTRATIVE_TAG)
-        allowed = ILLUSTRATIVE_BLOCK_ALLOWLIST.get(str(path.relative_to(REPO_ROOT)), 0)
+        allowed = ILLUSTRATIVE_BLOCK_ALLOWLIST.get(path.relative_to(REPO_ROOT).as_posix(), 0)
         if actual > allowed:
             errors.append(
                 f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but only {allowed} allowed. "

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
@@ -220,7 +220,8 @@ class TestEmbeddedNewlinesAreStrippedFromExplicitFilePaths:
         """The source value is the clean path, so the reader receives an openable file name."""
         _write(tmp_path, "a.py")
         clean = str(tmp_path / "a.py")
-        raw = f"{clean}\n" if newline_position == "trailing" else f"{tmp_path}\n/a.py"
+        split = len(str(tmp_path))
+        raw = f"{clean}\n" if newline_position == "trailing" else f"{clean[:split]}\n{clean[split:]}"
         options = Options(
             {
                 "file_paths": [raw],

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
@@ -1,3 +1,4 @@
+import re
 import sqlite3
 from typing import Any
 import pytest
@@ -92,7 +93,8 @@ class TestSQLITEReader:
     def test_is_valid_credentials_nonexistent(self, tmp_path: Any) -> None:
         credentials = {"sqlite": str(tmp_path / "nonexistent.db")}
         with pytest.raises(
-            ValueError, match=f"Database file {credentials['sqlite']} does not exist, but key is given."
+            ValueError,
+            match=f"Database file {re.escape(credentials['sqlite'])} does not exist, but key is given.",
         ):
             SQLITEReader.is_valid_credentials(credentials)
 


### PR DESCRIPTION
## Summary

Fixes 4 Windows-specific `tox` failures caused by backslash doing double duty as both the OS path separator and an escape character — a docs-fence allowlist lookup, a test fixture, an error message, and a regex match pattern all broke on native Windows while passing on Linux/WSL.

- read_context_files.py: join raw path strings instead of interpolating
  the list, avoiding repr()'s backslash-doubling
- test_docs_fences.py: use as_posix() for the allowlist lookup key
- test_read_context_files_file_paths_filtering.py: build the interior-
  newline fixture from an OS-native joined path
- test_sqlite.py: re.escape() the path before using it as a regex
  match pattern

## Related issue

Closes #1144

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [x] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [x] Tests added or updated for the change (and the skip count adjusted if needed)
- [ ] Documentation updated where relevant
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)