### PR TITLE
docs: state that mloda.core.* is not public API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,9 @@ Tests that drive FeatureGroup resolution target the seam in `tests/test_core/tes
 ripple across test files. Exact failure-message wording is not part of the seam. Plugin authors debugging
 resolution use the public `resolve_feature`; see the
 [resolution errors guide](docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md).
+This follows a repo-wide rule: nothing under `mloda.core.*` is public API (see
+[`mloda/core/README.md`](mloda/core/README.md#public-api-surface)), so it can change without a
+deprecation warning or a release-note entry.
 
 ### Running Checks Locally
 

--- a/mloda/core/README.md
+++ b/mloda/core/README.md
@@ -55,6 +55,13 @@ The mloda Core works by:
 
 This approach focuses on defining transformations rather than static states, facilitating smooth transitions between development phases and reducing redundant work.
 
+## Public API surface
+
+Nothing under `mloda.core.*` is public API, whether or not a name carries a leading underscore. The
+public surface is exclusively what `mloda.user`, `mloda.provider` and `mloda.steward` re-export through
+their `__all__` lists. A helper, class or function reachable only via a deep `mloda.core.*` import path
+can be renamed or removed without a deprecation warning or a release-note entry.
+
 ## Development
 When extending or modifying the core functionality, consider the following guidelines:
 


### PR DESCRIPTION
A downstream consumer hit a bare `ImportError` when an internal helper under `mloda.core.*` was removed, with no deprecation warning and no release-note mention. The helper was never re-exported from any of the public facades (`mloda.user`, `mloda.provider`, `mloda.steward`), so it was never public API, but that wasn't written down anywhere a consumer would find it.

This documents the existing convention explicitly:

- `mloda/core/README.md`: a new "Public API surface" section states that only `mloda.user`, `mloda.provider` and `mloda.steward` (via their `__all__` lists) are public; nothing under `mloda.core.*` is guaranteed, with or without a leading underscore.
- `CONTRIBUTING.md`: the existing note about `IdentifyFeatureGroupClass` internals now points to the general rule.

No code or behavior changes.