### PR TITLE
fix: stop Feature(domain=Domain(...)) from silently double-wrapping

### DIFF
--- a/docs/docs/in_depth/domain.md
+++ b/docs/docs/in_depth/domain.md
@@ -22,6 +22,8 @@ Feature(name="Revenue",
 )
 ```
 
+A `Domain` instance can be passed directly in both places instead of a string, with the same effect.
+
 The domain can also be set in the feature group.
 
 **Feature group**

--- a/mloda/core/abstract_plugins/components/domain.py
+++ b/mloda/core/abstract_plugins/components/domain.py
@@ -31,6 +31,11 @@ class Domain:
     """
 
     def __init__(self, name: str):
+        if not isinstance(name, str):
+            raise TypeError(
+                f"Domain requires a str name, got {type(name).__name__}; "
+                "pass an existing Domain instance through as-is instead of wrapping it again."
+            )
         self.name = name
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -50,7 +50,7 @@ class Feature:
     Attributes:
         name (FeatureName): The name of the feature.
         options (Options): The options associated with the feature.
-        domain (Optional[Domain]): The domain of the feature.
+        domain (Optional[str | Domain]): The domain of the feature.
         compute_frameworks (Optional[Set[Type[ComputeFramework]]]): The compute frameworks supported by the feature.
         data_type (Optional[DataType]): The data type of the feature.
         initial_requested_data (bool): Whether the data was initially requested.
@@ -99,7 +99,7 @@ class Feature:
         self,
         name: str | FeatureName,
         options: Optional[dict[str, Any] | Options] = None,
-        domain: Optional[str] = None,
+        domain: Optional[str | Domain] = None,
         compute_framework: Optional[str] = None,
         data_type: Optional[DataType | str] = None,
         initial_requested_data: bool = False,
@@ -115,6 +115,10 @@ class Feature:
         self.name = FeatureName(name) if isinstance(name, str) else name
         self.options = Options(options) if isinstance(options, dict) else options
         self.domain = self._set_domain(domain, self.options.get("domain"))
+        if "domain" in self.options.group:
+            # Copy first: options may be a caller-owned Options instance, not a private dict.
+            self.options = copy(self.options)
+            self.options.group.pop("domain", None)
 
         cf = self._set_compute_framework(compute_framework, self.options.get("compute_framework"))
         self.compute_frameworks = {cf} if cf else None
@@ -474,11 +478,11 @@ class Feature:
         """
         return self._grouping_hash(split_keys, include_data_type=False)
 
-    def _set_domain(self, domain: Optional[str], domain_options: Optional[str]) -> None | Domain:
+    def _set_domain(self, domain: Optional[str | Domain], domain_options: Optional[str | Domain]) -> None | Domain:
         if domain:
-            return Domain(domain)
+            return domain if isinstance(domain, Domain) else Domain(domain)
         elif domain_options:
-            return Domain(domain_options)
+            return domain_options if isinstance(domain_options, Domain) else Domain(domain_options)
         return None
 
     def _set_compute_framework(

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -416,12 +416,13 @@ class GlobalFilter:
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:
         # We have matched already the feature group and the feature.
         # Thus, we take the feature group domain if the feature domain is not set.
+        group_domain = self._read_group_domain(feature_group)
         feature_or_group_domain = None
         if feature_domain:
             feature_or_group_domain = feature_domain
         else:
-            if feature_group.get_domain() != Domain.get_default_domain():
-                feature_or_group_domain = feature_group.get_domain()
+            if group_domain is not None and group_domain != Domain.get_default_domain():
+                feature_or_group_domain = group_domain
 
         # no domains given -> ok
         if not filter.filter_feature.domain and not feature_or_group_domain:
@@ -436,7 +437,7 @@ class GlobalFilter:
         # In case that the filter has a domain and the feature not, it means that the
         # the feature group domain must be equal to the filter feature domain
         if filter.filter_feature.domain and not feature_domain:
-            if feature_group.get_domain() == filter.filter_feature.domain:
+            if group_domain == filter.filter_feature.domain:
                 return True
 
         # both domains same -> ok
@@ -444,6 +445,15 @@ class GlobalFilter:
             return True
 
         return False
+
+    @staticmethod
+    def _read_group_domain(feature_group: type[FeatureGroup]) -> Domain | None:
+        """get_domain() is plugin-owned; a raising or malformed read degrades to None instead of failing the gate."""
+
+        def _read() -> Domain | None:
+            return feature_group.get_domain()
+
+        return safe_field(_read, None)
 
     @staticmethod
     def _domain_reason(filter: SingleFilter, feat: Feature, feature_group: type[FeatureGroup]) -> str:

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature.py
@@ -2,6 +2,8 @@ import pytest
 from mloda.provider import ComputeFramework
 from mloda.user import Feature
 from mloda.core.abstract_plugins.components.data_types import DataType
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
 
@@ -46,6 +48,51 @@ def test_feature_set_domain() -> None:
 
     # Test when neither domain nor domain_options are set
     assert feature._set_domain(None, None) is None
+
+
+def test_feature_set_domain_accepts_already_built_domain() -> None:
+    """Passing a Domain instance for domain must not re-wrap it."""
+    feature = Feature(name="Feature1")
+
+    result = feature._set_domain(Domain("example_domain"), None)
+    assert result.name == "example_domain"  # type: ignore
+
+
+def test_feature_set_domain_options_accepts_already_built_domain() -> None:
+    """Passing a Domain instance for domain_options must not re-wrap it."""
+    feature = Feature(name="Feature1")
+
+    result = feature._set_domain(None, Domain("example_domain_options"))
+    assert result.name == "example_domain_options"  # type: ignore
+
+
+def test_feature_domain_param_matches_domain_str_param() -> None:
+    """Feature(domain=Domain(...)) must resolve identically to Feature(domain="...")."""
+    assert Feature("x", domain=Domain("m")) == Feature("x", domain="m")
+
+
+def test_feature_domain_options_matches_domain_str_param() -> None:
+    """Feature(options={"domain": Domain(...)}) must resolve identically to Feature(domain="...")."""
+    assert Feature("x", options={"domain": Domain("m")}) == Feature("x", domain="m")
+
+
+def test_feature_construction_does_not_mutate_a_shared_options_object() -> None:
+    """A caller-owned Options instance reused across features must keep its "domain" key."""
+    shared = Options({"domain": "sales"})
+
+    first = Feature("a", shared)
+    second = Feature("b", shared)
+
+    assert shared.group.get("domain") == "sales"
+    assert first.domain.name == "sales"  # type: ignore
+    assert second.domain.name == "sales"  # type: ignore
+
+
+def test_feature_domain_param_does_not_double_wrap() -> None:
+    """feature.domain.name must be the plain str, not a nested Domain instance."""
+    feature = Feature("x", domain=Domain("m"))
+    assert isinstance(feature.domain.name, str)  # type: ignore
+    assert feature.domain.name == "m"  # type: ignore
 
 
 def test_feature_data_type_from_string() -> None:

--- a/tests/test_core/test_abstract_plugins/test_eq_notimplemented.py
+++ b/tests/test_core/test_abstract_plugins/test_eq_notimplemented.py
@@ -83,6 +83,23 @@ class TestDomainEqTypeMismatch:
         assert (d == other) is False
 
 
+class TestDomainRejectsNonStrName:
+    """Domain.__init__ should raise TypeError when name is not a str."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            pytest.param(42, id="int"),
+            pytest.param(Domain("nested"), id="Domain-double-wrap"),
+            pytest.param(None, id="None"),
+            pytest.param(["not_a_str"], id="list"),
+        ],
+    )
+    def test_domain_non_str_name_raises_type_error(self, name: Any) -> None:
+        with pytest.raises(TypeError):
+            Domain(name)
+
+
 class TestNormalEqualityStillWorks:
     """Ensure normal same-type equality comparisons continue to work correctly."""
 
@@ -100,3 +117,6 @@ class TestNormalEqualityStillWorks:
 
     def test_domain_not_equal_different_name(self) -> None:
         assert Domain("x") != Domain("y")
+
+    def test_domain_accepts_str_name(self) -> None:
+        assert Domain("valid_name").name == "valid_name"


### PR DESCRIPTION
## Summary

`Feature(domain=Domain("x"))` and `Feature(name, options={"domain": Domain("x")})` were silently accepted but double-wrapped the value into `Domain(Domain("x"))`. That inner Domain never equals a plain `Domain("x")`, so a feature built this way failed to resolve against a matching feature group, and the resolution failure message rendered the domain as an object repr instead of its name.

## Changes

- `Domain.__init__` now raises `TypeError` when given a non-`str` name (including another `Domain` instance), naming the fix in the message.
- `Feature.domain` accepts a plain string or an already-built `Domain` instance; `Feature._set_domain` passes an existing `Domain` through as-is instead of re-wrapping it. This covers both the `domain=` parameter and `options={"domain": ...}`, so both now resolve identically to the equivalent string form.
- The now-redundant `"domain"` key is dropped from `Options.group` after construction (copy-on-write, so a caller-owned `Options` instance passed into multiple `Feature`s is never mutated).
- Two `get_domain()` reads in the domain filter gate (`GlobalFilter.domain`) now degrade like their sibling reads instead of raising, since a plugin-owned `Domain` can no longer be constructed with a broken name.
- One-line doc note that a `Domain` instance can be passed directly wherever a domain string is accepted.

No em dashes in this description, per repo convention.