### PR TITLE
fix: derive add_tfs transform hops from every FeatureGroupStep member

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -424,8 +424,10 @@ class ExecutionPlan:
                 if ep.features.any_uuid is None:
                     raise ValueError(f"Feature group {format_feature_group_class(ep.feature_group)} has no uuid.")
 
-                parents = graph.parent_to_children_mapping[ep.features.any_uuid]
-                parent_parents = self.get_parent_parents(parents, graph)
+                parents: set[UUID] = set()
+                for member_uuid in ep.get_uuids():
+                    member_parents = graph.parent_to_children_mapping.get(member_uuid, set())
+                    parents |= member_parents - self.get_parent_parents(member_parents, graph)
 
                 for parent in parents:
                     match = set()
@@ -438,10 +440,6 @@ class ExecutionPlan:
                             break
                     if match:
                         # parent is served by a join step; the expanded link token already orders the consumer
-                        continue
-
-                    # We only want to add TFS for direct parents and not for parent parents.
-                    if parent in parent_parents:
                         continue
 
                     if ep.compute_framework != parent_node_property.feature.get_compute_framework():
@@ -564,7 +562,7 @@ class ExecutionPlan:
     def get_parent_parents(self, parents: set[UUID], graph: Graph) -> set[UUID]:
         parent_parents = set()
         for parent in parents:
-            parent_parent = graph.parent_to_children_mapping[parent]
+            parent_parent = graph.parent_to_children_mapping.get(parent, set())
             if len(parent_parent) > 0:
                 parent_parents.update(parent_parent)
         return parent_parents

