### PR TITLE
fix: extend the unpicklable-class guard to FeatureGroupStep and TransformFrameworkStep

### DIFF
--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -25,7 +25,10 @@ from mloda.core.core.step.transform_frame_work_step import TransformFrameworkSte
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.error_utils import MlodaRunError, internal_invariant_error
 from mloda.core.abstract_plugins.feature_group import format_feature_group_class
-from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_join_link
+from mloda.core.runtime.validate_multiprocessing_link import (
+    raise_on_unpicklable_join_link,
+    raise_on_unpicklable_step_feature_group,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -423,6 +426,7 @@ class ExecutionOrchestrator:
             self.manager = None
         else:
             raise_on_unpicklable_join_link(self.execution_planner)
+            raise_on_unpicklable_step_feature_group(self.execution_planner)
 
             MyManager.register("CfwManager", CfwManager)
             self.manager = MyManager(ctx=mp_spawn_context()).__enter__()

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -1,6 +1,7 @@
-"""Guards a JoinStep's Link against a value pickle cannot round-trip, which otherwise fails deep
-inside a multiprocessing worker with an opaque PicklingError instead of being rejected clearly at
-plan time. This only proves resolvability in the current process: a class resolvable here but not
+"""Guards a JoinStep's Link, and a FeatureGroupStep's or TransformFrameworkStep's feature group
+classes, against a value pickle cannot round-trip, which otherwise fails deep inside a
+multiprocessing worker with an opaque PicklingError instead of being rejected clearly at plan
+time. This only proves resolvability in the current process: a class resolvable here but not
 inside a freshly spawned worker (e.g. one under `if __name__ == "__main__":`) can still fail there.
 """
 
@@ -8,7 +9,9 @@ import pickle  # nosec
 from collections.abc import Iterable
 from typing import Any
 
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 
 _UNPICKLABLE_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
@@ -59,3 +62,31 @@ def raise_on_unpicklable_join_link(steps: Iterable[Any]) -> None:
             raise ValueError(_unpicklable_link_error(step.link.right_feature_group, step))
 
         raise ValueError(_unpicklable_link_generic_error(step))
+
+
+def _unpicklable_step_feature_group_error(feature_group: type[Any], step: Any) -> str:
+    return (
+        f"{type(step).__name__} references {feature_group.__name__} "
+        f"({feature_group.__module__}.{feature_group.__qualname__}), which pickle cannot resolve back by "
+        "that path, so multiprocessing cannot send this step to a worker process. This happens when a "
+        "feature group class is created inside a function or by a dynamic type(...) factory instead of "
+        "being defined at module level.\n"
+        "Resolution: define the feature group class at module level, or run without "
+        "ParallelizationMode.MULTIPROCESSING."
+    )
+
+
+def raise_on_unpicklable_step_feature_group(steps: Iterable[Any]) -> None:
+    """Raise ValueError if a FeatureGroupStep or TransformFrameworkStep in steps carries a feature
+    group class multiprocessing cannot pickle."""
+    for step in steps:
+        if isinstance(step, FeatureGroupStep):
+            if not _is_picklable(step.feature_group):
+                raise ValueError(_unpicklable_step_feature_group_error(step.feature_group, step))
+            continue
+
+        if isinstance(step, TransformFrameworkStep):
+            if not _is_picklable(step.from_feature_group):
+                raise ValueError(_unpicklable_step_feature_group_error(step.from_feature_group, step))
+            if not _is_picklable(step.to_feature_group):
+                raise ValueError(_unpicklable_step_feature_group_error(step.to_feature_group, step))

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -9,6 +9,7 @@ import pickle  # nosec
 from collections.abc import Iterable
 from typing import Any
 
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
@@ -66,27 +67,48 @@ def raise_on_unpicklable_join_link(steps: Iterable[Any]) -> None:
 
 def _unpicklable_step_feature_group_error(feature_group: type[Any], step: Any) -> str:
     return (
-        f"{type(step).__name__} references {feature_group.__name__} "
+        f"{type(step).__name__} (uuid={step.uuid}) references {feature_group.__name__} "
         f"({feature_group.__module__}.{feature_group.__qualname__}), which pickle cannot resolve back by "
         "that path, so multiprocessing cannot send this step to a worker process. This happens when a "
-        "feature group class is created inside a function or by a dynamic type(...) factory instead of "
-        "being defined at module level.\n"
+        "feature group class is created inside a function, by a dynamic type(...) factory, or by "
+        "DynamicFeatureGroupCreator, instead of being defined at module level.\n"
         "Resolution: define the feature group class at module level, or run without "
         "ParallelizationMode.MULTIPROCESSING."
     )
 
 
+def _unpicklable_step_generic_error(step: Any) -> str:
+    return (
+        f"{type(step).__name__} (uuid={step.uuid}) cannot be pickled for multiprocessing, though its "
+        "feature group class(es) are picklable on their own. Some other value the step carries (e.g. a "
+        "Feature's Options) likely holds a value pickle cannot resolve, such as a locally defined class "
+        "or a lambda.\n"
+        "Resolution: use only picklable values on this step, or run without "
+        "ParallelizationMode.MULTIPROCESSING."
+    )
+
+
+def _step_feature_groups(step: Any) -> tuple[type[Any], ...]:
+    if isinstance(step, FeatureGroupStep):
+        return (step.feature_group,)
+    return (step.from_feature_group, step.to_feature_group)
+
+
 def raise_on_unpicklable_step_feature_group(steps: Iterable[Any]) -> None:
-    """Raise ValueError if a FeatureGroupStep or TransformFrameworkStep in steps carries a feature
-    group class multiprocessing cannot pickle."""
+    """Raise ValueError if a FeatureGroupStep or TransformFrameworkStep in steps, or anything it
+    carries, is something multiprocessing cannot pickle."""
     for step in steps:
-        if isinstance(step, FeatureGroupStep):
-            if not _is_picklable(step.feature_group):
-                raise ValueError(_unpicklable_step_feature_group_error(step.feature_group, step))
+        if not isinstance(step, (FeatureGroupStep, TransformFrameworkStep)):
             continue
 
-        if isinstance(step, TransformFrameworkStep):
-            if not _is_picklable(step.from_feature_group):
-                raise ValueError(_unpicklable_step_feature_group_error(step.from_feature_group, step))
-            if not _is_picklable(step.to_feature_group):
-                raise ValueError(_unpicklable_step_feature_group_error(step.to_feature_group, step))
+        if ParallelizationMode.MULTIPROCESSING not in step.get_parallelization_mode():
+            continue
+
+        if _is_picklable(step):
+            continue
+
+        for feature_group in _step_feature_groups(step):
+            if not _is_picklable(feature_group):
+                raise ValueError(_unpicklable_step_feature_group_error(feature_group, step))
+
+        raise ValueError(_unpicklable_step_generic_error(step))

--- a/mloda_plugins/feature_group/experimental/dynamic_feature_group_factory/dynamic_feature_group_factory.py
+++ b/mloda_plugins/feature_group/experimental/dynamic_feature_group_factory/dynamic_feature_group_factory.py
@@ -165,6 +165,8 @@ class DynamicFeatureGroupCreator:
     - Properties use lambda functions or regular functions as method implementations
     - Method signatures must match the original FeatureGroup signatures
     - Unspecified methods fall back to parent class implementations
+    - A created class cannot be pickled back by module path, so a feature relying on it is rejected
+      up front under ParallelizationMode.MULTIPROCESSING instead of run
 
     ## Requirements
 

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_step_feature_group.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_step_feature_group.py
@@ -1,0 +1,46 @@
+"""ExecutionOrchestrator.__enter__ must reject a FeatureGroupStep carrying an unpicklable feature
+group class before spawning any multiprocessing Manager, mirroring the
+ConcatenatedFileContent._create_join_class pattern in read_context_files.py. It must not touch
+SYNC mode at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
+
+
+def _plan_with_unpicklable_feature_group_step() -> ExecutionPlan:
+    dynamic_fg = DynamicFeatureGroupCreator.create(properties={}, class_name="OrchestratorProbeDynamicFeatureGroup")
+    step = FeatureGroupStep(dynamic_fg, FeatureSet([Feature("f")]), set(), PandasDataFrame)
+
+    plan = ExecutionPlan()
+    plan.execution_plan = [step]
+    return plan
+
+
+def test_enter_with_multiprocessing_rejects_an_unpicklable_feature_group_step_before_spawning_a_manager() -> None:
+    orchestrator = ExecutionOrchestrator(_plan_with_unpicklable_feature_group_step())
+
+    with pytest.raises(ValueError):
+        orchestrator.__enter__({ParallelizationMode.MULTIPROCESSING})
+
+    assert orchestrator.manager is None, "no MyManager/worker process may be created on the rejection path"
+
+
+def test_enter_with_sync_mode_does_not_reject_the_same_unpicklable_feature_group_step() -> None:
+    orchestrator = ExecutionOrchestrator(_plan_with_unpicklable_feature_group_step())
+
+    orchestrator.__enter__({ParallelizationMode.SYNC})
+
+    orchestrator.__exit__(None, None, None)

--- a/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_step_feature_group.py
+++ b/tests/test_core/test_runtime/test_orchestrator_rejects_unpicklable_step_feature_group.py
@@ -6,6 +6,9 @@ SYNC mode at all.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from pathlib import Path
+
 import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -14,14 +17,26 @@ from mloda.core.abstract_plugins.components.parallelization_modes import Paralle
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda.user import Options, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
     DynamicFeatureGroupCreator,
 )
