### PR TITLE
fix: resolve ReadDB credentials with a per-reader predicate

### DIFF
--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -96,7 +96,7 @@ class ReadDB(BaseInputData):
 
     @classmethod
     def _credentials_predicate(cls, credentials: Any) -> bool:
-        """Return True if `credentials` is a match this reader's is_valid_credentials accepts."""
+        """Wraps is_valid_credentials as a predicate, treating NotImplementedError as no match."""
         try:
             return cls.is_valid_credentials(credentials)
         except NotImplementedError:

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -95,14 +95,26 @@ class ReadDB(BaseInputData):
         raise NotImplementedError
 
     @classmethod
+    def _credentials_predicate(cls, credentials: Any) -> bool:
+        """Return True if `credentials` is a match this reader's is_valid_credentials accepts."""
+        try:
+            return cls.is_valid_credentials(credentials)
+        except NotImplementedError:
+            return False
+
+    @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
         data_accesses: list[Any] = []
 
         if isinstance(data_access, DataAccessCollection):
             hint = options.get("data_access_handle") if options is not None else None
-            if hint is not None and data_access.handles().get(hint) not in (None, "credentials"):
-                hint = None
-            creds = data_access.resolve("credentials", hint=hint)
+            if hint is not None:
+                handle_kind = data_access.handles().get(hint)
+                if handle_kind not in (None, "credentials"):
+                    hint = None
+                elif handle_kind == "credentials" and not cls._credentials_predicate(data_access.credentials[hint]):
+                    hint = None
+            creds = data_access.resolve("credentials", predicate=cls._credentials_predicate, hint=hint)
             if creds:
                 data_accesses.append(creds)
         elif isinstance(data_access, dict):

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -82,6 +82,10 @@ class ReadDB(BaseInputData):
         Matcher exception contract: match_read_db_data_access treats only NotImplementedError
         as a soft no-match; any other exception propagates and aborts matching for every
         reader sharing the DataAccessCollection.
