### PR TITLE
fix: decline instead of rescanning when a file hint fails a reader's predicate

### DIFF
--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -109,7 +109,7 @@ class ReadDocument(BaseInputData):
                 elif handle_kind == "file" and not cls._document_file_matches(
                     data_access.files[hint], document_suffixes
                 ):
-                    hint = None
+                    return None
             file_match = data_access.resolve(
                 "file",
                 predicate=lambda p: cls._document_file_matches(p, document_suffixes),

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -105,7 +105,7 @@ class ReadFile(BaseInputData):
                 elif handle_kind == "file" and not cls._file_matches(
                     data_access.files[hint], feature_names, document_suffixes
                 ):
-                    hint = None
+                    return None
             file_match = data_access.resolve(
                 "file",
                 predicate=lambda p: cls._file_matches(p, feature_names, document_suffixes),

--- a/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
+++ b/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
@@ -50,6 +50,16 @@ def two_txt_files(tmp_path: Path) -> tuple[str, str]:
 
 
 @pytest.fixture
+def csv_and_txt_files(tmp_path: Path) -> tuple[str, str]:
+    """A .csv path and a .txt path in an isolated tmp dir, for mixed-suffix hinting."""
+    csv_path = tmp_path / "data.csv"
+    txt_path = tmp_path / "notes.txt"
+    csv_path.write_text("id,amount\n1,10\n")
+    txt_path.write_text("hello")
+    return str(csv_path), str(txt_path)
+
+
+@pytest.fixture
 def two_sqlite_dbs(tmp_path: Path) -> tuple[Path, Path]:
     """Two distinct, valid SQLite database files."""
     db_a = tmp_path / "warehouse.sqlite"
@@ -118,6 +128,20 @@ class TestReadFileHint:
         resolved = _CsvLikeReader.match_subclass_data_access(dac, feature_names=["id"], options=Options())
         assert resolved == path_a
 
+    def test_hint_at_foreign_file_declines_instead_of_rescanning(self, csv_and_txt_files: tuple[str, str]) -> None:
+        """Issue #1170: a hint naming a "file" handle this reader's own predicate rejects
+        must make the reader decline (None), not fall back to an unhinted rescan that
+        silently binds a different file the caller never named.
+        """
+        csv_path, txt_path = csv_and_txt_files
+        dac = DataAccessCollection(files={"data": csv_path, "notes": txt_path})
+        options = Options(context={"data_access_handle": "notes"})
+        resolved = _CsvLikeReader.match_subclass_data_access(dac, feature_names=["id"], options=options)
+        # Crux of the bug: today this rescans the collection and wrongly returns csv_path
+        # (the OTHER file, which the caller never hinted at) instead of declining.
+        assert resolved != csv_path
+        assert resolved is None
+
 
 # ----------------------------------------------------------------------------
 # ReadDocument: multi-file ambiguity raises, data_access_handle disambiguates
@@ -146,6 +170,21 @@ class TestReadDocumentHint:
         dac = DataAccessCollection(files={"notes_a": path_a})
         resolved = _TxtDocReader.match_subclass_data_access(dac, feature_names=["content"], options=Options())
         assert resolved == path_a
+
+    def test_hint_at_foreign_file_declines_instead_of_rescanning(self, csv_and_txt_files: tuple[str, str]) -> None:
+        """Issue #1170: a hint naming a "file" handle this reader's own predicate rejects
+        (a .csv file, which ReadDocument excludes as a structured suffix by default) must
+        make the reader decline (None), not fall back to an unhinted rescan that silently
+        binds the .txt file the caller never named.
+        """
+        csv_path, txt_path = csv_and_txt_files
+        dac = DataAccessCollection(files={"notes": txt_path, "data": csv_path})
+        options = Options(context={"data_access_handle": "data"})
+        resolved = _TxtDocReader.match_subclass_data_access(dac, feature_names=["content"], options=options)
+        # Crux of the bug: today this rescans the collection and wrongly returns txt_path
+        # (the OTHER file, which the caller never hinted at) instead of declining.
+        assert resolved != txt_path
+        assert resolved is None
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `ReadFile.match_subclass_data_access` and `ReadDocument.match_subclass_data_access`
  now return `None` when a `data_access_handle` hint names a "file" handle that the
  reader's own predicate rejects, instead of clearing the hint and falling back to
  an unhinted rescan of the whole `DataAccessCollection`.
- Previously this let a reader that doesn't own the hinted file silently bind to a
  different file than the one the caller explicitly named, discarding the caller's
  disambiguation choice (and in edge cases letting a foreign file's validation
  exception abort matching for a reader that should have declined cleanly).
- Same bug class as the ReadDB credentials-hint fix in #1169.

## Test plan
- [x] Added regression tests in `tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py`
      covering both `ReadFile` and `ReadDocument` declining on a rejected file hint
- [x] `pytest tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py -v`
- [x] `tox`

Fixes #1170