### PR TITLE
fix: catch context-forwarded values that contradict a name-parsed binding

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -450,13 +450,21 @@ class FeatureChainParserMixin:
             unpacked = FeatureChainParser._unpack_property_value(inherited_value)
             if len(unpacked) == 1 and str(unpacked[0]) == name_value:
                 continue
+            if prop_key in options.inherited_group_keys:
+                remedy = (
+                    f"Carve the key out with forward_group_exclude={{'{prop_key}'}} on the child in the "
+                    f"consumer's input_features, or use an allowlist / forward_group=False."
+                )
+            else:
+                remedy = (
+                    f"Adjust inherit_context_keys on the child or propagate_context_keys on the consumer "
+                    f"so '{prop_key}' is no longer forwarded."
+                )
             message = (
                 f"Feature '{feature_name}': option '{prop_key}' was forwarded from a consumer with value "
                 f"'{inherited_value}', but the feature name parses to '{name_value}'. The name-parsed value "
-                f"takes precedence, so the forwarded value would be silently ignored. Carve the key out with "
-                f"forward_group_exclude={{'{prop_key}'}} on the child in the consumer's input_features, or use an "
-                f"allowlist / forward_group=False. Set MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to downgrade this "
-                f"error to a warning."
+                f"takes precedence, so the forwarded value would be silently ignored. {remedy} Set "
+                f"MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to downgrade this error to a warning."
             )
             if os.environ.get("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "").lower() in ("1", "true"):
                 logger.warning(message)

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -269,11 +269,11 @@ class FeatureChainParserMixin:
 
         For string-parsed features, additionally checks consumer-forwarded option
         values against the value parsed from the feature name: if a PROPERTY_MAPPING
-        key arrived via forwarding (it is in ``options.inherited_group_keys``) and its
-        value differs from the name-parsed value, a ``ValueError`` is raised, because
-        the name-parsed value would otherwise silently win. Setting the environment
-        variable ``MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1`` downgrades this error to a
-        warning.
+        key arrived via forwarding (it is in ``options.inherited_group_keys`` or
+        ``options.inherited_context_keys``) and its value differs from the name-parsed
+        value, a ``ValueError`` is raised, because the name-parsed value would
+        otherwise silently win. Setting the environment variable
+        ``MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1`` downgrades this error to a warning.
 
         The options view depends on the caller: feature resolution passes declared (pre-default)
         options, filter matching a post-intake merge. See ``FeatureGroup.match_feature_group_criteria``.
@@ -429,16 +429,18 @@ class FeatureChainParserMixin:
         bindings: dict[str, str],
         options: Options,
     ) -> None:
