### PR TITLE
fix: reclaim ConcatenatedFileContent join class in four test files

### DIFF
--- a/tests/test_plugins/feature_group/input_data/test_read_context_files.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files.py
@@ -9,9 +9,13 @@ will not find it. These tests verify the consumer has been updated.
 import inspect
 import os
 import tempfile
+from collections.abc import Iterator
 
 import pytest
 
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
 from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
 from mloda_plugins.feature_group.input_data.read_document_feature import ReadDocumentFeature
 from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature
@@ -19,6 +23,12 @@ from mloda.user import FeatureName, Options
 from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader
 from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_dynamic_feature_groups() -> Iterator[None]:
+    yield
+    DynamicFeatureGroupCreator._created_classes.pop(ConcatenatedFileContent.join_feature_name, None)
 
 
 class TestConcatenatedFileContentUsesReadDocumentFeature:

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
@@ -22,23 +22,35 @@ Filtering that removes EVERY named file is the sharp edge of the fix and is pinn
 empty result must be a loud error, not a join child whose ``in_features`` is an empty frozenset.
 
 Subclass-leak policy: this module defines no ``FeatureGroup`` or ``BaseInputData`` subclass at all,
-so it has nothing to leak; it drives the shipped ``ConcatenatedFileContent`` directly.
+so it has nothing to leak that way; ``_create_join_class`` still registers
+``ConcatenatedFileContent.join_feature_name`` in ``DynamicFeatureGroupCreator._created_classes``, a
+permanent strong reference no ``gc.collect()`` reclaims, so the autouse fixture below pops it back out.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from mloda.provider import DefaultOptionKeys
 from mloda.user import FeatureName, Options
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
 from mloda_plugins.feature_group.experimental.source_input_feature import SourceTuple
 from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
 from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader
 
 
 PROBE_FEATURE = FeatureName("rcff_file_paths_probe")
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_dynamic_feature_groups() -> Iterator[None]:
+    yield
+    DynamicFeatureGroupCreator._created_classes.pop(ConcatenatedFileContent.join_feature_name, None)
 
 
 def _source_tuples(instance: ConcatenatedFileContent, options: Options) -> set[SourceTuple]:

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -50,6 +50,9 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.provider import DefaultOptionKeys, PropertySpec, is_no_default
 from mloda.user import FeatureName, Options
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
 from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
 from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
 from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader
@@ -59,6 +62,12 @@ from mloda_plugins.feature_group.input_data.read_files.text_file_reader import P
 DECLARED_KEYS = frozenset({"disallowed_files", "file_paths", "target_folder", "file_type", "document_reader_class"})
 
 PROBE_FEATURE = FeatureName("rcfd_declaration_probe")
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_dynamic_feature_groups() -> Iterator[None]:
+    yield
+    DynamicFeatureGroupCreator._created_classes.pop(ConcatenatedFileContent.join_feature_name, None)
 
 
 @pytest.fixture

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -46,6 +46,9 @@ from mloda_plugins.feature_group.experimental.forecasting.base import Forecastin
 from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
+    DynamicFeatureGroupCreator,
+)
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
 from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
@@ -131,6 +134,16 @@ def _load_all_plugins() -> Iterator[None]:
     yield
     gc.collect()
     gc.collect()
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_dynamic_feature_groups() -> Iterator[None]:
+    """This module only imports ``ConcatenatedFileContent``, but a sibling test file in the same xdist
+    worker can register its join class first; pop it here too so this module never carries the leak
+    forward regardless of run order.
+    """
+    yield
+    DynamicFeatureGroupCreator._created_classes.pop(ConcatenatedFileContent.join_feature_name, None)
 
 
 def _make_leaked_reader_probe() -> type[BaseInputData]:


### PR DESCRIPTION
## Summary

DynamicFeatureGroupCreator._created_classes holds a permanent strong reference to every class it creates, keyed by class_name. ConcatenatedFileContent._create_join_class registers a join class under this cache, so once a test exercises that path the class is never reclaimed, regardless of gc.collect(). A leaked feature group is reachable by resolution and would compete for features in any test that enumerates or resolves feature groups.

One existing test already pops this exact class name in its own teardown fixture. This PR adds the same autouse teardown fixture to the four other test files that exercise the same path:

- tests/test_plugins/feature_group/input_data/test_read_context_files.py
- tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
- tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
- tests/test_plugins/test_undeclared_option_reads.py

## Test plan

- [x] `tox` passes (9350 passed, 170 skipped, 2 xfailed; format, lint, mypy strict, bandit all green)
- [x] Verified in isolation that `DynamicFeatureGroupCreator._created_classes` is empty after each of the four files runs