+from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
+from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader
+
+_ORCHESTRATOR_PROBE_CLASS_NAME = "OrchestratorProbeDynamicFeatureGroup"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_dynamic_feature_groups() -> Iterator[None]:
+    yield
+    for name in (_ORCHESTRATOR_PROBE_CLASS_NAME, ConcatenatedFileContent.join_feature_name):
+        DynamicFeatureGroupCreator._created_classes.pop(name, None)
 
 
 def _plan_with_unpicklable_feature_group_step() -> ExecutionPlan:
-    dynamic_fg = DynamicFeatureGroupCreator.create(properties={}, class_name="OrchestratorProbeDynamicFeatureGroup")
+    dynamic_fg = DynamicFeatureGroupCreator.create(properties={}, class_name=_ORCHESTRATOR_PROBE_CLASS_NAME)
     step = FeatureGroupStep(dynamic_fg, FeatureSet([Feature("f")]), set(), PandasDataFrame)
 
     plan = ExecutionPlan()
@@ -32,7 +47,7 @@ def _plan_with_unpicklable_feature_group_step() -> ExecutionPlan:
 def test_enter_with_multiprocessing_rejects_an_unpicklable_feature_group_step_before_spawning_a_manager() -> None:
     orchestrator = ExecutionOrchestrator(_plan_with_unpicklable_feature_group_step())
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=_ORCHESTRATOR_PROBE_CLASS_NAME):
         orchestrator.__enter__({ParallelizationMode.MULTIPROCESSING})
 
     assert orchestrator.manager is None, "no MyManager/worker process may be created on the rejection path"