-        """Reject consumer-forwarded option values that contradict a name-derived binding.
+        """Reject a value forwarded via either the group or the context path that contradicts a
+        name-derived binding.
 
         Iterates every binding, so a secondary capture is protected exactly like the first one. The
         name-parsed value takes precedence, so a differing forwarded value would be silently ignored.
         Raises ValueError unless MLODA_ALLOW_FORWARDED_NAME_MISMATCH downgrades the error to a warning.
         """
-        if not options.inherited_group_keys or not bindings:
+        inherited_keys = options.inherited_group_keys | options.inherited_context_keys
+        if not inherited_keys or not bindings:
             return
         for prop_key, name_value in bindings.items():
-            if prop_key not in options.inherited_group_keys:
+            if prop_key not in inherited_keys:
                 continue
             inherited_value = options.get(prop_key)
             if inherited_value is None:

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -16,13 +16,9 @@ No behavior change when: values are equal, K was set by the author (not
 inherited), the feature is config-based (no string parse), or K is absent from
 the options.
 
-Also covers the context-path counterpart: a value forwarded into
-``options.inherited_context_keys`` via ``inherit_context_keys`` or the
-consumer's ``propagate_context_keys`` must be checked exactly like a
-group-forwarded value, not silently ignored. Its remedy text must differ
-from the group path's: "forward_group_exclude" does not remove a
-context-forwarded value, so the message must omit it and instead name
-"inherit_context_keys" / "propagate_context_keys".
+Also covers the context path: inherited_context_keys must be checked like
+inherited_group_keys, with remedy text naming
+inherit_context_keys/propagate_context_keys instead of forward_group_exclude.
 
 All fixture names carry a "namemis579" (group path) or "ctxmis579" (context
 path) marker so they cannot collide with other tests in the global plugin
@@ -80,11 +76,7 @@ STRING_FEATURE_NAME_CTX = "sales__sum_ctxmis579"
 
 
 class _ContextMismatchChainedGroup(FeatureChainParserMixin):
-    """Context-path counterpart of ``_NameMismatchChainedGroup``.
-
-    The operation key is context-categorized (context=True, the default made explicit here):
-    it is reachable only through the context-forwarding flows, not group forwarding.
-    """
+    """Context-path counterpart of ``_NameMismatchChainedGroup``; context=True, reachable only via context forward."""
 
     PREFIX_PATTERN = r".*__(sum|max)_ctxmis579$"
     PROPERTY_MAPPING = {
@@ -267,13 +259,10 @@ class TestForwardedSingletonUnpack:
 
 
 class TestForwardedContextNameMismatch:
-    """The check must also catch a value forwarded via the context path
-    (inherited_context_keys), not just options.inherited_group_keys.
-    """
+    """The check must also catch a value forwarded via the context path (inherited_context_keys), not just group."""
 
     def test_context_pull_differing_value_raises(self) -> None:
-        """A value pulled into the child's context via inherit_context_keys, contradicting the
-        name-parsed value, must raise."""
+        """A context-pulled value contradicting the name-parsed value must raise."""
         child_options = _context_pull_child_options({CONTEXT_KEY: "max"})
         assert child_options.inherited_context_keys == frozenset({CONTEXT_KEY})  # precondition
 
@@ -286,15 +275,12 @@ class TestForwardedContextNameMismatch:
         assert "sum" in message
         assert "max" in message
         assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
-        # A context-forwarded mismatch cannot be fixed with the group-only remedy; the message
-        # must instead name the context-forwarding controls that actually carried the value.
         assert "forward_group_exclude" not in message
         assert "inherit_context_keys" in message
         assert "propagate_context_keys" in message
 
     def test_context_propagate_differing_value_raises(self) -> None:
-        """A value pushed into the child's context via consumer.propagate_context_keys,
-        contradicting the name-parsed value, must also raise."""
+        """A context-pushed value contradicting the name-parsed value must also raise."""
         child_options = _context_propagate_child_options({CONTEXT_KEY: "max"})
         assert child_options.inherited_context_keys == frozenset({CONTEXT_KEY})  # precondition
 
@@ -307,7 +293,6 @@ class TestForwardedContextNameMismatch:
         assert "sum" in message
         assert "max" in message
         assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
-        # Same context-only remedy requirement as the pull path above.
         assert "forward_group_exclude" not in message
         assert "inherit_context_keys" in message
         assert "propagate_context_keys" in message

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -19,7 +19,10 @@ the options.
 Also covers the context-path counterpart: a value forwarded into
 ``options.inherited_context_keys`` via ``inherit_context_keys`` or the
 consumer's ``propagate_context_keys`` must be checked exactly like a
-group-forwarded value, not silently ignored.
+group-forwarded value, not silently ignored. Its remedy text must differ
+from the group path's: "forward_group_exclude" does not remove a
+context-forwarded value, so the message must omit it and instead name
+"inherit_context_keys" / "propagate_context_keys".
 
 All fixture names carry a "namemis579" (group path) or "ctxmis579" (context
 path) marker so they cannot collide with other tests in the global plugin
@@ -283,6 +286,11 @@ class TestForwardedContextNameMismatch:
         assert "sum" in message
         assert "max" in message
         assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
+        # A context-forwarded mismatch cannot be fixed with the group-only remedy; the message
+        # must instead name the context-forwarding controls that actually carried the value.
+        assert "forward_group_exclude" not in message
+        assert "inherit_context_keys" in message
+        assert "propagate_context_keys" in message
 
     def test_context_propagate_differing_value_raises(self) -> None:
         """A value pushed into the child's context via consumer.propagate_context_keys,
@@ -299,6 +307,10 @@ class TestForwardedContextNameMismatch:
         assert "sum" in message
         assert "max" in message
         assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
