### PR TITLE
fix: reject an unpicklable Link before multiprocessing starts

### DIFF
--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -25,6 +25,7 @@ from mloda.core.core.step.transform_frame_work_step import TransformFrameworkSte
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.error_utils import MlodaRunError, internal_invariant_error
 from mloda.core.abstract_plugins.feature_group import format_feature_group_class
+from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_join_link
 
 
 logger = logging.getLogger(__name__)
@@ -421,6 +422,8 @@ class ExecutionOrchestrator:
             self.cfw_register = CfwManager(parallelization_modes, function_extender)
             self.manager = None
         else:
+            raise_on_unpicklable_join_link(self.execution_planner)
+
             MyManager.register("CfwManager", CfwManager)
             self.manager = MyManager(ctx=mp_spawn_context()).__enter__()
             self.cfw_register = self.manager.CfwManager(parallelization_modes, function_extender)

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -1,6 +1,6 @@
 """Guards a JoinStep's Link against a feature group class that pickle cannot round-trip,
 which otherwise fails deep inside a multiprocessing worker with an opaque
-PicklingError instead of being rejected clearly at plan time. See issue #1117.
+PicklingError instead of being rejected clearly at plan time.
 """
 
 import pickle  # nosec

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -3,7 +3,7 @@ which otherwise fails deep inside a multiprocessing worker with an opaque
 PicklingError instead of being rejected clearly at plan time. See issue #1117.
 """
 
-import pickle
+import pickle  # nosec
 from collections.abc import Iterable
 from typing import Any
 

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -1,0 +1,42 @@
+"""Guards a JoinStep's Link against a feature group class that pickle cannot round-trip,
+which otherwise fails deep inside a multiprocessing worker with an opaque
+PicklingError instead of being rejected clearly at plan time. See issue #1117.
+"""
+
+import pickle
+from collections.abc import Iterable
+from typing import Any
+
+from mloda.core.abstract_plugins.feature_group import format_feature_group_class
+from mloda.core.core.step.join_step import JoinStep
+
+_UNPICKLABLE_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
+
+
+def _is_picklable(feature_group: type[Any]) -> bool:
+    try:
+        pickle.dumps(feature_group)
+    except _UNPICKLABLE_ERRORS:
+        return False
+    return True
+
+
+def _unpicklable_link_error(feature_group: type[Any], step: JoinStep) -> str:
+    return (
+        f"Link {step.link} references {format_feature_group_class(feature_group)}, which cannot be "
+        "pickled for multiprocessing. Feature groups created inside a local function or via a "
+        "dynamic type(...) factory are not picklable; define the feature group at module level."
+    )
+
+
+def raise_on_unpicklable_join_link(steps: Iterable[Any]) -> None:
+    """Raise ValueError if any JoinStep in steps carries a Link whose feature group is unpicklable."""
+    for step in steps:
+        if not isinstance(step, JoinStep):
+            continue
+
+        if not _is_picklable(step.link.left_feature_group):
+            raise ValueError(_unpicklable_link_error(step.link.left_feature_group, step))
+
+        if not _is_picklable(step.link.right_feature_group):
+            raise ValueError(_unpicklable_link_error(step.link.right_feature_group, step))

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -1,21 +1,21 @@
-"""Guards a JoinStep's Link against a feature group class that pickle cannot round-trip,
-which otherwise fails deep inside a multiprocessing worker with an opaque
-PicklingError instead of being rejected clearly at plan time.
+"""Guards a JoinStep's Link against a value pickle cannot round-trip, which otherwise fails deep
+inside a multiprocessing worker with an opaque PicklingError instead of being rejected clearly at
+plan time. This only proves resolvability in the current process: a class resolvable here but not
+inside a freshly spawned worker (e.g. one under `if __name__ == "__main__":`) can still fail there.
 """
 
 import pickle  # nosec
 from collections.abc import Iterable
 from typing import Any
 
-from mloda.core.abstract_plugins.feature_group import format_feature_group_class
 from mloda.core.core.step.join_step import JoinStep
 
 _UNPICKLABLE_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
 
-def _is_picklable(feature_group: type[Any]) -> bool:
+def _is_picklable(value: Any) -> bool:
     try:
-        pickle.dumps(feature_group)
+        pickle.dumps(value)
     except _UNPICKLABLE_ERRORS:
         return False
     return True
@@ -23,16 +23,33 @@ def _is_picklable(feature_group: type[Any]) -> bool:
 
 def _unpicklable_link_error(feature_group: type[Any], step: JoinStep) -> str:
     return (
-        f"Link {step.link} references {format_feature_group_class(feature_group)}, which cannot be "
-        "pickled for multiprocessing. Feature groups created inside a local function or via a "
-        "dynamic type(...) factory are not picklable; define the feature group at module level."
+        f"Link {step.link} references {feature_group.__name__} "
+        f"({feature_group.__module__}.{feature_group.__qualname__}), which pickle cannot resolve back by "
+        "that path, so multiprocessing cannot send this join to a worker process. This happens when a "
+        "feature group class is created inside a function or by a dynamic type(...) factory instead of "
+        "being defined at module level.\n"
+        "Resolution: define the feature group class at module level, or run without "
+        "ParallelizationMode.MULTIPROCESSING."
+    )
+
+
+def _unpicklable_link_generic_error(step: JoinStep) -> str:
+    return (
+        f"Link {step.link} cannot be pickled for multiprocessing, though both its feature group classes "
+        "are picklable on their own. The left_discriminator, right_discriminator, or asof_config likely "
+        "holds a value pickle cannot resolve (e.g. a locally defined class or a lambda).\n"
+        "Resolution: use only picklable values in the link's discriminators and asof configuration, or "
+        "run without ParallelizationMode.MULTIPROCESSING."
     )
 
 
 def raise_on_unpicklable_join_link(steps: Iterable[Any]) -> None:
-    """Raise ValueError if any JoinStep in steps carries a Link whose feature group is unpicklable."""
+    """Raise ValueError if any JoinStep in steps carries a Link that multiprocessing cannot pickle."""
     for step in steps:
         if not isinstance(step, JoinStep):
+            continue
+
+        if _is_picklable(step.link):
             continue
 
         if not _is_picklable(step.link.left_feature_group):
@@ -40,3 +57,5 @@ def raise_on_unpicklable_join_link(steps: Iterable[Any]) -> None:
 
         if not _is_picklable(step.link.right_feature_group):
             raise ValueError(_unpicklable_link_error(step.link.right_feature_group, step))
