### PR TITLE
fix: keep ATTRIBUTION.md's mloda row in sync with releases

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -50,7 +50,7 @@ plugins:
   - [
       "@semantic-release/exec",
       {
-        "prepareCmd": 'sed -i ''s/^version = .*$/version = "${nextRelease.version}"/'' pyproject.toml && uv lock',
+        "prepareCmd": 'sed -i ''s/^version = .*$/version = "${nextRelease.version}"/'' pyproject.toml && uv lock && python -m attribution.attributions sync-version "${nextRelease.version}"',
       },
     ]
   - [
@@ -63,6 +63,6 @@ plugins:
     ]
   - [
       "@semantic-release/git",
-      { "assets": ["pyproject.toml", "uv.lock"] },
+      { "assets": ["pyproject.toml", "uv.lock", "attribution/ATTRIBUTION.md"] },
     ]
 repositoryUrl: "https://github.com/mloda-ai/mloda"

--- a/attribution/attributions.py
+++ b/attribution/attributions.py
@@ -5,11 +5,6 @@ import sys
 from typing import Any
 from urllib.request import urlopen
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-
 
 def download_files(base_url: str, files: list[str], output_dir: str = ".") -> None:
     """Downloads files from a given base URL."""
@@ -24,6 +19,11 @@ def download_files(base_url: str, files: list[str], output_dir: str = ".") -> No
 
 def get_version(path: str = "pyproject.toml") -> Any:
     """Extracts the version from a pyproject.toml file."""
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
     with open(path, "rb") as f:
         return tomllib.load(f)["project"]["version"]
 
@@ -59,9 +59,9 @@ def add_file_to_git(files: list[str], out: str) -> None:
 
 def update_mloda_version(content: str, new_version: str) -> str:
     """Replaces the mloda row's version cell in a pip-licenses markdown table and re-renders the table."""
-    lines = content.split("\n")
-    if lines and lines[-1] == "":
-        lines = lines[:-1]
+    lines = [line for line in content.split("\n") if line.strip() != ""]
+    if len(lines) < 2:
+        raise ValueError("Attribution table content must contain a header row and a separator row.")
     header_line = lines[0]
     data_lines = lines[2:]
 
@@ -70,6 +70,10 @@ def update_mloda_version(content: str, new_version: str) -> str:
 
     header_cells = parse_row(header_line)
     rows = [parse_row(line) for line in data_lines]
+
+    for line, row in zip(data_lines, rows):
+        if len(row) != len(header_cells):
+            raise ValueError(f"Expected {len(header_cells)} cell(s) per row but found {len(row)} in row: {line!r}")
 
     mloda_index = None
     for index, row in enumerate(rows):