+        # Same context-only remedy requirement as the pull path above.
+        assert "forward_group_exclude" not in message
+        assert "inherit_context_keys" in message
+        assert "propagate_context_keys" in message
 
     def test_context_pull_equal_value_matches(self) -> None:
         """A pulled context value equal to the name-parsed value matches silently."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -16,8 +16,14 @@ No behavior change when: values are equal, K was set by the author (not
 inherited), the feature is config-based (no string parse), or K is absent from
 the options.
 
-All fixture names carry a "namemis579" marker so they cannot collide with
-other tests in the global plugin registry.
+Also covers the context-path counterpart (#1159): a value forwarded into
+``options.inherited_context_keys`` via ``inherit_context_keys`` or the
+consumer's ``propagate_context_keys`` must be checked exactly like a
+group-forwarded value, not silently ignored.
+
+All fixture names carry a "namemis579" (group path) or "ctxmis579" (context
+path) marker so they cannot collide with other tests in the global plugin
+registry.
 """
 
 from __future__ import annotations
@@ -63,6 +69,46 @@ def _inherited_child_options(consumer_group: dict[str, Any]) -> Options:
     """Build child options exactly like the engine does: inherit_from the consumer."""
     child_options = Options()
     child_options.inherit_from(Options(group=consumer_group))