+
+        raise ValueError(_unpicklable_link_generic_error(step))

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
@@ -1,5 +1,5 @@
 """ExecutionOrchestrator.__enter__ must reject an unpicklable JoinStep link before
-spawning any multiprocessing Manager, and must not touch SYNC mode at all. See #1117.
+spawning any multiprocessing Manager, and must not touch SYNC mode at all.
 """
 
 from __future__ import annotations

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
@@ -1,0 +1,63 @@
+"""ExecutionOrchestrator.__enter__ must reject an unpicklable JoinStep link before
+spawning any multiprocessing Manager, and must not touch SYNC mode at all. See #1117.
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda.provider import FeatureGroup
+from mloda.user import Index, JoinSpec, Link
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class OrchestratorLinkRight(FeatureGroup):
+    """Ordinary module-level feature group: picklable."""
+
+
+def _make_local_feature_group() -> type[FeatureGroup]:
+    """A FeatureGroup subclass whose __qualname__ contains '<locals>': unpicklable."""
+
+    class LocallyDefinedFeatureGroup(FeatureGroup):
+        pass
+
+    return LocallyDefinedFeatureGroup
+
+
+def _plan_with_unpicklable_link() -> ExecutionPlan:
+    link = Link.inner(
+        JoinSpec(_make_local_feature_group(), Index(("left_key",))),
+        JoinSpec(OrchestratorLinkRight, Index(("right_key",))),
+    )
+    join_step = JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+
+    plan = ExecutionPlan()
+    plan.execution_plan = [join_step]
+    return plan
+
+
+def test_enter_with_multiprocessing_rejects_an_unpicklable_link_before_spawning_a_manager() -> None:
+    orchestrator = ExecutionOrchestrator(_plan_with_unpicklable_link())
+
+    with pytest.raises(ValueError) as excinfo:
+        orchestrator.__enter__({ParallelizationMode.MULTIPROCESSING})
+
+    assert type(excinfo.value) is not pickle.PicklingError, (
+        "the plan-time guard must fire, not the deep multiprocessing pickling failure"
+    )
+    assert orchestrator.manager is None, "no MyManager/worker process may be created on the rejection path"
+
+
+def test_enter_with_sync_mode_does_not_reject_the_same_unpicklable_link() -> None:
+    orchestrator = ExecutionOrchestrator(_plan_with_unpicklable_link())
+
+    orchestrator.__enter__({ParallelizationMode.SYNC})
+
+    orchestrator.__exit__(None, None, None)

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
@@ -4,8 +4,6 @@ spawning any multiprocessing Manager, and must not touch SYNC mode at all.
 
 from __future__ import annotations
 
-import pickle  # nosec
-
 import pytest
 
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
@@ -46,12 +44,9 @@ def _plan_with_unpicklable_link() -> ExecutionPlan:
 def test_enter_with_multiprocessing_rejects_an_unpicklable_link_before_spawning_a_manager() -> None:
     orchestrator = ExecutionOrchestrator(_plan_with_unpicklable_link())
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         orchestrator.__enter__({ParallelizationMode.MULTIPROCESSING})
 
-    assert not isinstance(excinfo.value, pickle.PicklingError), (
-        "the plan-time guard must fire, not the deep multiprocessing pickling failure"
-    )
     assert orchestrator.manager is None, "no MyManager/worker process may be created on the rejection path"
 
 

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
@@ -49,7 +49,7 @@ def test_enter_with_multiprocessing_rejects_an_unpicklable_link_before_spawning_
     with pytest.raises(ValueError) as excinfo:
         orchestrator.__enter__({ParallelizationMode.MULTIPROCESSING})
 
-    assert type(excinfo.value) is not pickle.PicklingError, (
+    assert not isinstance(excinfo.value, pickle.PicklingError), (
         "the plan-time guard must fire, not the deep multiprocessing pickling failure"
     )
     assert orchestrator.manager is None, "no MyManager/worker process may be created on the rejection path"

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_link.py
@@ -4,7 +4,7 @@ spawning any multiprocessing Manager, and must not touch SYNC mode at all. See #
 
 from __future__ import annotations
 
-import pickle
+import pickle  # nosec
 
 import pytest
 

--- a/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
+++ b/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
@@ -1,9 +1,7 @@
 """Unit tests for raise_on_unpicklable_join_link, hand-building Link/JoinStep objects.
-
-A Link whose feature group class is created inside a local function is genuinely
-unpicklable (its __qualname__ contains "<locals>"), which is what a JoinStep queued
-to a multiprocessing worker would fail deep inside pickle for. See issue #1117.
-"""
+A feature group class created inside a local function has "<locals>" in its
+__qualname__ and is genuinely unpicklable, which is what a JoinStep queued to a
+multiprocessing worker would otherwise fail deep inside pickle for."""
 
 from __future__ import annotations
 