+
+        match_subclass_data_access also enforces this via the _credentials_predicate wrapper,
+        and may invoke it once per registered credentials entry while matching, not only the
+        entry ultimately bound to this reader.
         """
         raise NotImplementedError
 
@@ -113,7 +117,7 @@ class ReadDB(BaseInputData):
                 if handle_kind not in (None, "credentials"):
                     hint = None
                 elif handle_kind == "credentials" and not cls._credentials_predicate(data_access.credentials[hint]):
-                    hint = None
+                    return None
             creds = data_access.resolve("credentials", predicate=cls._credentials_predicate, hint=hint)
             if creds:
                 data_accesses.append(creds)

--- a/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
+++ b/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
@@ -276,6 +276,36 @@ class TestReadDBCredentialsPredicateFiltering:
         assert warehouse == {"warehouse_dsn": "warehouse://a"}
         assert analytics == {"analytics_dsn": "analytics://b"}
 
+    def test_hint_at_foreign_credentials_declines_instead_of_rescanning(self) -> None:
+        """A reader whose predicate rejects the hinted entry must decline, not rescan for its own unrelated entry."""
+        dac = DataAccessCollection(
+            credentials={
+                "warehouse": {"warehouse_dsn": "warehouse://a"},
+                "analytics": {"analytics_dsn": "analytics://b"},
+            }
+        )
+        options = Options(context={"data_access_handle": "analytics"})
+        resolved = _WarehouseCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=options)
+        assert resolved is None
+
+    def test_hint_at_owned_credentials_still_resolves(self) -> None:
+        """Sanity check: the correct owner still resolves via the same hint."""
+        dac = DataAccessCollection(
+            credentials={
+                "warehouse": {"warehouse_dsn": "warehouse://a"},
+                "analytics": {"analytics_dsn": "analytics://b"},
+            }
+        )
+        options = Options(context={"data_access_handle": "analytics"})
+        resolved = _AnalyticsCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=options)
+        assert resolved == {"analytics_dsn": "analytics://b"}
+
+    def test_not_implemented_credentials_check_resolves_to_none_via_predicate(self) -> None:
+        """Base ReadDB.is_valid_credentials always raises NotImplementedError; the predicate treats it as no match."""
+        dac = DataAccessCollection(credentials={"only": {"whatever": "value"}})
+        resolved = ReadDB.match_subclass_data_access(dac, feature_names=["any"], options=Options())
+        assert resolved is None
+
 
 # ----------------------------------------------------------------------------
 # Typed Credential through the real SQLITEReader matcher (issue #511 pin).

--- a/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
+++ b/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
@@ -213,7 +213,7 @@ class TestReadDBHint:
 # ----------------------------------------------------------------------------
 # ReadDB: resolve() must filter candidates through *this* reader's
 # is_valid_credentials before flagging ambiguity, not treat every registered
-# credentials entry as a match (mloda-ai/mloda#1126 pin).
+# credentials entry as a match.
 # ----------------------------------------------------------------------------
 
 
@@ -242,9 +242,7 @@ class _AnalyticsCredsDB(ReadDB):
 
 
 class TestReadDBCredentialsPredicateFiltering:
-    """Pins mloda-ai/mloda#1126: resolve() must filter candidates through this
-    reader's is_valid_credentials before flagging ambiguity.
-    """
+    """resolve() must filter candidates through this reader's is_valid_credentials before flagging ambiguity."""
 
     def test_only_matching_entry_resolves_without_hint(self) -> None:
         dac = DataAccessCollection(

--- a/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
+++ b/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
@@ -211,6 +211,75 @@ class TestReadDBHint:
 
 
 # ----------------------------------------------------------------------------
+# ReadDB: resolve() must filter candidates through *this* reader's
+# is_valid_credentials before flagging ambiguity, not treat every registered
+# credentials entry as a match (mloda-ai/mloda#1126 pin).
+# ----------------------------------------------------------------------------
+
+
+class _WarehouseCredsDB(ReadDB):
+    """DB reader that only accepts credentials carrying its own connector key, not any dict."""
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return isinstance(credentials, dict) and "warehouse_dsn" in credentials
+
+    @classmethod
+    def check_feature_in_data_access(cls, feature_name: str, data_access: Any) -> bool:
+        return True
+
+
+class _AnalyticsCredsDB(ReadDB):
+    """Sibling reader accepting a different connector key than _WarehouseCredsDB."""
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return isinstance(credentials, dict) and "analytics_dsn" in credentials
+
+    @classmethod
+    def check_feature_in_data_access(cls, feature_name: str, data_access: Any) -> bool:
+        return True
+
+
+class TestReadDBCredentialsPredicateFiltering:
+    """Pins mloda-ai/mloda#1126: resolve() must filter candidates through this
+    reader's is_valid_credentials before flagging ambiguity.
+    """
+
+    def test_only_matching_entry_resolves_without_hint(self) -> None:
+        dac = DataAccessCollection(
+            credentials={
+                "warehouse": {"warehouse_dsn": "warehouse://a"},
+                "analytics": {"analytics_dsn": "analytics://b"},
+            }
+        )
+        resolved = _WarehouseCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=Options())
+        assert resolved == {"warehouse_dsn": "warehouse://a"}
+
+    def test_no_matching_entry_resolves_to_none(self) -> None:
+        dac = DataAccessCollection(
+            credentials={
+                "analytics_one": {"analytics_dsn": "analytics://a"},
+                "analytics_two": {"analytics_dsn": "analytics://b"},
+            }
+        )
+        resolved = _WarehouseCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=Options())
+        assert resolved is None
+
+    def test_sibling_readers_each_resolve_their_own_entry(self) -> None:
+        dac = DataAccessCollection(
+            credentials={
+                "warehouse": {"warehouse_dsn": "warehouse://a"},
+                "analytics": {"analytics_dsn": "analytics://b"},
+            }
+        )
+        warehouse = _WarehouseCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=Options())
+        analytics = _AnalyticsCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=Options())
+        assert warehouse == {"warehouse_dsn": "warehouse://a"}
+        assert analytics == {"analytics_dsn": "analytics://b"}
+
+
+# ----------------------------------------------------------------------------
 # Typed Credential through the real SQLITEReader matcher (issue #511 pin).
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`ReadDB.match_subclass_data_access` resolved credentials from a `DataAccessCollection` with no predicate, unlike the connection consumer (`ComputeFramework.pick_connection_from_dac`), which already binds via `_connection_matches`. Because every registered credentials entry counted as a match candidate, a collection holding two or more credentials entries always raised the ambiguous-resolve error for every reader, even when only one entry would actually pass that reader's own `is_valid_credentials` check.

This adds a `_credentials_predicate` wrapper (soft no-match on `NotImplementedError`, any other exception still propagates) and passes it into the `resolve("credentials", ...)` call, so multiple credentials entries disambiguate per reader the way multiple connections already do.

A hint-vs-predicate-mismatch case needed different handling than the connection precedent: `ReadDB` matching runs every reader subclass through a first-match-wins loop over the same collection, so falling back to an unhinted rescan (as the connection path does) could let a non-owning reader silently bind an unrelated entry the caller never named via `data_access_handle`. When a hint names a credentials handle this reader's own predicate rejects, the reader now declines outright instead of rescanning.

## Test plan

- [x] New tests in `tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py` covering: multiple credentials entries resolving to the one matching predicate, no match resolving to `None`, sibling readers each resolving their own entry from the same collection, a hint-mismatch declining rather than rescanning, and the correct owner still resolving via a hint.
- [x] Full existing suite passes, no regressions.
- [x] `ruff format`, `ruff check`, `mypy --strict` clean.