@@ -97,34 +101,45 @@ def run_sync_version_command(version: str, path: str = "attribution/ATTRIBUTION.
     """Rewrites the mloda version cell in the attribution file at the given path."""
     with open(path, "r") as f:
         content = f.read()
+    updated = update_mloda_version(content, version)
     with open(path, "w") as f:
-        f.write(update_mloda_version(content, version))
+        f.write(updated)
+
+
+def run_default_sync_command() -> None:
+    """Downloads attribution files from the latest mloda release and compares them using tox."""
+    files = ["THIRD_PARTY_LICENSES.md"]
+    version = get_version()
+    print(f"Version: {version}")
+
+    base = f"https://github.com/mloda-ai/mloda/releases/download/{version}/"
+    out = "attribution/"
+
+    download_files(base, files, out)
+    add_file_to_git(files, out)
+    remove_tox()
+
+    os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"] = "true"
+    try:
+        run_tox()
+    finally:
+        del os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"]
+
+
+def main(argv: list[str]) -> None:
+    """Dispatches to the default sync workflow or the sync-version subcommand."""
+    if len(argv) <= 1:
+        run_default_sync_command()
+        return
+
+    if argv[1] != "sync-version":
+        raise ValueError(f"Unknown subcommand: {argv[1]!r}")
+
+    if len(argv) < 3 or not argv[2].strip():
+        raise ValueError("sync-version requires a non-empty version argument.")
+
+    run_sync_version_command(argv[2])
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "sync-version":
-        run_sync_version_command(sys.argv[2])
-    else:
-        """
-            This script downloads attribution files from the latest release of mloda and compares them using tox.
-            The version is extracted from the pyproject.toml file, thus you need the latest pull from main.
-
-            You can view the results with git diff.
-        """
-
-        files = ["THIRD_PARTY_LICENSES.md"]
-        version = get_version()
-        print(f"Version: {version}")
-
-        base = f"https://github.com/mloda-ai/mloda/releases/download/{version}/"
-        out = "attribution/"
-
-        download_files(base, files, out)
-        add_file_to_git(files, out)
-        remove_tox()
-
-        os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"] = "true"
-        try:
-            run_tox()
-        finally:
-            del os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"]
+    main(sys.argv)

--- a/attribution/attributions.py
+++ b/attribution/attributions.py
@@ -57,27 +57,74 @@ def add_file_to_git(files: list[str], out: str) -> None:
         print(f"{file_path} was successfully added to the git staging area.")
 
 
+def update_mloda_version(content: str, new_version: str) -> str:
+    """Replaces the mloda row's version cell in a pip-licenses markdown table and re-renders the table."""
+    lines = content.split("\n")
+    if lines and lines[-1] == "":
+        lines = lines[:-1]
+    header_line = lines[0]
+    data_lines = lines[2:]
+
+    def parse_row(line: str) -> list[str]:
+        return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+    header_cells = parse_row(header_line)
+    rows = [parse_row(line) for line in data_lines]
+
+    mloda_index = None
+    for index, row in enumerate(rows):
+        if row[0] == "mloda":
+            mloda_index = index
+            break
+
+    if mloda_index is None:
+        raise ValueError("No row with package name 'mloda' found in attribution table.")
+
+    rows[mloda_index][1] = new_version
+
+    all_rows = [header_cells] + rows
+    widths = [max(len(row[col]) for row in all_rows) for col in range(len(header_cells))]
+
+    def render_row(cells: list[str]) -> str:
+        return "| " + " | ".join(cell.ljust(width) for cell, width in zip(cells, widths)) + " |"
+
+    separator = "|" + "|".join("-" * (width + 2) for width in widths) + "|"
+    rendered = [render_row(header_cells), separator] + [render_row(row) for row in rows]
+    return "\n".join(rendered) + "\n"
+
+
+def run_sync_version_command(version: str, path: str = "attribution/ATTRIBUTION.md") -> None:
+    """Rewrites the mloda version cell in the attribution file at the given path."""
+    with open(path, "r") as f:
+        content = f.read()
+    with open(path, "w") as f:
+        f.write(update_mloda_version(content, version))
+
+
 if __name__ == "__main__":
-    """
-        This script downloads attribution files from the latest release of mloda and compares them using tox.
-        The version is extracted from the pyproject.toml file, thus you need the latest pull from main.
+    if len(sys.argv) > 1 and sys.argv[1] == "sync-version":
+        run_sync_version_command(sys.argv[2])
+    else:
+        """
+            This script downloads attribution files from the latest release of mloda and compares them using tox.
+            The version is extracted from the pyproject.toml file, thus you need the latest pull from main.
 
-        You can view the results with git diff.
-    """
+            You can view the results with git diff.
+        """
 
-    files = ["THIRD_PARTY_LICENSES.md"]
-    version = get_version()
-    print(f"Version: {version}")
+        files = ["THIRD_PARTY_LICENSES.md"]
+        version = get_version()
+        print(f"Version: {version}")
 
-    base = f"https://github.com/mloda-ai/mloda/releases/download/{version}/"
-    out = "attribution/"
+        base = f"https://github.com/mloda-ai/mloda/releases/download/{version}/"
+        out = "attribution/"
 
-    download_files(base, files, out)
-    add_file_to_git(files, out)
-    remove_tox()
+        download_files(base, files, out)
+        add_file_to_git(files, out)
+        remove_tox()
 
-    os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"] = "true"
-    try:
-        run_tox()
-    finally:
-        del os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"]
+        os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"] = "true"
+        try:
+            run_tox()
+        finally:
+            del os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"]

--- a/tests/test_attributions.py
+++ b/tests/test_attributions.py
@@ -5,7 +5,15 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from attribution.attributions import add_file_to_git, download_files, get_version, remove_tox, run_tox
+from attribution.attributions import (
+    add_file_to_git,
+    download_files,
+    get_version,
+    remove_tox,
+    run_sync_version_command,
+    run_tox,
+    update_mloda_version,
+)
 
 
 class TestGetVersion:
@@ -94,3 +102,111 @@ class TestAddFileToGit:
     def test_raises_on_git_failure(self, mock_run: MagicMock) -> None:
         with pytest.raises(subprocess.CalledProcessError):
             add_file_to_git(["file.md"], "output/")
+
+
+class TestUpdateMlodaVersion:
+    def test_updates_only_the_mloda_version_cell(self) -> None:
+        content = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 0.9.0   | Apache-2.0 |\n"
+            "| zeta  | 2.3.4   | BSD        |\n"
+        )
+        expected = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 1.0.0   | Apache-2.0 |\n"
+            "| zeta  | 2.3.4   | BSD        |\n"
+        )
+        assert update_mloda_version(content, "1.0.0") == expected
+
+    def test_widens_version_column_when_new_version_is_longer(self) -> None:
+        content = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 0.9.0   | Apache-2.0 |\n"
+            "| zeta  | 2.3.4   | BSD        |\n"
+        )
+        expected = (
+            "| Name  | Version    | License    |\n"
+            "|-------|------------|------------|\n"
+            "| alpha | 1.0.0      | MIT        |\n"
+            "| mloda | 10.100.100 | Apache-2.0 |\n"
+            "| zeta  | 2.3.4      | BSD        |\n"
+        )
+        assert update_mloda_version(content, "10.100.100") == expected
+
+    def test_shrinks_version_column_when_old_version_was_the_widest_cell(self) -> None:
+        content = (
+            "| Name  | Version    | License    |\n"
+            "|-------|------------|------------|\n"
+            "| alpha | 1.0.0      | MIT        |\n"
+            "| mloda | 10.100.100 | Apache-2.0 |\n"
+            "| zeta  | 2.3.4      | BSD        |\n"
+        )
+        expected = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 1.0.0   | Apache-2.0 |\n"
+            "| zeta  | 2.3.4   | BSD        |\n"
+        )
+        assert update_mloda_version(content, "1.0.0") == expected
+
+    def test_idempotent_when_mloda_already_has_target_version(self) -> None:
+        content = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 0.11.0  | Apache-2.0 |\n"
+        )
+        assert update_mloda_version(content, "0.11.0") == content
+
+    def test_raises_value_error_when_mloda_row_is_missing(self) -> None:
+        content = (
+            "| Name  | Version | License |\n"
+            "|-------|---------|---------|\n"
+            "| alpha | 1.0.0   | MIT     |\n"
+            "| zeta  | 2.3.4   | BSD     |\n"
+        )
+        with pytest.raises(ValueError, match="mloda"):
+            update_mloda_version(content, "1.0.0")
+
+    def test_does_not_match_package_name_that_merely_contains_mloda(self) -> None:
+        content = (
+            "| Name         | Version | License    |\n"
+            "|--------------|---------|------------|\n"
+            "| mloda-plugin | 3.3.3   | MIT        |\n"
+            "| mloda        | 0.9.0   | Apache-2.0 |\n"
+        )
+        expected = (
+            "| Name         | Version | License    |\n"
+            "|--------------|---------|------------|\n"
+            "| mloda-plugin | 3.3.3   | MIT        |\n"
+            "| mloda        | 1.5.0   | Apache-2.0 |\n"
+        )
+        assert update_mloda_version(content, "1.5.0") == expected
+
+
+class TestRunSyncVersionCommand:
+    def test_writes_updated_attribution_file_at_default_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        attribution_dir = tmp_path / "attribution"
+        attribution_dir.mkdir()
+        original = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 0.9.0   | Apache-2.0 |\n"
+        )
+        attribution_file = attribution_dir / "ATTRIBUTION.md"
+        attribution_file.write_text(original)
+
+        run_sync_version_command("2.0.0")
+
+        assert attribution_file.read_text() == update_mloda_version(original, "2.0.0")

