### PR TITLE
fix(runtime): extend unpicklable-class guard to FeatureGroupStep and TransformFrameworkStep

### DIFF
--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -1,14 +1,17 @@
-"""Guards a JoinStep's Link against a value pickle cannot round-trip, which otherwise fails deep
-inside a multiprocessing worker with an opaque PicklingError instead of being rejected clearly at
-plan time. This only proves resolvability in the current process: a class resolvable here but not
-inside a freshly spawned worker (e.g. one under `if __name__ == "__main__":`) can still fail there.
+"""Guards JoinStep, FeatureGroupStep, and TransformFrameworkStep against classes and values
+pickle cannot round-trip, which otherwise fail deep inside a multiprocessing worker with an
+opaque PicklingError instead of being rejected clearly at plan time. This only proves
+resolvability in the current process: a class resolvable here but not inside a freshly spawned
+worker (e.g. one under `if __name__ == "__main__":`) can still fail there.
 """
 
 import pickle  # nosec
 from collections.abc import Iterable
 from typing import Any
 
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 
 _UNPICKLABLE_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
@@ -43,19 +46,55 @@ def _unpicklable_link_generic_error(step: JoinStep) -> str:
     )
 
 
-def raise_on_unpicklable_join_link(steps: Iterable[Any]) -> None:
-    """Raise ValueError if any JoinStep in steps carries a Link that multiprocessing cannot pickle."""
+def _unpicklable_feature_group_step_error(feature_group: type[Any], step: FeatureGroupStep) -> str:
+    return (
+        f"FeatureGroupStep for {feature_group.__name__} "
+        f"({feature_group.__module__}.{feature_group.__qualname__}) references a feature group class that pickle "
+        "cannot resolve back by that path, so multiprocessing cannot send this step to a worker process. This happens "
+        "when a feature group class is created inside a function or by a dynamic type(...) factory instead of being "
+        "defined at module level.\n"
+        "Resolution: define the feature group class at module level, or run without "
+        "ParallelizationMode.MULTIPROCESSING."
+    )
+
+
+def _unpicklable_transform_step_error(feature_group: type[Any], step: TransformFrameworkStep) -> str:
+    return (
+        f"TransformFrameworkStep references {feature_group.__name__} "
+        f"({feature_group.__module__}.{feature_group.__qualname__}), which pickle cannot resolve back by "
+        "that path, so multiprocessing cannot send this transformation to a worker process. This happens when a "
+        "feature group class is created inside a function or by a dynamic type(...) factory instead of "
+        "being defined at module level.\n"
+        "Resolution: define the feature group class at module level, or run without "
+        "ParallelizationMode.MULTIPROCESSING."
+    )
+
+
+def raise_on_unpicklable_multiprocessing_steps(steps: Iterable[Any]) -> None:
+    """Raise ValueError if any step in steps carries an unpicklable FeatureGroup, Link, or transformation."""
     for step in steps:
-        if not isinstance(step, JoinStep):
-            continue
+        if isinstance(step, JoinStep):
+            if _is_picklable(step.link):
+                continue
 
-        if _is_picklable(step.link):
-            continue
+            if not _is_picklable(step.link.left_feature_group):
+                raise ValueError(_unpicklable_link_error(step.link.left_feature_group, step))
 
-        if not _is_picklable(step.link.left_feature_group):
-            raise ValueError(_unpicklable_link_error(step.link.left_feature_group, step))
+            if not _is_picklable(step.link.right_feature_group):
+                raise ValueError(_unpicklable_link_error(step.link.right_feature_group, step))
 
-        if not _is_picklable(step.link.right_feature_group):
-            raise ValueError(_unpicklable_link_error(step.link.right_feature_group, step))
+            raise ValueError(_unpicklable_link_generic_error(step))
 
-        raise ValueError(_unpicklable_link_generic_error(step))
+        if isinstance(step, FeatureGroupStep):
+            if not _is_picklable(step.feature_group):
+                raise ValueError(_unpicklable_feature_group_step_error(step.feature_group, step))
+
+        if isinstance(step, TransformFrameworkStep):
+            if not _is_picklable(step.from_feature_group):
+                raise ValueError(_unpicklable_transform_step_error(step.from_feature_group, step))
+            if not _is_picklable(step.to_feature_group):
+                raise ValueError(_unpicklable_transform_step_error(step.to_feature_group, step))
+
+
+raise_on_unpicklable_join_link = raise_on_unpicklable_multiprocessing_steps
+

--- a/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
+++ b/tests/test_core/test_runtime/test_validate_multiprocessing_link.py
@@ -8,13 +8,19 @@ from __future__ import annotations
 
 import pytest
 
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda.provider import FeatureGroup
 from mloda.user import Index, JoinSpec, Link
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
-from mloda.core.runtime.validate_multiprocessing_link import raise_on_unpicklable_join_link
+from mloda.core.runtime.validate_multiprocessing_link import (
+    raise_on_unpicklable_join_link,
+    raise_on_unpicklable_multiprocessing_steps,
+)
 from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
     DynamicFeatureGroupCreator,
 )
@@ -149,3 +155,59 @@ def test_a_link_with_a_dynamic_feature_group_creator_class_is_rejected() -> None
 
     message = str(excinfo.value)
     assert dynamic_fg.__name__ in message, f"the dynamically created class must be named; got: {message}"
+
+
+def test_feature_group_step_with_unpicklable_class_is_rejected() -> None:
+    unpicklable_fg = _make_local_feature_group("DynamicFeatureGroupStepTarget")
+    step = FeatureGroupStep(unpicklable_fg, FeatureSet(), set(), PandasDataFrame)
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_multiprocessing_steps([step])
+
+    message = str(excinfo.value)
+    assert f"FeatureGroupStep for {unpicklable_fg.__name__} (" in message, (
+        f"the offending class must be named; got: {message}"
+    )
+
+
+def test_feature_group_step_with_picklable_class_does_not_raise() -> None:
+    step = FeatureGroupStep(ValidateLinkLeft, FeatureSet(), set(), PandasDataFrame)
+    raise_on_unpicklable_multiprocessing_steps([step])
+
+
+def test_transform_framework_step_with_unpicklable_from_class_is_rejected() -> None:
+    unpicklable_from = _make_local_feature_group("DynamicFromFeatureGroup")
+    step = TransformFrameworkStep(
+        PandasDataFrame, PyArrowTable, set(), unpicklable_from, ValidateLinkRight
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_multiprocessing_steps([step])
+
+    message = str(excinfo.value)
+    assert f"TransformFrameworkStep references {unpicklable_from.__name__} (" in message, (
+        f"the offending from-class must be named; got: {message}"
+    )
+
+
+def test_transform_framework_step_with_unpicklable_to_class_is_rejected() -> None:
+    unpicklable_to = _make_local_feature_group("DynamicToFeatureGroup")
+    step = TransformFrameworkStep(
+        PandasDataFrame, PyArrowTable, set(), ValidateLinkLeft, unpicklable_to
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        raise_on_unpicklable_multiprocessing_steps([step])
+
+    message = str(excinfo.value)
+    assert f"TransformFrameworkStep references {unpicklable_to.__name__} (" in message, (
+        f"the offending to-class must be named; got: {message}"
+    )
+
+
+def test_transform_framework_step_with_picklable_classes_does_not_raise() -> None:
+    step = TransformFrameworkStep(
+        PandasDataFrame, PyArrowTable, set(), ValidateLinkLeft, ValidateLinkRight
+    )
+    raise_on_unpicklable_multiprocessing_steps([step])
+


### PR DESCRIPTION
## Summary
Extends the plan-time multiprocessing unpicklable-class validator to cover `FeatureGroupStep` and `TransformFrameworkStep`, preventing runtime worker crashes with opaque `PicklingError` when dynamically created or function-local feature groups are scheduled (#1162).

## Changes
- **Validator Extension (`mloda/core/runtime/validate_multiprocessing_link.py`)**: Added checks in `raise_on_unpicklable_multiprocessing_steps` for `FeatureGroupStep.feature_group` and `TransformFrameworkStep.from_feature_group` / `to_feature_group`. Retained `raise_on_unpicklable_join_link` as an alias for full backward compatibility.
- **Unit Tests (`tests/test_core/test_runtime/test_validate_multiprocessing_link.py`)**: Added tests covering unpicklable and picklable `FeatureGroupStep` classes, as well as unpicklable and picklable `TransformFrameworkStep` from/to class pairs.

Fixes #1162