### PR TITLE
Add scalar_only to PropertySpec to reject collections outright on reader options

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -36,6 +36,7 @@ PROPERTY_MAPPING = {
 | `context` | `bool` | `True` | `True`: context parameter. `False`: group parameter, which splits feature groups. |
 | `strict_validation` | `bool` | `False` | Enforce the value space at match time. |
 | `element_validator` | `Callable \| None` | `None` | Per-element predicate. Requires `strict_validation=True`. |
+| `scalar_only` | `bool` | `False` | Reader-only: rejects a `list`/`tuple`/`set`/`frozenset` value outright instead of unpacking it element-wise. Requires `strict_validation=True`. |
 | `match_guard` | `Callable \| None` | `None` | Whole-value predicate. A falsy return is a non-match. |
 | `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
 | `allow_explicit_none` | `bool` | `False` | Opt-in so an explicit `None` is honored (not treated as absent) and flows through validation. |
@@ -83,7 +84,7 @@ does not understand can be absorbed silently.
 | Class definition (mixin) | Universal-matcher diagnostic | An all-optional `PROPERTY_MAPPING` inherits the configuration matcher, so it matches any name with empty options | The class | `logger.warning`, unless `ALLOW_UNIVERSAL_MATCHER = True` |
 | Author time (reader surface) | `mypy --strict` | `READER_OPTIONS` holds `PropertySpec` values | The constructor call | mypy error at the declaration |
 | Class definition (`BaseInputData.__init_subclass__`) | Spec type + surface guard | Every value IS a `PropertySpec` and declares nothing inert on a reader (`match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key); the reserved key's **winning** declaration across the MRO keeps `framework_set=True` | Every value in that class's declaration, plus the reserved key as the MRO merge resolves it | `ValueError` naming class, key and field |
-| Match time (reader selection) | Presence + strict validation | Required keys are present and present strict values pass, element-wise; `framework_set` keys exempt | The candidate's merged specs and the options | Reader non-match. Addressed-reader and supplied-value failures record a `stage="input_data"` rejection; unaddressed absence and an unjudgeable predicate decline silently |
+| Match time (reader selection) | Presence + strict validation | Required keys are present and present strict values pass, element-wise unless `scalar_only` rejects a collection outright; `framework_set` keys exempt | The candidate's merged specs and the options | Reader non-match. Addressed-reader and supplied-value failures record a `stage="input_data"` rejection; unaddressed absence and an unjudgeable predicate decline silently |
 | Match time (reader code) | `reader_option(key, options)` | Supplied value, else the declared `default` | The key name and the options | `ValueError` for an undeclared key or an absent `NO_DEFAULT` one |
 
 A spec is constructed inside the class body, so its own rules fire before the class exists.
@@ -149,6 +150,11 @@ consequences keep the shared type honest on this surface:
   `PROPERTY_MAPPING` the field is rejected outright. The reserved key is checked as the MRO merge
   resolves it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a
   plain mixin can turn the framework-written key into a user-enforced one.