@@ -44,3 +59,27 @@ def test_enter_with_sync_mode_does_not_reject_the_same_unpicklable_feature_group
     orchestrator.__enter__({ParallelizationMode.SYNC})
 
     orchestrator.__exit__(None, None, None)
+
+
+def test_enter_with_multiprocessing_rejects_a_real_concatenated_file_content_plan(tmp_path: Path) -> None:
+    """Drives ConcatenatedFileContent's own planner path, not a hand-built step."""
+    (tmp_path / "a.py").write_text("# a")
+    (tmp_path / "b.py").write_text("# b")
+
+    ConcatenatedFileContent()._create_join_class(ConcatenatedFileContent.join_feature_name)
+
+    api = mloda(
+        [
+            Feature(
+                "ConcatenatedFileContent",
+                options=Options(
+                    {"target_folder": [str(tmp_path)], "document_reader_class": PyFileReader.get_class_name()}
+                ),
+            )
+        ],
+        compute_frameworks={PandasDataFrame},
+    )
+
+    assert api.engine is not None
+    with pytest.raises(ValueError, match=ConcatenatedFileContent.join_feature_name):
+        api.engine.compute().__enter__({ParallelizationMode.MULTIPROCESSING})

--- a/tests/test_core/test_runtime/test_validate_multiprocessing_step_feature_group.py
+++ b/tests/test_core/test_runtime/test_validate_multiprocessing_step_feature_group.py
@@ -1,0 +1,105 @@
+"""Unit tests for raise_on_unpicklable_step_feature_group, hand-building FeatureGroupStep and
+TransformFrameworkStep objects. A feature group class built via type(name, (FeatureGroup,), {}) is
+genuinely unpicklable (pickle cannot resolve it back by module/qualname), which is what such a step
+queued to a multiprocessing worker would otherwise fail deep inside pickle for."""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_step_feature_group
+from mloda.provider import FeatureGroup
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
+
+
+class ValidateStepFeatureGroup(FeatureGroup):
+    """Ordinary module-level feature group: picklable."""
+
+
+def _make_local_feature_group(name: str = "LocallyDefinedFeatureGroup") -> type[FeatureGroup]:
+    """A dynamically built FeatureGroup subclass pickle cannot resolve back by name: unpicklable."""
+
+    return type(name, (FeatureGroup,), {})
+
+
+def _feature_group_step(feature_group: type[FeatureGroup]) -> FeatureGroupStep:
+    return FeatureGroupStep(feature_group, FeatureSet([Feature("f")]), set(), PandasDataFrame)
+
+
+def _transform_step(
+    from_feature_group: type[FeatureGroup], to_feature_group: type[FeatureGroup]
+) -> TransformFrameworkStep:
+    return TransformFrameworkStep(PandasDataFrame, PyArrowTable, set(), from_feature_group, to_feature_group)
+
+
+def test_a_feature_group_step_with_an_unpicklable_feature_group_is_rejected() -> None:
+    unpicklable = _make_local_feature_group()
+    step = _feature_group_step(unpicklable)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_step_feature_group([step])
+
+    message = str(excinfo.value)
+    assert f"references {unpicklable.__name__} (" in message, f"the offending class must be named; got: {message}"
+    assert "FeatureGroupStep" in message, f"the step type must be named; got: {message}"
+
+
+def test_a_feature_group_step_with_a_picklable_feature_group_does_not_raise() -> None:
+    step = _feature_group_step(ValidateStepFeatureGroup)
+
+    raise_on_unpicklable_step_feature_group([step])
+
+
+def test_a_transform_framework_step_with_an_unpicklable_from_feature_group_is_rejected() -> None:
+    unpicklable = _make_local_feature_group("UnpicklableFromFeatureGroup")
+    step = _transform_step(unpicklable, ValidateStepFeatureGroup)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_step_feature_group([step])
+
+    message = str(excinfo.value)
+    assert f"references {unpicklable.__name__} (" in message, f"the offending class must be named; got: {message}"
+    assert "TransformFrameworkStep" in message, f"the step type must be named; got: {message}"
+
+
+def test_a_transform_framework_step_with_an_unpicklable_to_feature_group_is_rejected() -> None:
+    unpicklable = _make_local_feature_group("UnpicklableToFeatureGroup")
+    step = _transform_step(ValidateStepFeatureGroup, unpicklable)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_step_feature_group([step])
+
+    message = str(excinfo.value)
+    assert f"references {unpicklable.__name__} (" in message, f"the offending class must be named; got: {message}"
+
+
+def test_a_transform_framework_step_with_both_feature_groups_picklable_does_not_raise() -> None:
+    step = _transform_step(ValidateStepFeatureGroup, ValidateStepFeatureGroup)
+
+    raise_on_unpicklable_step_feature_group([step])
+
+
+def test_non_matching_step_entries_are_ignored_not_crashed_on() -> None:
+    raise_on_unpicklable_step_feature_group([object(), None])
+
+
+def test_a_feature_group_step_with_a_dynamic_feature_group_creator_class_is_rejected() -> None:
+    """Mirrors ConcatenatedFileContent._create_join_class in read_context_files.py."""
+    dynamic_fg = DynamicFeatureGroupCreator.create(
+        properties={}, class_name="ReviewProbeDynamicFeatureGroup_ValidateStepTest"
+    )
+    step = _feature_group_step(dynamic_fg)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_step_feature_group([step])
+
+    message = str(excinfo.value)
+    assert dynamic_fg.__name__ in message, f"the dynamically created class must be named; got: {message}"