--- a/tests/test_attributions.py
+++ b/tests/test_attributions.py
@@ -1,10 +1,13 @@
+import importlib
 import os
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+import attribution.attributions as attributions_module
 from attribution.attributions import (
     add_file_to_git,
     download_files,
@@ -31,6 +34,18 @@ class TestGetVersion:
         pyproject.write_text("[project]\n")
         with pytest.raises(KeyError):
             get_version(str(pyproject))
+
+
+class TestLazyTomlImport:
+    def test_module_imports_without_tomli_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Importing the module must not require tomli/tomllib (release Python 3.10 lacks tomli outside tox)."""
+        monkeypatch.setitem(sys.modules, "tomli", None)
+        monkeypatch.setitem(sys.modules, "tomllib", None)
+        try:
+            importlib.reload(attributions_module)
+        finally:
+            monkeypatch.undo()
+            importlib.reload(attributions_module)
 
 
 class TestDownloadFiles:
@@ -190,6 +205,45 @@ class TestUpdateMlodaVersion:
         )
         assert update_mloda_version(content, "1.5.0") == expected
 
+    def test_raises_clear_error_on_row_with_too_many_cells(self) -> None:
+        content = (
+            "| Name  | Version | License |\n"
+            "|-------|---------|---------|\n"
+            "| mloda | 1.0.0   | MIT     |\n"
+            "| weird | 1.0     | MIT | BSD |\n"
+        )
+        with pytest.raises(ValueError, match="cell"):
+            update_mloda_version(content, "1.0.0")
+
+    def test_raises_clear_error_on_row_with_too_few_cells(self) -> None:
+        content = (
+            "| Name  | Version | License |\n"
+            "|-------|---------|---------|\n"
+            "| mloda | 1.0.0   | MIT     |\n"
+            "| weird | 1.0     |\n"
+        )
+        with pytest.raises(ValueError, match="cell"):
+            update_mloda_version(content, "1.0.0")
+
+    def test_raises_clear_error_on_empty_content(self) -> None:
+        with pytest.raises(ValueError):
+            update_mloda_version("", "1.0.0")
+
+    def test_handles_multiple_trailing_blank_lines(self) -> None:
+        content = (
+            "| Name  | Version | License    |\n"
+            "|-------|---------|------------|\n"
+            "| alpha | 1.0.0   | MIT        |\n"
+            "| mloda | 0.9.0   | Apache-2.0 |\n"
+        )
+        single_trailing_newline = content
+        three_trailing_newlines = content + "\n\n"
+
+        result_single = update_mloda_version(single_trailing_newline, "1.0.0")
+        result_extra = update_mloda_version(three_trailing_newlines, "1.0.0")
+
+        assert result_single == result_extra
+
 
 class TestRunSyncVersionCommand:
     def test_writes_updated_attribution_file_at_default_path(
@@ -210,3 +264,87 @@ class TestRunSyncVersionCommand:
         run_sync_version_command("2.0.0")
 
         assert attribution_file.read_text() == update_mloda_version(original, "2.0.0")
+
+    def test_preserves_original_file_when_update_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        attribution_dir = tmp_path / "attribution"
+        attribution_dir.mkdir()
+        original = (
+            "| Name  | Version | License |\n"
+            "|-------|---------|---------|\n"
+            "| alpha | 1.0.0   | MIT     |\n"
+            "| zeta  | 2.3.4   | BSD     |\n"
+        )
+        attribution_file = attribution_dir / "ATTRIBUTION.md"
+        attribution_file.write_text(original)
+
+        with pytest.raises(ValueError):
+            run_sync_version_command("2.0.0")
+
+        assert attribution_file.read_text() == original
+
+
+class TestMain:
+    def test_main_with_no_args_runs_default_command(self) -> None:
+        from attribution.attributions import main
+
+        with (
+            patch("attribution.attributions.run_default_sync_command") as mock_default,
+            patch("attribution.attributions.run_sync_version_command") as mock_sync,
+        ):
+            main(["prog"])
+
+        mock_default.assert_called_once_with()
+        mock_sync.assert_not_called()
+
+    def test_main_dispatches_sync_version_to_handler(self) -> None:
+        from attribution.attributions import main
+
+        with (
+            patch("attribution.attributions.run_default_sync_command") as mock_default,
+            patch("attribution.attributions.run_sync_version_command") as mock_sync,
+        ):
+            main(["prog", "sync-version", "1.2.3"])
+
+        mock_sync.assert_called_once_with("1.2.3")
+        mock_default.assert_not_called()
+
+    def test_main_rejects_unknown_subcommand_without_running_default(self) -> None:
+        from attribution.attributions import main
+
+        with (
+            patch("attribution.attributions.run_default_sync_command") as mock_default,
+            patch("attribution.attributions.run_sync_version_command") as mock_sync,
+        ):
+            with pytest.raises(ValueError):
+                main(["prog", "bogus"])
+
+        mock_default.assert_not_called()
+        mock_sync.assert_not_called()
+
+    def test_main_rejects_sync_version_with_missing_argument(self) -> None:
+        from attribution.attributions import main
+
+        with (
+            patch("attribution.attributions.run_default_sync_command") as mock_default,
+            patch("attribution.attributions.run_sync_version_command") as mock_sync,
+        ):
+            with pytest.raises(ValueError):
+                main(["prog", "sync-version"])
+
+        mock_default.assert_not_called()
+        mock_sync.assert_not_called()
+
+    @pytest.mark.parametrize("empty_argument", ["", "   "])
+    def test_main_rejects_sync_version_with_empty_argument(self, empty_argument: str) -> None:
+        from attribution.attributions import main
+
+        with (
+            patch("attribution.attributions.run_default_sync_command") as mock_default,
+            patch("attribution.attributions.run_sync_version_command") as mock_sync,
+        ):
+            with pytest.raises(ValueError):
+                main(["prog", "sync-version", empty_argument])
+
+        mock_default.assert_not_called()
+        mock_sync.assert_not_called()


### PR DESCRIPTION
## Summary

`attribution/ATTRIBUTION.md`'s own `mloda` row went stale by one version after every release. The release job regenerates `ATTRIBUTION.md` via tox before the version bump, then explicitly restores the previously committed copy so the shipped file isn't a runner-specific regeneration. The exec plugin's `prepareCmd` bumps `pyproject.toml`'s version afterward, but nothing re-derived `ATTRIBUTION.md`'s own mloda row from the new version, and the git plugin didn't commit that file.

## Changes

- Add `update_mloda_version` to `attribution/attributions.py`: finds the `mloda` row in the license table and updates its version cell, then re-renders the whole table with column widths recomputed from every row, rather than a fixed-width text substitution (the table's column widths are derived from the longest cell in each column, so an in-place patch can silently misalign it when the version string changes length).
- Add a `sync-version` CLI subcommand so the release pipeline can call `python -m attribution.attributions sync-version <version>` after the version bump.
- Wire it into `.releaserc.yaml`: the exec plugin's `prepareCmd` now calls the sync command after bumping `pyproject.toml` and running `uv lock`, and `attribution/ATTRIBUTION.md` is added to the git plugin's committed assets alongside `pyproject.toml` and `uv.lock`.
- Move the `tomllib`/`tomli` import (needed only for the manual local maintenance path) out of module scope and into the function that actually uses it, since the release runner's base Python interpreter doesn't have `tomli` installed outside tox's isolated environment.
- Validate malformed table rows with a clear error instead of silently dropping data or raising a bare exception, avoid truncating the file when an update is rejected, tolerate stray trailing blank lines, and give the CLI an explicit dispatch so a typo in the subcommand can't fall through into the destructive default workflow.

## Test plan

- [x] `tox` passes (tests, ruff format/check, mypy --strict, bandit)
- [x] New unit tests cover version-length changes forcing column realignment, round-trip idempotency, malformed input, and the CLI dispatch contract
- [x] Verified the sync command runs correctly even with `tomli`/`tomllib` unavailable, matching the release runner's environment