+    return child_options
+
+
+CONTEXT_KEY = "operation_ctxmis579"
+STRING_FEATURE_NAME_CTX = "sales__sum_ctxmis579"
+
+
+class _ContextMismatchChainedGroup(FeatureChainParserMixin):
+    """Context-path counterpart of ``_NameMismatchChainedGroup``.
+
+    The operation key is context-categorized (context=True, the default made explicit here):
+    it is reachable only through the context-forwarding flows, not group forwarding.
+    """
+
+    PREFIX_PATTERN = r".*__(sum|max)_ctxmis579$"
+    PROPERTY_MAPPING = {
+        CONTEXT_KEY: PropertySpec(
+            "Operation of the ctxmis579 fixture",
+            allowed_values={
+                "sum": "Sum of the in feature (ctxmis579 fixture)",
+                "max": "Maximum of the in feature (ctxmis579 fixture)",
+            },
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+
+def _context_pull_child_options(consumer_context: dict[str, Any]) -> Options:
+    """Child-side pull: child.inherit_from(consumer, inherit_context_keys=...)."""
+    child_options = Options()
+    child_options.inherit_from(Options(context=consumer_context), inherit_context_keys=frozenset(consumer_context.keys()))
+    return child_options
+
+
+def _context_propagate_child_options(consumer_context: dict[str, Any]) -> Options:
+    """Consumer-side push: consumer.propagate_context_keys flows into the child on inherit_from."""
+    child_options = Options()
+    consumer = Options(context=consumer_context, propagate_context_keys=frozenset(consumer_context.keys()))
+    child_options.inherit_from(consumer)
     return child_options
 
 
@@ -213,3 +259,83 @@ class TestForwardedSingletonUnpack:
             _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
 
         assert "forward_group_exclude" in str(exc_info.value)
+
+
+class TestForwardedContextNameMismatch:
+    """Issue #1159: the check must also catch a value forwarded via the context path
+    (inherited_context_keys), not just options.inherited_group_keys.
+    """
+
+    def test_context_pull_differing_value_raises(self) -> None:
+        """A value pulled into the child's context via inherit_context_keys, contradicting the
+        name-parsed value, must raise."""
+        child_options = _context_pull_child_options({CONTEXT_KEY: "max"})
+        assert child_options.inherited_context_keys == frozenset({CONTEXT_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            _ContextMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME_CTX, child_options)
+
+        message = str(exc_info.value)
+        assert STRING_FEATURE_NAME_CTX in message
+        assert CONTEXT_KEY in message
+        assert "sum" in message
+        assert "max" in message
+        assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
+
+    def test_context_propagate_differing_value_raises(self) -> None:
+        """A value pushed into the child's context via consumer.propagate_context_keys,
+        contradicting the name-parsed value, must also raise."""
+        child_options = _context_propagate_child_options({CONTEXT_KEY: "max"})
+        assert child_options.inherited_context_keys == frozenset({CONTEXT_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            _ContextMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME_CTX, child_options)
+
+        message = str(exc_info.value)
+        assert STRING_FEATURE_NAME_CTX in message
+        assert CONTEXT_KEY in message
+        assert "sum" in message
+        assert "max" in message
+        assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
+
+    def test_context_pull_equal_value_matches(self) -> None:
+        """A pulled context value equal to the name-parsed value matches silently."""
+        child_options = _context_pull_child_options({CONTEXT_KEY: "sum"})
+        assert child_options.inherited_context_keys == frozenset({CONTEXT_KEY})  # precondition
+
+        result = _ContextMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME_CTX, child_options)
+
+        assert result is True
+
+    def test_env_var_downgrades_context_mismatch_to_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """With MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 a context-path mismatch warns once, no raise."""
+        monkeypatch.setenv("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "1")
+        child_options = _context_pull_child_options({CONTEXT_KEY: "max"})
+
+        with caplog.at_level(logging.WARNING):
+            result = _ContextMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME_CTX, child_options)
+
+        assert result is True
+        records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and CONTEXT_KEY in record.getMessage()
+        ]
+        assert len(records) == 1, (
+            f"Expected exactly one WARNING mentioning '{CONTEXT_KEY}', got {len(records)}: "
+            f"{[record.getMessage() for record in records]}"
+        )
+        message = records[0].getMessage()
+        assert "sum" in message
+        assert "max" in message
+
+    def test_author_set_context_value_does_not_raise(self) -> None:
+        """An author-set context value (not inherited) keeps today's silent name precedence."""
+        child_options = Options(context={CONTEXT_KEY: "max"})
+        assert child_options.inherited_context_keys == frozenset()  # precondition: nothing inherited
+
+        result = _ContextMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME_CTX, child_options)
+
+        assert result is True

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -16,7 +16,7 @@ No behavior change when: values are equal, K was set by the author (not
 inherited), the feature is config-based (no string parse), or K is absent from
 the options.
 
-Also covers the context-path counterpart (#1159): a value forwarded into
+Also covers the context-path counterpart: a value forwarded into
 ``options.inherited_context_keys`` via ``inherit_context_keys`` or the
 consumer's ``propagate_context_keys`` must be checked exactly like a
 group-forwarded value, not silently ignored.
@@ -264,7 +264,7 @@ class TestForwardedSingletonUnpack:
 
 
 class TestForwardedContextNameMismatch:
-    """Issue #1159: the check must also catch a value forwarded via the context path
+    """The check must also catch a value forwarded via the context path
     (inherited_context_keys), not just options.inherited_group_keys.
     """
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -100,7 +100,9 @@ class _ContextMismatchChainedGroup(FeatureChainParserMixin):
 def _context_pull_child_options(consumer_context: dict[str, Any]) -> Options:
     """Child-side pull: child.inherit_from(consumer, inherit_context_keys=...)."""
     child_options = Options()
-    child_options.inherit_from(Options(context=consumer_context), inherit_context_keys=frozenset(consumer_context.keys()))
+    child_options.inherit_from(
+        Options(context=consumer_context), inherit_context_keys=frozenset(consumer_context.keys())
+    )
     return child_options
 
 


### PR DESCRIPTION
## Summary

`FeatureChainParserMixin._validate_forwarded_name_mismatch` rejects a consumer-forwarded PROPERTY_MAPPING value that contradicts the value a feature name parses to, but it only checked `options.inherited_group_keys`. A value forwarded via the context path, either pulled in with `inherit_context_keys` on the child or pushed by `propagate_context_keys` on the consumer, populates `options.inherited_context_keys` instead and was not caught, so a contradicting context-forwarded value could silently lose to the name-parsed value.

## Changes

- Check the union of `options.inherited_group_keys` and `options.inherited_context_keys`, so a context-forwarded mismatch is now caught exactly like a group-forwarded one.
- The remedy text in the raised (or, with `MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1`, warned) error now depends on which path forwarded the key: `forward_group_exclude` / allowlist / `forward_group=False` for a group-forwarded key, and guidance to adjust `inherit_context_keys` or `propagate_context_keys` for a context-forwarded key, since the group-forwarding controls do not remove a context-forwarded value.
- Added tests covering the `inherit_context_keys` pull path, the `propagate_context_keys` push path, equal-value matches, the env var downgrade, and author-set context values.

## Test plan

- `tox` passes: full suite, ruff format/check, mypy strict, bandit.