+- **The reverse also holds: a reader-only field has no `PROPERTY_MAPPING` meaning.** `scalar_only=True`
+  (#1154) rejects a collection value outright instead of unpacking it element-wise, which only makes
+  sense at reader selection; `FeatureChainParser` rejects it on `PROPERTY_MAPPING` at class definition,
+  mirroring how `match_guard`, `deferred_binding` and `context=False` are rejected on the reader
+  surface, because `PROPERTY_MAPPING` keys always unpack element-wise.
 
 `READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
 so a concrete reader inherits its family's keys and redeclares nothing, and

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -149,12 +149,10 @@ consequences keep the shared type honest on this surface:
   `PROPERTY_MAPPING` the field is rejected outright. The reserved key is checked as the MRO merge
   resolves it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a
   plain mixin can turn the framework-written key into a user-enforced one.
-- **The reverse also holds: a reader-only field has no `PROPERTY_MAPPING` meaning.** `scalar_only`
-  (`bool`, default `False`, requires `strict_validation=True`) (#1154) rejects a `list`/`tuple`/`set`/
-  `frozenset` value outright instead of unpacking it element-wise, which only makes sense at reader
-  selection; `FeatureChainParser` rejects it on `PROPERTY_MAPPING` at class definition, mirroring how
-  `match_guard`, `deferred_binding` and `context=False` are rejected on the reader surface, because
-  `PROPERTY_MAPPING` keys always unpack element-wise.
+- **The reverse also holds: a reader-only field has no `PROPERTY_MAPPING` meaning.** `scalar_only` (#1154)
+  rejects a collection value outright instead of unpacking it element-wise, so `FeatureChainParser` rejects
+  it on `PROPERTY_MAPPING` at class definition, the same way `match_guard`/`deferred_binding`/`context=False`
+  are rejected on the reader surface.
 
 `READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
 so a concrete reader inherits its family's keys and redeclares nothing, and

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -36,7 +36,6 @@ PROPERTY_MAPPING = {
 | `context` | `bool` | `True` | `True`: context parameter. `False`: group parameter, which splits feature groups. |
 | `strict_validation` | `bool` | `False` | Enforce the value space at match time. |
 | `element_validator` | `Callable \| None` | `None` | Per-element predicate. Requires `strict_validation=True`. |
-| `scalar_only` | `bool` | `False` | Reader-only: rejects a `list`/`tuple`/`set`/`frozenset` value outright instead of unpacking it element-wise. Requires `strict_validation=True`. |
 | `match_guard` | `Callable \| None` | `None` | Whole-value predicate. A falsy return is a non-match. |
 | `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
 | `allow_explicit_none` | `bool` | `False` | Opt-in so an explicit `None` is honored (not treated as absent) and flows through validation. |
@@ -150,11 +149,12 @@ consequences keep the shared type honest on this surface:
   `PROPERTY_MAPPING` the field is rejected outright. The reserved key is checked as the MRO merge
   resolves it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a
   plain mixin can turn the framework-written key into a user-enforced one.
-- **The reverse also holds: a reader-only field has no `PROPERTY_MAPPING` meaning.** `scalar_only=True`
-  (#1154) rejects a collection value outright instead of unpacking it element-wise, which only makes
-  sense at reader selection; `FeatureChainParser` rejects it on `PROPERTY_MAPPING` at class definition,
-  mirroring how `match_guard`, `deferred_binding` and `context=False` are rejected on the reader
-  surface, because `PROPERTY_MAPPING` keys always unpack element-wise.
+- **The reverse also holds: a reader-only field has no `PROPERTY_MAPPING` meaning.** `scalar_only`
+  (`bool`, default `False`, requires `strict_validation=True`) (#1154) rejects a `list`/`tuple`/`set`/
+  `frozenset` value outright instead of unpacking it element-wise, which only makes sense at reader
+  selection; `FeatureChainParser` rejects it on `PROPERTY_MAPPING` at class definition, mirroring how
+  `match_guard`, `deferred_binding` and `context=False` are rejected on the reader surface, because
+  `PROPERTY_MAPPING` keys always unpack element-wise.
 
 `READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
 so a concrete reader inherits its family's keys and redeclares nothing, and

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -273,6 +273,13 @@ class FeatureChainParser:
                 f"reader-surface (READER_OPTIONS) key written by the framework; PROPERTY_MAPPING keys "
                 f"are user-set."
             )
+        if spec.scalar_only:
+            # Contained: a scalar_only spec is that candidate's own defect, so the seam reads it as a non-match.
+            raise ValueError(
+                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares scalar_only=True, which marks a "
+                f"reader-surface (READER_OPTIONS) key rejected outright as a collection; PROPERTY_MAPPING "
+                f"keys always unpack element-wise."
+            )
         return spec
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -90,10 +90,7 @@ class PropertySpec:
     deferred_binding: bool = False
     # Marks a reader-surface key the framework writes rather than the user; rejected on the PROPERTY_MAPPING surface.
     framework_set: bool = False
-    # allowed_values and element_validator apply element-wise to a list/tuple/set/frozenset value (a
-    # str is one scalar, a dict one composite value). Reader-only: scalar_only=True rejects such a
-    # collection outright on a reader key instead of unpacking it. Enforced only in
-    # BaseInputData._present_reader_option_admits.
+    # Reader-only: rejects a list/tuple/set/frozenset value outright instead of unpacking it element-wise.
     scalar_only: bool = False
 
     def __post_init__(self) -> None:

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -90,8 +90,10 @@ class PropertySpec:
     deferred_binding: bool = False
     # Marks a reader-surface key the framework writes rather than the user; rejected on the PROPERTY_MAPPING surface.
     framework_set: bool = False
-    # Reader-only: a list/tuple/set/frozenset value is rejected outright as a collection rather than
-    # unpacked element-wise. Enforced only in BaseInputData._present_reader_option_admits.
+    # allowed_values and element_validator apply element-wise to a list/tuple/set/frozenset value (a
+    # str is one scalar, a dict one composite value). Reader-only: scalar_only=True rejects such a
+    # collection outright on a reader key instead of unpacking it. Enforced only in
+    # BaseInputData._present_reader_option_admits.
     scalar_only: bool = False
 
     def __post_init__(self) -> None:
@@ -180,6 +182,12 @@ class PropertySpec:
         if is_no_default(self.default) or self.default is None or not self.strict_validation:
             return
 
+        if self.scalar_only and isinstance(self.default, (list, tuple, set, frozenset)):
+            raise ValueError(
+                f"{prefix}: scalar_only=True with a {type(self.default).__name__} default {self.default!r}; "
+                f"reader_option() would return the collection the flag rejects."
+            )
+
         if self.element_validator is not None:
             try:
                 verdict = self.element_validator(self.default)
@@ -216,7 +224,6 @@ def property_spec(
     match_guard: Callable[[Any], Any] | None = None,
     allow_explicit_none: bool = False,
     deferred_binding: bool = False,
-    scalar_only: bool = False,
 ) -> PropertySpec:
     """Build a ``PropertySpec``; the ``strict=`` keyword sets the ``strict_validation`` field."""
     return PropertySpec(
@@ -230,5 +237,4 @@ def property_spec(
         required_when=required_when,
         allow_explicit_none=allow_explicit_none,
         deferred_binding=deferred_binding,
-        scalar_only=scalar_only,
     )

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -90,6 +90,9 @@ class PropertySpec:
     deferred_binding: bool = False
     # Marks a reader-surface key the framework writes rather than the user; rejected on the PROPERTY_MAPPING surface.
     framework_set: bool = False
+    # Reader-only: a list/tuple/set/frozenset value is rejected outright as a collection rather than
+    # unpacked element-wise. Enforced only in BaseInputData._present_reader_option_admits.
+    scalar_only: bool = False
 
     def __post_init__(self) -> None:
         prefix = f"PropertySpec({self.explanation!r})"
@@ -130,6 +133,9 @@ class PropertySpec:
         if not isinstance(self.framework_set, bool):
             raise ValueError(f"{prefix}: framework_set must be a bool, got {type(self.framework_set).__name__}.")
 
+        if not isinstance(self.scalar_only, bool):
+            raise ValueError(f"{prefix}: scalar_only must be a bool, got {type(self.scalar_only).__name__}.")
+
         if self.element_validator is not None and not callable(self.element_validator):
             raise ValueError(f"{prefix}: element_validator must be callable.")
 
@@ -141,6 +147,9 @@ class PropertySpec:
 
         if self.element_validator is not None and not self.strict_validation:
             raise ValueError(f"{prefix}: element_validator is never enforced without strict_validation=True.")
+
+        if self.scalar_only and not self.strict_validation:
+            raise ValueError(f"{prefix}: scalar_only is never enforced without strict_validation=True.")
 
         self._check_value_space(prefix)
         self._check_declared_default(prefix)
@@ -207,6 +216,7 @@ def property_spec(
     match_guard: Callable[[Any], Any] | None = None,
     allow_explicit_none: bool = False,
     deferred_binding: bool = False,
+    scalar_only: bool = False,
 ) -> PropertySpec:
     """Build a ``PropertySpec``; the ``strict=`` keyword sets the ``strict_validation`` field."""
     return PropertySpec(
@@ -220,4 +230,5 @@ def property_spec(
         required_when=required_when,
         allow_explicit_none=allow_explicit_none,
         deferred_binding=deferred_binding,
+        scalar_only=scalar_only,
     )

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -285,8 +285,8 @@ class BaseInputData(ABC):
             owner = cls.get_class_name()
             record_match_rejection(
                 owner,
-                f"reader option '{key}' value {value!r} is a {type(value).__name__}, but the declaration of "
-                f"{owner} marks it scalar_only and rejects a collection outright",
+                f"reader option '{key}' value is a {type(value).__name__} of {len(value)} elements, but the "
+                f"declaration of {owner} marks it scalar_only and rejects a collection outright",
                 stage=INPUT_DATA_OWNED_STAGE if owned else INPUT_DATA_STAGE,
             )
             return False

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -279,7 +279,17 @@ class BaseInputData(ABC):
     @classmethod
     def _present_reader_option_admits(cls, key: str, spec: PropertySpec, value: Any, owned: bool) -> bool:
         """Strict validation of a PRESENT value: list/tuple/set/frozenset unpack element-wise,
-        a str is one scalar, a dict one composite value; owned stages the recorded rejection."""
+        a str is one scalar, a dict one composite value; owned stages the recorded rejection.
+        scalar_only=True short-circuits: a list/tuple/set/frozenset value is rejected outright, never unpacked."""
+        if spec.scalar_only and isinstance(value, (list, tuple, set, frozenset)):
+            owner = cls.get_class_name()
+            record_match_rejection(
+                owner,
+                f"reader option '{key}' value {value!r} is a {type(value).__name__}, but the declaration of "
+                f"{owner} marks it scalar_only and rejects a collection outright",
+                stage=INPUT_DATA_OWNED_STAGE if owned else INPUT_DATA_STAGE,
+            )
+            return False
         elements = list(value) if isinstance(value, (list, tuple, set, frozenset)) else [value]
         for element in elements:
             if cls._reader_option_element_admits(key, spec, element):

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -28,6 +28,9 @@ class ReadDB(BaseInputData):
         "data_access_handle": PropertySpec(
             "Hint naming which DataAccessCollection credentials handle to prefer while matching.",
             default=None,
+            element_validator=lambda value: isinstance(value, str),
+            strict_validation=True,
+            scalar_only=True,
         ),
     }
 

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -48,6 +48,9 @@ class ReadFile(BaseInputData):
         "data_access_handle": PropertySpec(
             "Hint naming which DataAccessCollection file handle to prefer while matching.",
             default=None,
+            element_validator=lambda value: isinstance(value, str),
+            strict_validation=True,
+            scalar_only=True,
         ),
     }
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
@@ -45,7 +45,7 @@ class TestTheConstructorIsTheSchema:
     """The dataclass field set is the whole schema; an unknown field cannot exist."""
 
     def test_field_set_is_exactly_the_schema(self) -> None:
-        """The schema is these eleven fields, nothing more: there is no key set to drift from."""
+        """The schema is these twelve fields, nothing more: there is no key set to drift from."""
         assert {field.name for field in dataclasses.fields(PropertySpec)} == {
             "explanation",
             "allowed_values",
@@ -58,6 +58,7 @@ class TestTheConstructorIsTheSchema:
             "allow_explicit_none",
             "deferred_binding",
             "framework_set",
+            "scalar_only",
         }
 
     def test_typo_field_is_a_constructor_type_error_naming_the_offender(self) -> None:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py
@@ -19,6 +19,8 @@ invariants. This module pins the Phase B hard break:
    ``default`` or a ``required_when`` predicate makes the key skippable.
 9. ``framework_set=True`` (#949) is reader-surface only and rejected at class definition, naming
    the owner class and the key.
+10. ``scalar_only=True`` (#1154) is reader-surface only and rejected at class definition, naming
+    the owner class and the key.
 """
 
 from __future__ import annotations
@@ -360,3 +362,50 @@ class TestFrameworkSetStaysOffThePropertyMappingSurface:
                 return data
 
         assert "hardbreak949_plain_key" in HardBreak949FlaglessFeatureGroup.declared_option_keys()
+
+
+class TestScalarOnlyStaysOffThePropertyMappingSurface:
+    """Item 10: ``scalar_only=True`` in a PROPERTY_MAPPING is a category error, rejected at class definition."""
+
+    def test_scalar_only_spec_rejected_at_class_definition(self) -> None:
+        """``scalar_only=True`` in a PROPERTY_MAPPING names the class, the key, and the flag."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class HardBreak1154ScalarOnlyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "hardbreak1154_scalar_key": PropertySpec(
+                        "Reader-surface key.",
+                        element_validator=_hardbreak694_positive_int,
+                        strict_validation=True,
+                        scalar_only=True,
+                    )
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "HardBreak1154ScalarOnlyFeatureGroup" in message
+        assert "hardbreak1154_scalar_key" in message
+        assert "scalar_only" in message
+
+    def test_scalar_only_false_spec_defines_fine(self) -> None:
+        """Control: ``scalar_only=False`` (the default) stays valid on this surface."""
+
+        class HardBreak1154FlatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "hardbreak1154_plain_key": PropertySpec(
+                    "Plain user-facing key.",
+                    element_validator=_hardbreak694_positive_int,
+                    strict_validation=True,
+                    scalar_only=False,
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert "hardbreak1154_plain_key" in HardBreak1154FlatFeatureGroup.declared_option_keys()

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -104,6 +104,57 @@ class TestPropertySpecFrameworkSetField:
         assert "bool" in message
 
 
+class TestPropertySpecScalarOnlyField:
+    """The one spec type carries the reader-surface ``scalar_only`` flag (#1154)."""
+
+    def test_scalar_only_defaults_to_false(self) -> None:
+        """A plain spec admits a list/tuple/set/frozenset element-wise unless declared otherwise."""
+        assert PropertySpec("x").scalar_only is False
+
+    def test_scalar_only_true_constructs_with_strict_validation(self) -> None:
+        """Marking a spec scalar-only is a plain field, paired with its required strict_validation."""
+        spec = PropertySpec("x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=3)
+
+        assert spec.scalar_only is True
+
+    def test_scalar_only_is_frozen(self) -> None:
+        """Assigning the field raises ``dataclasses.FrozenInstanceError`` like every other field."""
+        spec = PropertySpec("x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=3)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(spec, "scalar_only", False)
+
+    def test_scalar_only_participates_in_value_equality(self) -> None:
+        """Two specs differing only in ``scalar_only`` are unequal; equal fields stay equal."""
+        assert PropertySpec(
+            "x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=3
+        ) != PropertySpec("x", element_validator=is_positive_int, strict_validation=True, default=3)
+        assert PropertySpec(
+            "x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=3
+        ) == PropertySpec("x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=3)
+
+    @pytest.mark.parametrize("non_bool", ["yes", 1, None])
+    def test_non_bool_scalar_only_rejected_at_construction(self, non_bool: Any) -> None:
+        """A non-bool is a ``ValueError`` naming the field, like the other bool fields."""
+        with pytest.raises(ValueError) as exc_info:
+            _spec("x", scalar_only=non_bool)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "scalar_only" in message
+        assert "bool" in message
+
+    def test_scalar_only_without_strict_validation_rejected_at_construction(self) -> None:
+        """``scalar_only=True`` can never be enforced without ``strict_validation=True``, mirroring ``element_validator``."""
+        with pytest.raises(ValueError) as exc_info:
+            PropertySpec("x", scalar_only=True)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "scalar_only" in message
+        assert "strict_validation" in message
+
+
 class TestTheOldSpecTypeIsGone:
     """The two-type world is over: the ``ReaderOptionSpec`` module and export no longer exist."""
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -154,6 +154,24 @@ class TestPropertySpecScalarOnlyField:
         assert "scalar_only" in message
         assert "strict_validation" in message
 
+    def test_scalar_only_true_rejects_a_collection_default_at_construction(self) -> None:
+        """``scalar_only=True`` rejects a collection outright, so its OWN declared default must be a scalar too."""
+        with pytest.raises(ValueError) as exc_info:
+            PropertySpec(
+                "x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=[3, 5]
+            )
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "scalar_only" in message
+        assert "default" in message
+
+    def test_scalar_only_true_with_a_scalar_default_constructs_fine(self) -> None:
+        """Control: scalar_only only rejects a COLLECTION default; a plain scalar default still constructs."""
+        spec = PropertySpec("x", element_validator=is_positive_int, strict_validation=True, scalar_only=True, default=3)
+
+        assert spec.default == 3
+
 
 class TestTheOldSpecTypeIsGone:
     """The two-type world is over: the ``ReaderOptionSpec`` module and export no longer exist."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
@@ -38,6 +38,9 @@ ROE_STRICT_HANDLE = "roe_strict_handle"
 ROE_FORMAT_KEY = "roe_format"
 ROE_CHAR_KEY = "roe_char_mode"
 
+ROE_SCALAR_ACCESS = "roe_scalar_access"
+ROE_SCALAR_KEY = "roe_scalar"
+
 ROE_VALIDATOR_ACCESS = "roe_validator_access"
 ROE_COUNT_KEY = "roe_count"
 ROE_TOUCHY_KEY = "roe_touchy"
@@ -133,6 +136,26 @@ class RoeStrictValuesReader(RoeStrictFamily):
             allowed_values=("x", "y", "z"),
             strict_validation=True,
             default="x",
+        ),
+    }
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {ROE_FEATURE_NAME: [1]}
+
+
+class RoeScalarOnlyReader(_RoeMarkedReader):
+    """Final reader whose key rejects a list/tuple/set/frozenset value outright, never unpacked (#1154)."""
+
+    ROE_ACCESS = ROE_SCALAR_ACCESS
+
+    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        ROE_SCALAR_KEY: PropertySpec(
+            "Scalar-only strict key: a container value is rejected before any element-wise check.",
+            element_validator=is_positive_int,
+            strict_validation=True,
+            scalar_only=True,
+            default=3,
         ),
     }
 
@@ -515,6 +538,55 @@ class TestFeatureScopeStrictValues:
             ROE_STRICT_ACCESS,
         )
         assert rejection_window == {}
+
+
+class TestScalarOnlyRejectsCollectionsOutright:
+    """``scalar_only=True`` rejects a list/tuple/set/frozenset value BEFORE any element-wise check (#1154)."""
+
+    @pytest.mark.parametrize(
+        "container",
+        [
+            [3, 5],
+            (3, 5),
+            {3, 5},
+            frozenset({3, 5}),
+        ],
+        ids=["list", "tuple", "set", "frozenset"],
+    )
+    def test_every_element_valid_container_is_still_rejected_outright(
+        self, container: Any, rejection_window: dict[str, MatchRejection]
+    ) -> None:
+        """Every element individually passes the validator, yet scalar_only rejects the shape itself."""
+        options = Options({RoeScalarOnlyReader.__name__: ROE_SCALAR_ACCESS, ROE_SCALAR_KEY: container})
+
+        matched = BaseInputData.feature_scope_data_access(options, ROE_FEATURE_NAME)
+
+        assert matched is False
+        stored = rejection_window[RoeScalarOnlyReader.get_class_name()]
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
+        assert ROE_SCALAR_KEY in stored.reason
+
+    def test_a_valid_scalar_still_matches(self, rejection_window: dict[str, MatchRejection]) -> None:
+        """Control: a plain scalar value the validator accepts still matches."""
+        options = Options({RoeScalarOnlyReader.__name__: ROE_SCALAR_ACCESS, ROE_SCALAR_KEY: 5})
+
+        matched = BaseInputData.feature_scope_data_access(options, ROE_FEATURE_NAME)
+
+        assert matched is True
+        assert rejection_window == {}
+
+    def test_an_invalid_scalar_is_still_rejected_by_the_ordinary_path(
+        self, rejection_window: dict[str, MatchRejection]
+    ) -> None:
+        """Control: scalar_only changes nothing for a plain scalar value the validator rejects."""
+        options = Options({RoeScalarOnlyReader.__name__: ROE_SCALAR_ACCESS, ROE_SCALAR_KEY: -1})
+
+        matched = BaseInputData.feature_scope_data_access(options, ROE_FEATURE_NAME)
+
+        assert matched is False
+        stored = rejection_window[RoeScalarOnlyReader.get_class_name()]
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
+        assert ROE_SCALAR_KEY in stored.reason
 
 
 class TestElementValidator:

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
@@ -565,6 +565,7 @@ class TestScalarOnlyRejectsCollectionsOutright:
         stored = rejection_window[RoeScalarOnlyReader.get_class_name()]
         assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert ROE_SCALAR_KEY in stored.reason
+        assert "scalar_only" in stored.reason
 
     def test_a_valid_scalar_still_matches(self, rejection_window: dict[str, MatchRejection]) -> None:
         """Control: a plain scalar value the validator accepts still matches."""

--- a/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
+++ b/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
@@ -22,6 +22,7 @@ from mloda_plugins.feature_group.input_data.read_db import ReadDB
 from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
 
 
 # ----------------------------------------------------------------------------
@@ -227,6 +228,24 @@ class TestSqliteReaderMatchesTypedCredential:
         assert resolved is not None
         assert isinstance(resolved, dict)
         assert resolved[SQLITEReader.db_path()] == str(db_a)
+
+
+class TestDataAccessHandleRejectsCollectionsOutright:
+    """A collection-shaped data_access_handle must not reach dict.get() as an unhashable key (#1165)."""
+
+    def test_file_reader_rejects_a_list_handle_instead_of_crashing(self, two_csv_files: tuple[str, str]) -> None:
+        path_a, path_b = two_csv_files
+        dac = DataAccessCollection(files={"transactions": path_a, "users": path_b})
+        options = Options(context={"data_access_handle": ["users", "transactions"]})
+        assert CsvReader.match_data_access(["id"], dac, options=options) == (None, None)
+
+    def test_db_reader_rejects_a_list_handle_instead_of_crashing(self, two_sqlite_dbs: tuple[Path, Path]) -> None:
+        db_a, db_b = two_sqlite_dbs
+        dac = DataAccessCollection(
+            credentials={"warehouse": {"db_path": str(db_a)}, "analytics": {"db_path": str(db_b)}}
+        )
+        options = Options(context={"data_access_handle": ["warehouse", "analytics"]})
+        assert SQLITEReader.match_data_access(["id"], dac, options=options) == (None, None)
 
 
 # Sanity check that fixtures are isolated (parallel-safety smoke).


### PR DESCRIPTION
## Summary

`READER_OPTIONS` strict validation unpacked a `list`/`tuple`/`set`/`frozenset` value element-wise, so a scalar-only key silently admitted a collection whenever every element individually passed, and `reader_option()` handed the collection back verbatim, often after expensive work already ran.

## Changes

- `PropertySpec` gains `scalar_only: bool`: rejects a collection value outright at reader-option admission instead of unpacking it. Requires `strict_validation=True`, rejects a collection-shaped `default` too, and is rejected on `PROPERTY_MAPPING` specs since that surface always unpacks element-wise.
- `data_access_handle` on `ReadDB`/`ReadFile` now uses it: a list/set value previously crashed with an uncontained `TypeError` inside `dict.get()`; it's now a clean non-match.

Closes #1165.

## Test plan

- [x] `tox` passes clean
- [x] New tests cover construction-time rejection, collection defaults, the `PROPERTY_MAPPING` rejection, and the `data_access_handle` crash-to-clean-reject fix