--- a/tests/test_core/test_prepare/test_add_tfs_multi_member_parents.py
+++ b/tests/test_core/test_prepare/test_add_tfs_multi_member_parents.py
@@ -1,0 +1,204 @@
+"""Regression coverage for add_tfs's FeatureGroupStep branch: it must plan a transform hop for
+every member feature's parents, not only for the member that happens to be FeatureSet.any_uuid
+(set to whichever feature was ``.add()``-ed first).
+"""
+
+from typing import NamedTuple
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.provider import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class MultiMemberBaseFG(FeatureGroup):
+    """Unmatchable base so a leaked subclass stays invisible to feature resolution."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class MultiMemberUpstreamFG(MultiMemberBaseFG):
+    pass
+
+
+class MultiMemberDestFG(MultiMemberBaseFG):
+    pass
+
+
+def _feature(name: str, cfw: type[ComputeFramework]) -> Feature:
+    feature = Feature(name)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _root_node(graph: Graph, feature: Feature, fg: type[FeatureGroup]) -> None:
+    graph.add_node(feature.uuid, NodeProperties(feature, fg))
+    graph.parent_to_children_mapping[feature.uuid] = set()
+
+
+def _producer_step(fg: type[FeatureGroup], feature: Feature, cfw: type[ComputeFramework]) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    feature_set.add(feature)
+    return FeatureGroupStep(fg, feature_set, set(), cfw)
+
+
+class MultiMemberScenario(NamedTuple):
+    step: FeatureGroupStep
+    producer: FeatureGroupStep
+    member_with_parent: Feature
+    member_without_parent: Feature
+    parent: Feature
+    graph: Graph
+
+
+def _multi_member_scenario(parent_bearing_member_added_first: bool) -> MultiMemberScenario:
+    """One FeatureGroupStep whose FeatureSet holds two members: one with a parent living on a
+    different compute framework (needs a transform hop), and one parentless, like an
+    auto-added index companion feature. Add order decides which member becomes any_uuid."""
+    graph = Graph()
+
+    parent = _feature("multi_member_upstream", PyArrowTable)
+    _root_node(graph, parent, MultiMemberUpstreamFG)
+    producer = _producer_step(MultiMemberUpstreamFG, parent, PyArrowTable)
+
+    member_with_parent = _feature("multi_member_with_parent", PandasDataFrame)
+    member_without_parent = _feature("multi_member_without_parent", PandasDataFrame)
+
+    graph.parent_to_children_mapping[member_with_parent.uuid] = {parent.uuid}
+    graph.parent_to_children_mapping[member_without_parent.uuid] = set()
+
+    feature_set = FeatureSet()
+    if parent_bearing_member_added_first:
+        feature_set.add(member_with_parent)
+        feature_set.add(member_without_parent)
+    else:
+        feature_set.add(member_without_parent)
+        feature_set.add(member_with_parent)
+
+    step = FeatureGroupStep(MultiMemberDestFG, feature_set, set(), PandasDataFrame)
+
+    return MultiMemberScenario(step, producer, member_with_parent, member_without_parent, parent, graph)
+
+
+def test_transform_hop_created_when_parent_bearing_member_is_any_uuid() -> None:
+    """any_uuid resolves to the parent-bearing member: the existing loop already finds the hop."""
+    scenario = _multi_member_scenario(parent_bearing_member_added_first=True)
+
+    new_plan = ExecutionPlan().add_tfs([scenario.producer, scenario.step], scenario.graph)
+
+    tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
+    assert len(tfs_steps) == 1, f"expected one transform hop for member_with_parent's parent, got: {tfs_steps}"
+    tfs_uuid = tfs_steps[0].uuid
+
+    assert scenario.parent.uuid in tfs_steps[0].required_uuids
+    assert tfs_uuid in scenario.step.required_uuids
+    assert tfs_uuid in scenario.step.tfs_ids
+
+
+def test_transform_hop_created_when_parentless_member_is_any_uuid() -> None:
+    """any_uuid resolves to the parentless member: add_tfs must still find member_with_parent's
+    parent by scanning all of the step's member features (FeatureGroupStep.get_uuids()), not just
+    any_uuid, or the hop for member_with_parent's parent is silently skipped.
+    """
+    scenario = _multi_member_scenario(parent_bearing_member_added_first=False)
+
+    new_plan = ExecutionPlan().add_tfs([scenario.producer, scenario.step], scenario.graph)
+
+    tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
+    assert len(tfs_steps) == 1, (
+        f"expected one transform hop for member_with_parent's parent regardless of which member "
+        f"is any_uuid, got: {tfs_steps}"
+    )
+    tfs_uuid = tfs_steps[0].uuid
+
+    assert scenario.parent.uuid in tfs_steps[0].required_uuids
+    assert tfs_uuid in scenario.step.required_uuids
+    assert tfs_uuid in scenario.step.tfs_ids
+
+
+# ---------------------------------------------------------------------------
+# Overlapping ancestor chains across members
+# ---------------------------------------------------------------------------
+
+
+class OverlappingAncestorsScenario(NamedTuple):
+    step: FeatureGroupStep
+    producer_p: FeatureGroupStep
+    producer_q: FeatureGroupStep
+    member_a: Feature
+    member_b: Feature
+    p: Feature
+    q: Feature
+    graph: Graph
+
+
+def _overlapping_ancestors_scenario() -> OverlappingAncestorsScenario:
+    """One FeatureGroupStep with two members whose direct parents chain into each other: member_a's
+    direct parent is p, member_b's direct parent is q, and q's own direct parent is p. Pruning
+    member_a's direct parent p just because p is also an indirect ancestor (via q) of member_b
+    would wrongly drop member_a's hop."""
+    graph = Graph()
+
+    p = _feature("multi_member_overlap_p", PyArrowTable)
+    _root_node(graph, p, MultiMemberUpstreamFG)
+    producer_p = _producer_step(MultiMemberUpstreamFG, p, PyArrowTable)
+
+    q = _feature("multi_member_overlap_q", PyArrowTable)
+    graph.add_node(q.uuid, NodeProperties(q, MultiMemberUpstreamFG))
+    graph.parent_to_children_mapping[q.uuid] = {p.uuid}
+    producer_q = _producer_step(MultiMemberUpstreamFG, q, PyArrowTable)
+
+    member_a = _feature("multi_member_overlap_a", PandasDataFrame)
+    member_b = _feature("multi_member_overlap_b", PandasDataFrame)
+
+    graph.parent_to_children_mapping[member_a.uuid] = {p.uuid}
+    graph.parent_to_children_mapping[member_b.uuid] = {p.uuid, q.uuid}
+
+    feature_set = FeatureSet()
+    feature_set.add(member_a)
+    feature_set.add(member_b)
+
+    step = FeatureGroupStep(MultiMemberDestFG, feature_set, set(), PandasDataFrame)
+
+    return OverlappingAncestorsScenario(step, producer_p, producer_q, member_a, member_b, p, q, graph)
+
+
+def test_transform_hop_created_for_each_members_own_direct_parent_with_overlapping_ancestor_chains() -> None:
+    """member_a's direct parent p must not be pruned away just because it is also an indirect
+    ancestor of member_b's direct parent q."""
+    scenario = _overlapping_ancestors_scenario()
+
+    new_plan = ExecutionPlan().add_tfs([scenario.producer_p, scenario.producer_q, scenario.step], scenario.graph)
+
+    tfs_steps = [step for step in new_plan if isinstance(step, TransformFrameworkStep)]
+    assert len(tfs_steps) == 2, (
+        f"expected one transform hop for member_a's direct parent p and one for member_b's "
+        f"direct parent q, got: {[(s.uuid, s.required_uuids) for s in tfs_steps]}"
+    )
+
+    hop_p = next(step for step in tfs_steps if scenario.p.uuid in step.required_uuids)
+    hop_q = next(step for step in tfs_steps if scenario.q.uuid in step.required_uuids)
+    assert hop_p.uuid != hop_q.uuid
+
+    assert hop_p.uuid in scenario.step.tfs_ids
+    assert hop_q.uuid in scenario.step.tfs_ids


### PR DESCRIPTION
Closes #1138

## Summary

`ExecutionPlan.add_tfs`'s `FeatureGroupStep` branch decided which cross-framework transform hops a step needs by looking only at `FeatureSet.any_uuid`, one arbitrary member feature of the step. A step whose members have different parent sets, for example a derived feature sharing a `(framework, options)` group with an auto-added, parentless index companion feature, only got a hop planned when the parent-bearing member happened to be `any_uuid`. Since `any_uuid` is set to whichever feature was added first to a plain `set`, the outcome depended on the process hash seed: sometimes the needed hop was silently missing and the consuming feature group saw no parent data.

## Fix

`add_tfs` now derives each member feature's direct parents individually (its full ancestor closure minus its own ancestors-of-ancestors) and unions the per-member results, instead of unioning raw ancestor closures across members before pruning. Pruning on the union directly is unsound when members have overlapping ancestor chains: a feature that is a genuine direct parent of one member can also be a transitive ancestor of another member's direct parent, so a single global prune wrongly discards it. Doing the direct-parent reduction per member first avoids that.

Also switched two `defaultdict` lookups from bracket indexing to `.get(..., set())`, matching existing precedent elsewhere in the graph code, so that looking up a parentless member no longer inserts a spurious empty entry as a side effect.

## Tests

Added unit coverage that drives `ExecutionPlan.add_tfs` directly: a step with a parent-bearing member next to a parentless one (both add orders, so it is not order-dependent), and a step with two members whose direct parents overlap through a shared upstream ancestor chain.