--- a/tests/test_core/test_runtime/test_validate_multiprocessing_step_feature_group.py
+++ b/tests/test_core/test_runtime/test_validate_multiprocessing_step_feature_group.py
@@ -5,23 +5,46 @@ queued to a multiprocessing worker would otherwise fail deep inside pickle for."
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_step_feature_group
 from mloda.provider import FeatureGroup
+from mloda.user import Index, JoinSpec, Link
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
     DynamicFeatureGroupCreator,
 )
 
+_DYNAMIC_CLASS_NAME = "ReviewProbeDynamicFeatureGroup_ValidateStepTest"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_dynamic_feature_groups() -> Iterator[None]:
+    yield
+    DynamicFeatureGroupCreator._created_classes.pop(_DYNAMIC_CLASS_NAME, None)
+
 
 class ValidateStepFeatureGroup(FeatureGroup):
     """Ordinary module-level feature group: picklable."""
+
+
+class SyncOnlyComputeFramework(ComputeFramework):
+    """A compute framework restricted to SYNC, like SqliteFramework or DuckDBFramework."""
+
+    @classmethod
+    def supported_parallelization_modes(cls) -> set[ParallelizationMode]:
+        return {ParallelizationMode.SYNC}
 
 
 def _make_local_feature_group(name: str = "LocallyDefinedFeatureGroup") -> type[FeatureGroup]:
@@ -30,8 +53,10 @@ def _make_local_feature_group(name: str = "LocallyDefinedFeatureGroup") -> type[
     return type(name, (FeatureGroup,), {})
 
 
-def _feature_group_step(feature_group: type[FeatureGroup]) -> FeatureGroupStep:
-    return FeatureGroupStep(feature_group, FeatureSet([Feature("f")]), set(), PandasDataFrame)
+def _feature_group_step(
+    feature_group: type[FeatureGroup], compute_framework: type[ComputeFramework] = PandasDataFrame
+) -> FeatureGroupStep:
+    return FeatureGroupStep(feature_group, FeatureSet([Feature("f")]), set(), compute_framework)
 
 
 def _transform_step(
@@ -58,6 +83,29 @@ def test_a_feature_group_step_with_a_picklable_feature_group_does_not_raise() ->
     raise_on_unpicklable_step_feature_group([step])
 
 
+def test_a_feature_group_step_whose_compute_framework_does_not_support_multiprocessing_is_not_rejected() -> None:
+    """A step that will never actually route to a multiprocessing worker must not be blocked."""
+    unpicklable = _make_local_feature_group()
+    step = _feature_group_step(unpicklable, compute_framework=SyncOnlyComputeFramework)
+
+    raise_on_unpicklable_step_feature_group([step])
+
+
+def test_a_feature_group_step_unpicklable_for_a_reason_other_than_its_feature_group_is_rejected() -> None:
+    """The whole step crosses the multiprocessing queue, not just its feature_group attribute."""
+    feature = Feature("f", options=Options({"unpicklable": lambda: None}))
+    step = FeatureGroupStep(ValidateStepFeatureGroup, FeatureSet([feature]), set(), PandasDataFrame)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_step_feature_group([step])
+
+    message = str(excinfo.value)
+    assert f"references {ValidateStepFeatureGroup.__name__} (" not in message, (
+        f"the feature group is individually picklable; got: {message}"
+    )
+    assert "FeatureGroupStep" in message, f"the step type must be named; got: {message}"
+
+
 def test_a_transform_framework_step_with_an_unpicklable_from_feature_group_is_rejected() -> None:
     unpicklable = _make_local_feature_group("UnpicklableFromFeatureGroup")
     step = _transform_step(unpicklable, ValidateStepFeatureGroup)
@@ -67,6 +115,9 @@ def test_a_transform_framework_step_with_an_unpicklable_from_feature_group_is_re
 
     message = str(excinfo.value)
     assert f"references {unpicklable.__name__} (" in message, f"the offending class must be named; got: {message}"
+    assert f"references {ValidateStepFeatureGroup.__name__} (" not in message, (
+        f"the picklable side must not be blamed; got: {message}"
+    )
     assert "TransformFrameworkStep" in message, f"the step type must be named; got: {message}"
 
 
@@ -79,6 +130,23 @@ def test_a_transform_framework_step_with_an_unpicklable_to_feature_group_is_reje
 
     message = str(excinfo.value)
     assert f"references {unpicklable.__name__} (" in message, f"the offending class must be named; got: {message}"
+    assert f"references {ValidateStepFeatureGroup.__name__} (" not in message, (
+        f"the picklable side must not be blamed; got: {message}"
+    )
+
+
+def test_a_transform_framework_step_with_both_feature_groups_unpicklable_blames_the_from_one() -> None:
+    unpicklable_from = _make_local_feature_group("FromUnpicklableFeatureGroup")
+    unpicklable_to = _make_local_feature_group("ToUnpicklableFeatureGroup")
+    step = _transform_step(unpicklable_from, unpicklable_to)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_step_feature_group([step])
+
+    message = str(excinfo.value)
+    assert f"references {unpicklable_from.__name__} (" in message, (
+        f"the from side must be blamed first, per the from-then-to check order; got: {message}"
+    )
 
 
 def test_a_transform_framework_step_with_both_feature_groups_picklable_does_not_raise() -> None:
@@ -91,11 +159,20 @@ def test_non_matching_step_entries_are_ignored_not_crashed_on() -> None:
     raise_on_unpicklable_step_feature_group([object(), None])
 
 
+def test_a_join_step_is_ignored_by_this_function() -> None:
+    unpicklable = _make_local_feature_group("UnpicklableJoinStepFeatureGroup")
+    link = Link.inner(
+        JoinSpec(unpicklable, Index(("left_key",))),
+        JoinSpec(ValidateStepFeatureGroup, Index(("right_key",))),
+    )
+    step = JoinStep(link, PyArrowTable, PandasDataFrame, set(), set(), set())
+
+    raise_on_unpicklable_step_feature_group([step])
+
+
 def test_a_feature_group_step_with_a_dynamic_feature_group_creator_class_is_rejected() -> None:
     """Mirrors ConcatenatedFileContent._create_join_class in read_context_files.py."""
-    dynamic_fg = DynamicFeatureGroupCreator.create(
-        properties={}, class_name="ReviewProbeDynamicFeatureGroup_ValidateStepTest"
-    )
+    dynamic_fg = DynamicFeatureGroupCreator.create(properties={}, class_name=_DYNAMIC_CLASS_NAME)
     step = _feature_group_step(dynamic_fg)
 
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
## Summary

The plan-time guard that rejects a multiprocessing-bound plan carrying a runtime-created feature group class only covered `JoinStep`'s `Link`. A `FeatureGroupStep.feature_group` or a `TransformFrameworkStep`'s feature group classes could carry the same kind of class (for example a class built at runtime via `DynamicFeatureGroupCreator`, as `ConcatenatedFileContent._create_join_class` does) and still crash multiprocessing deep inside a worker with an opaque `PicklingError`.

## Change

Adds `raise_on_unpicklable_step_feature_group`, a sibling to the existing `raise_on_unpicklable_join_link`, wired into `ExecutionOrchestrator.__enter__` right alongside it. For each `FeatureGroupStep` or `TransformFrameworkStep` that would actually route through a multiprocessing worker (skipping steps whose compute framework never supports multiprocessing, e.g. SQLite or DuckDB), it checks whether the whole step is picklable and, if not, raises a clear `ValueError` naming the offending feature group class rather than letting the failure surface later as an opaque pickling error inside a worker.

## Testing

Unit tests cover `FeatureGroupStep` and `TransformFrameworkStep` individually, a step bound to a sync-only compute framework (not rejected, since it never crosses the multiprocessing boundary), and a step unpicklable for a reason other than its feature group class. An orchestrator-level test drives `ConcatenatedFileContent` through its real planning path with a temp directory of files and confirms `ExecutionOrchestrator.__enter__` rejects it under `ParallelizationMode.MULTIPROCESSING` before any worker spawns, while leaving SYNC mode untouched.