### PR TITLE
Export declared_columnwise_hooks from mloda.provider

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -206,6 +206,17 @@ def test_pandas_rolling_implements_its_hooks():
     assert missing_columnwise_hooks(PandasRolling) == []
 ```
 
+`missing_columnwise_hooks(cls) == []` also passes vacuously for a class that never sets
+`REQUIRED_COLUMNWISE_HOOKS`. Use `declared_columnwise_hooks(cls)`, also from `mloda.provider`, to
+assert the declaration itself is what's expected:
+
+```python
+from mloda.provider import declared_columnwise_hooks, COLUMN_DISCOVERY_HOOKS
+
+def test_pandas_rolling_declares_all_hooks():
+    assert declared_columnwise_hooks(PandasRolling) == COLUMN_DISCOVERY_HOOKS
+```
+
 A hook that is not a `@classmethod` or `@staticmethod` counts as missing: the `cls._hook(...)` call
 cannot reach it. A family base reports all of its declared hooks, since it declares the contract its
 subclasses implement, so assert this on the framework-bound class rather than on the base.

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -76,6 +76,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     COLUMNWISE_HOOKS,
     COLUMN_DISCOVERY_HOOKS,
     missing_columnwise_hooks,
+    declared_columnwise_hooks,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import (
@@ -166,6 +167,7 @@ __all__ = [
     "COLUMNWISE_HOOKS",
     "COLUMN_DISCOVERY_HOOKS",
     "missing_columnwise_hooks",
+    "declared_columnwise_hooks",
     "ParsedFeatureName",
     "PropertySpec",
     "is_no_default",

--- a/tests/test_mloda_imports.py
+++ b/tests/test_mloda_imports.py
@@ -152,6 +152,7 @@ def test_import_provider_base_classes() -> None:
         COLUMNWISE_HOOKS,
         COLUMN_DISCOVERY_HOOKS,
         missing_columnwise_hooks,
+        declared_columnwise_hooks,
         # Match rejection recording
         record_match_rejection,
         INPUT_DATA_STAGE,
@@ -196,6 +197,7 @@ def test_import_provider_base_classes() -> None:
     assert COLUMNWISE_HOOKS
     assert COLUMN_DISCOVERY_HOOKS > COLUMNWISE_HOOKS
     assert callable(missing_columnwise_hooks)
+    assert callable(declared_columnwise_hooks)
     # Match rejection recording
     assert callable(record_match_rejection)
     assert INPUT_DATA_STAGE == "input_data"


### PR DESCRIPTION
## Summary

`mloda.provider` already re-exports `missing_columnwise_hooks`, `COLUMNWISE_HOOKS`, and `COLUMN_DISCOVERY_HOOKS` from the feature chain parser mixin, but not `declared_columnwise_hooks`. This left plugin authors without a public way to assert a class's `REQUIRED_COLUMNWISE_HOOKS` declaration directly (only whether it's implemented via `missing_columnwise_hooks`, which returns `[]` both when every declared hook is implemented and when nothing was declared at all).

## Related issue

Closes #1155

## Changes

- Export `declared_columnwise_hooks` from `mloda.provider`.
- Extend the provider import test to cover it.
- Add a short docs example showing the vacuous-pass pitfall and how `declared_columnwise_hooks(cls) == COLUMN_DISCOVERY_HOOKS` closes it.

## Test plan

- [x] `tox` passes (pytest, ruff format/check, mypy --strict, bandit, license check)