--- a/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
+++ b/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
@@ -1,7 +1,8 @@
 """Unit tests for raise_on_unpicklable_join_link, hand-building Link/JoinStep objects.
-A feature group class created inside a local function has "<locals>" in its
-__qualname__ and is genuinely unpicklable, which is what a JoinStep queued to a
-multiprocessing worker would otherwise fail deep inside pickle for."""
+A feature group class built via type(name, (FeatureGroup,), {}) is genuinely
+unpicklable (pickle cannot resolve it back by module/qualname), which is what a
+JoinStep queued to a multiprocessing worker would otherwise fail deep inside
+pickle for."""
 
 from __future__ import annotations
 
@@ -14,6 +15,9 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_join_link
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
 
 
 class ValidateLinkLeft(FeatureGroup):
@@ -24,13 +28,10 @@ class ValidateLinkRight(FeatureGroup):
     """Ordinary module-level feature group: picklable."""
 
 
-def _make_local_feature_group() -> type[FeatureGroup]:
-    """A FeatureGroup subclass whose __qualname__ contains '<locals>': unpicklable."""
+def _make_local_feature_group(name: str = "LocallyDefinedFeatureGroup") -> type[FeatureGroup]:
+    """A dynamically built FeatureGroup subclass pickle cannot resolve back by name: unpicklable."""
 
-    class LocallyDefinedFeatureGroup(FeatureGroup):
-        pass
-
-    return LocallyDefinedFeatureGroup
+    return type(name, (FeatureGroup,), {})
 
 
 def _joinstep_for(link: Link) -> JoinStep:
@@ -49,7 +50,10 @@ def test_a_link_with_an_unpicklable_left_feature_group_is_rejected() -> None:
         raise_on_unpicklable_join_link([step])
 
     message = str(excinfo.value)
-    assert unpicklable_left.__name__ in message, f"the offending class must be named; got: {message}"
+    assert f"references {unpicklable_left.__name__} (" in message, f"the offending class must be named; got: {message}"
+    assert f"references {ValidateLinkRight.__name__} (" not in message, (
+        f"the picklable side must not be blamed; got: {message}"
+    )
     assert str(link.uuid) in message, f"the link must be named; got: {message}"
 
 
@@ -65,7 +69,10 @@ def test_a_link_with_an_unpicklable_right_feature_group_is_rejected() -> None:
         raise_on_unpicklable_join_link([step])
 
     message = str(excinfo.value)
-    assert unpicklable_right.__name__ in message, f"the offending class must be named; got: {message}"
+    assert f"references {unpicklable_right.__name__} (" in message, f"the offending class must be named; got: {message}"
+    assert f"references {ValidateLinkLeft.__name__} (" not in message, (
+        f"the picklable side must not be blamed; got: {message}"
+    )
     assert str(link.uuid) in message, f"the link must be named; got: {message}"
 
 
@@ -87,3 +94,58 @@ def test_non_joinstep_entries_are_ignored_not_crashed_on() -> None:
     step = _joinstep_for(link)
 
     raise_on_unpicklable_join_link([object(), None, step])
+
+
+def test_a_link_with_both_feature_groups_unpicklable_blames_the_left_one() -> None:
+    unpicklable_left = _make_local_feature_group("LeftUnpicklableFeatureGroup")
+    unpicklable_right = _make_local_feature_group("RightUnpicklableFeatureGroup")
+    link = Link.inner(
+        JoinSpec(unpicklable_left, Index(("left_key",))),
+        JoinSpec(unpicklable_right, Index(("right_key",))),
+    )
+    step = _joinstep_for(link)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_join_link([step])
+
+    message = str(excinfo.value)
+    assert f"references {unpicklable_left.__name__} (" in message, (
+        f"the left side must be blamed first, per the left-then-right check order; got: {message}"
+    )
+
+
+def test_a_link_with_unpicklable_discriminator_and_picklable_feature_groups_is_rejected() -> None:
+    link = Link.inner(
+        JoinSpec(ValidateLinkLeft, Index(("left_key",))),
+        JoinSpec(ValidateLinkRight, Index(("right_key",))),
+        left_discriminator={"marker": _make_local_feature_group("DiscriminatorMarkerFeatureGroup")},
+    )
+    step = _joinstep_for(link)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_join_link([step])
+
+    message = str(excinfo.value)
+    assert f"references {ValidateLinkLeft.__name__} (" not in message, (
+        f"neither feature group is individually unpicklable; got: {message}"
+    )
+    assert f"references {ValidateLinkRight.__name__} (" not in message, (
+        f"neither feature group is individually unpicklable; got: {message}"
+    )
+
+
+def test_a_link_with_a_dynamic_feature_group_creator_class_is_rejected() -> None:
+    dynamic_fg = DynamicFeatureGroupCreator.create(
+        properties={}, class_name="ReviewProbeDynamicFeatureGroup_ValidateLinkTest"
+    )
+    link = Link.inner(
+        JoinSpec(dynamic_fg, Index(("left_key",))),
+        JoinSpec(ValidateLinkRight, Index(("right_key",))),
+    )
+    step = _joinstep_for(link)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_join_link([step])
+
+    message = str(excinfo.value)
+    assert dynamic_fg.__name__ in message, f"the dynamically created class must be named; got: {message}"

--- a/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
+++ b/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
@@ -1,0 +1,91 @@
+"""Unit tests for raise_on_unpicklable_join_link, hand-building Link/JoinStep objects.
+
+A Link whose feature group class is created inside a local function is genuinely
+unpicklable (its __qualname__ contains "<locals>"), which is what a JoinStep queued
+to a multiprocessing worker would fail deep inside pickle for. See issue #1117.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.core.step.join_step import JoinStep
+from mloda.provider import FeatureGroup
+from mloda.user import Index, JoinSpec, Link
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_join_link
+
+
+class ValidateLinkLeft(FeatureGroup):
+    """Ordinary module-level feature group: picklable."""
+
+
+class ValidateLinkRight(FeatureGroup):
+    """Ordinary module-level feature group: picklable."""
+
+
+def _make_local_feature_group() -> type[FeatureGroup]:
+    """A FeatureGroup subclass whose __qualname__ contains '<locals>': unpicklable."""
+
+    class LocallyDefinedFeatureGroup(FeatureGroup):
+        pass
+
+    return LocallyDefinedFeatureGroup
+
+
+def _joinstep_for(link: Link) -> JoinStep:
+    return JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+
+
+def test_a_link_with_an_unpicklable_left_feature_group_is_rejected() -> None:
+    unpicklable_left = _make_local_feature_group()
+    link = Link.inner(
+        JoinSpec(unpicklable_left, Index(("left_key",))),
+        JoinSpec(ValidateLinkRight, Index(("right_key",))),
+    )
+    step = _joinstep_for(link)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_join_link([step])
+
+    message = str(excinfo.value)
+    assert unpicklable_left.__name__ in message, f"the offending class must be named; got: {message}"
+    assert str(link.uuid) in message, f"the link must be named; got: {message}"
+
+
+def test_a_link_with_an_unpicklable_right_feature_group_is_rejected() -> None:
+    unpicklable_right = _make_local_feature_group()
+    link = Link.inner(
+        JoinSpec(ValidateLinkLeft, Index(("left_key",))),
+        JoinSpec(unpicklable_right, Index(("right_key",))),
+    )
+    step = _joinstep_for(link)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_join_link([step])
+
+    message = str(excinfo.value)
+    assert unpicklable_right.__name__ in message, f"the offending class must be named; got: {message}"
+    assert str(link.uuid) in message, f"the link must be named; got: {message}"
+
+
+def test_a_link_whose_both_sides_are_picklable_does_not_raise() -> None:
+    link = Link.inner(
+        JoinSpec(ValidateLinkLeft, Index(("left_key",))),
+        JoinSpec(ValidateLinkRight, Index(("right_key",))),
+    )
+    step = _joinstep_for(link)
+
+    raise_on_unpicklable_join_link([step])
+
+
+def test_non_joinstep_entries_are_ignored_not_crashed_on() -> None:
+    link = Link.inner(
+        JoinSpec(ValidateLinkLeft, Index(("left_key",))),
+        JoinSpec(ValidateLinkRight, Index(("right_key",))),
+    )
+    step = _joinstep_for(link)
+
+    raise_on_unpicklable_join_link([object(), None, step])


### PR DESCRIPTION
## Summary

A `Link` declared on a feature group class produced at runtime (for example by a dynamic feature group creator) could not be pickled, so a plan containing it crashed deep inside a multiprocessing worker with an opaque `PicklingError` instead of failing clearly.

`ExecutionOrchestrator.__enter__` now checks every planned `JoinStep`'s `Link` before spawning the multiprocessing manager or any worker process. If pickle cannot round-trip the link (its feature group classes, or a value hidden in `left_discriminator`, `right_discriminator`, or `asof_config`), it raises a `ValueError` naming the link and, where possible, the specific offending class, with a resolution hint. SYNC and THREADING modes never pickle, so they are unaffected and this dynamic-feature-group pattern keeps working there exactly as before.

## Test plan

- [x] New unit tests for the guard function directly (single-side unpicklable, both-sides unpicklable, discriminator-only unpicklable, and the production `DynamicFeatureGroupCreator` pattern)
- [x] New tests confirming `ExecutionOrchestrator.__enter__` rejects before any manager/worker is spawned under MULTIPROCESSING, and leaves SYNC mode unaffected
- [x] `tox` green: full suite, ruff format/check, mypy --strict, bandit