### PR TITLE
docs: align class snippets with shipped bases, extract shared docs-corpus test helper

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -209,7 +209,7 @@ Feature groups follow a layered architecture:
 
 ```
 FeatureGroup
-  └── BaseFeatureGroup (e.g., ClusteringFeatureGroup)
+  └── BaseFeatureGroup (e.g., SegmentationFeatureGroup)
         ├── PandasImplementation
         ├── PyArrowImplementation
         └── PythonDictFrameworkImplementation
@@ -277,11 +277,11 @@ For more details on how data transformation works between compute frameworks, se
 
 ## Example
 
-For a clustering feature group:
+For a segmentation feature group:
 
 ```py
 # Base class (framework-agnostic)
-class ClusteringFeatureGroup(FeatureGroup):
+class SegmentationFeatureGroup(FeatureGroup):
     def input_features(self, options, feature_name):
         # Extract source features from feature name
         
@@ -290,31 +290,31 @@ class ClusteringFeatureGroup(FeatureGroup):
         # This will be overridden by framework-specific implementations
 
 # Pandas implementation
-class PandasClusteringFeatureGroup(ClusteringFeatureGroup):
+class PandasSegmentationFeatureGroup(SegmentationFeatureGroup):
     @classmethod
     def compute_framework_rule(cls):
         return {PandasDataFrame}
     
     @classmethod
     def calculate_feature(cls, data, features):
-        # Pandas-specific clustering implementation
+        # Pandas-specific segmentation implementation
         
 # PyArrow implementation
-class PyArrowClusteringFeatureGroup(ClusteringFeatureGroup):
+class PyArrowSegmentationFeatureGroup(SegmentationFeatureGroup):
     @classmethod
     def compute_framework_rule(cls):
         return {PyArrowTable}
     
     @classmethod
     def calculate_feature(cls, data, features):
-        # PyArrow-specific clustering implementation
+        # PyArrow-specific segmentation implementation
 ```
 
-For an aggregated feature group with Polars support:
+For a summary feature group with Polars support:
 
 ```py
 # Base class (framework-agnostic)
-class AggregatedFeatureGroup(FeatureGroup):
+class SummaryFeatureGroup(FeatureGroup):
     def input_features(self, options, feature_name):
         # Extract source features from feature name
         
@@ -323,14 +323,14 @@ class AggregatedFeatureGroup(FeatureGroup):
         # This will be overridden by framework-specific implementations
 
 # Polars Lazy implementation
-class PolarsLazyAggregatedFeatureGroup(AggregatedFeatureGroup):
+class PolarsLazySummaryFeatureGroup(SummaryFeatureGroup):
     @classmethod
     def compute_framework_rule(cls):
         return {PolarsLazyDataFrame}
     
     @classmethod
     def calculate_feature(cls, data, features):
-        # Polars lazy-specific aggregation implementation
+        # Polars lazy-specific summary implementation
         # Uses lazy evaluation for query optimization
 ```
 

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -264,7 +264,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 Override when you need to add additional input features (e.g., time filter):
 
 ```py
-class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         # Try string-based parsing first
         _, in_feature = FeatureChainParser.parse_feature_name(str(feature_name), [self.PREFIX_PATTERN])

--- a/docs/docs/in_depth/framework-connection-object.md
+++ b/docs/docs/in_depth/framework-connection-object.md
@@ -40,7 +40,7 @@ Other frameworks don't require connection objects:
 The base `ComputeFramework` class provides methods to manage connection objects:
 
 ```py
-class ComputeFramework:
+class ComputeFramework(ABC):
     def __init__(self) -> None:
         # Connection object for frameworks that need persistent connections
         self.framework_connection_object: Optional[Any] = None

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,12 +11,14 @@ Directories to three levels deep; regenerate with
 ```
 tests/
 ├── conftest.py                     # Common pytest fixtures and configuration
+├── docs_corpus.py                  # Helper: shared markdown file list for the doc guard tests
 ├── registry_isolation.py           # Helper: run a body in an isolated plugin registry
 ├── registry_isolation_probe.py     # Helper: subprocess probe for registry isolation
 ├── test_agent_docs_sync.py         # Agent-facing docs stay in sync with the code
 ├── test_attributions.py            # Third-party attributions are complete
 ├── test_ci_paths_ignore.py         # CI path filters do not skip real changes
 ├── test_docs_fences.py             # Fenced code blocks in docs are well-formed
+├── test_docs_near_miss_labels.py   # Rendered near-miss labels in docs match the code
 ├── test_docs_taught_values.py      # Values taught in docs match the code
 ├── test_gc_freeze_contract.py      # GC freeze contract around plugin loading
 ├── test_mloda_imports.py           # Public import surface of the package

--- a/tests/docs_corpus.py
+++ b/tests/docs_corpus.py
@@ -1,0 +1,16 @@
+"""Shared file list for the docs/docs guard tests."""
+
+from pathlib import Path
+
+# Anchored to this file, not the cwd: a relative glob run from elsewhere yields nothing,
+# so these guards would pass while checking zero files (issue #937).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_ROOT = REPO_ROOT / "docs" / "docs"
+
+
+def doc_files() -> list[Path]:
+    """Every markdown file under DOCS_ROOT; never an empty list, so a bad path fails loudly at import time."""
+    files = sorted(DOCS_ROOT.rglob("*.md"))
+    if not files:
+        raise RuntimeError(f"no markdown files found under {DOCS_ROOT}, doc guard tests would check nothing")
+    return files

--- a/tests/test_docs_fences.py
+++ b/tests/test_docs_fences.py
@@ -12,9 +12,7 @@ from typing import cast
 import pytest
 from mktestdocs import grab_code_blocks
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-
-DOCS_ROOT = REPO_ROOT / "docs" / "docs"
+from tests.docs_corpus import REPO_ROOT, doc_files
 
 RUNNABLE_TAG = "python"
 ILLUSTRATIVE_TAG = "py"
@@ -119,12 +117,6 @@ def _iter_fence_openings(path: Path) -> Iterator[Fence]:
     return iter(openings)
 
 
-def _doc_files() -> list[Path]:
-    files = sorted(DOCS_ROOT.rglob("*.md"))
-    assert files, f"no markdown files under {DOCS_ROOT}, the fence checks would pass vacuously"
-    return files
-
-
 def _suggested_tag(tag: str) -> str:
     if tag.lower() == "pycon":
         return OUTPUT_TAG
@@ -183,7 +175,7 @@ def _violations_in_file(path: Path) -> list[str]:
 
 
 def _fence_violations() -> list[str]:
-    return [message for path in _doc_files() for message in _violations_in_file(path)]
+    return [message for path in doc_files() for message in _violations_in_file(path)]
 
 
 def _stale_allowlist_keys(allowlist: Mapping[str, int]) -> list[str]:
@@ -207,7 +199,7 @@ def test_doc_fences_use_the_documented_vocabulary() -> None:
 
 def test_illustrative_py_blocks_match_allowlist() -> None:
     errors: list[str] = []
-    for path in _doc_files():
+    for path in doc_files():
         actual = sum(1 for fence in _iter_fence_openings(path) if fence.info.strip() == ILLUSTRATIVE_TAG)
         allowed = ILLUSTRATIVE_BLOCK_ALLOWLIST.get(path.relative_to(REPO_ROOT).as_posix(), 0)
         if actual > allowed:
@@ -355,11 +347,11 @@ class TestDocCorpusIsNotCwdDependent:
     def test_doc_files_are_found_from_any_working_directory(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from_repo_root = _doc_files()
+        from_repo_root = doc_files()
         assert from_repo_root, "the doc corpus is empty even from the repo root"
 
         monkeypatch.chdir(tmp_path)
-        from_elsewhere = _doc_files()
+        from_elsewhere = doc_files()
         assert from_elsewhere, (
             "DOCS_ROOT resolves against the process CWD, so from any other directory the fence "
             "vocabulary and allowlist checks pass over an empty corpus"

--- a/tests/test_docs_near_miss_labels.py
+++ b/tests/test_docs_near_miss_labels.py
@@ -24,24 +24,9 @@ from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, render_resolution_failure
 from mloda.core.prepare.resolution_types import Elimination, EliminationStage, EvaluationResult
 
+from tests.docs_corpus import DOCS_ROOT, REPO_ROOT, doc_files
 
-# Anchored to this file, not to the cwd: a relative glob run from anywhere but
-# the repo root yields nothing and these guards pass vacuously (issue #937).
-REPO_ROOT = Path(__file__).resolve().parents[1]
-DOCS_ROOT = REPO_ROOT / "docs" / "docs"
 FENCE_PATTERN = re.compile(r"^\s*```")
-
-
-def _docs_pages() -> list[Path]:
-    """Every published page, never an empty list.
-
-    ``parametrize`` runs at import time, where an empty list collapses to zero
-    cases instead of failing, so an empty glob must raise rather than return.
-    """
-    pages = sorted(DOCS_ROOT.rglob("*.md"))
-    if not pages:
-        raise RuntimeError(f"no documentation pages found under {DOCS_ROOT} - this guard would check nothing")
-    return pages
 
 
 # Derived, never restated: a renamed label moves this set with it, and a label no page quotes costs nothing.
@@ -76,7 +61,7 @@ def _near_miss_bullets(text: str) -> Iterator[tuple[int, re.Match[str]]]:
             yield number, match
 
 
-@pytest.mark.parametrize("fpath", _docs_pages(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+@pytest.mark.parametrize("fpath", doc_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
 def test_rendered_near_miss_bullets_carry_a_current_stage_label(fpath: Path) -> None:
     """Every label a page reproduces in a near-miss bullet is still a value of ``_STAGE_LABELS``."""
     stale = [
@@ -174,7 +159,7 @@ def _unmatched_filter_warnings(text: str) -> Iterator[tuple[int, re.Match[str]]]
             yield number, match
 
 
-@pytest.mark.parametrize("fpath", _docs_pages(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+@pytest.mark.parametrize("fpath", doc_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
 def test_rendered_unmatched_filter_warnings_carry_a_current_stage_label(fpath: Path) -> None:
     """Every label a page reproduces in an unmatched-filter warning is still a value of ``_STAGE_LABELS``."""
     stale = [

--- a/tests/test_docs_taught_values.py
+++ b/tests/test_docs_taught_values.py
@@ -6,7 +6,6 @@ filter matches framework names case-insensitively, and a fenced identifier is ne
 
 import difflib
 import re
-from pathlib import Path
 
 import pytest
 
@@ -18,9 +17,7 @@ from mloda.core.prepare.resolution_failure_renderer import render_resolution_fai
 from mloda.core.prepare.resolution_types import EvaluationResult, RenderFacts
 from mloda.user import PluginLoader
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-
-DOCS_ROOT = REPO_ROOT / "docs" / "docs"
+from tests.docs_corpus import REPO_ROOT, doc_files
 
 # The doc spellings that teach a framework name: quoted keyword, quoted dict key, and quoted list/set bodies.
 SINGULAR_NAME = re.compile(r"""compute_framework\s*=\s*(?P<quote>["'])(?P<name>[^"']+)(?P=quote)""")
@@ -44,12 +41,6 @@ FRAMEWORK_IDENTIFIER_ALLOWLIST = frozenset({"ComputeFramework", "CustomFramework
 
 GET_DOMAIN_MARKER = "def get_domain"
 DOMAIN_RETURN_MARKER = "return Domain("
-
-
-def _doc_files() -> list[Path]:
-    files = sorted(DOCS_ROOT.rglob("*.md"))
-    assert files, f"no markdown files under {DOCS_ROOT}, the taught-value checks would pass vacuously"
-    return files
 
 
 def _line_of(text: str, offset: int) -> int:
@@ -132,7 +123,7 @@ def test_doc_taught_compute_framework_names_are_loaded_class_names() -> None:
     assert loaded, "no ComputeFramework subclass is loaded, the name check would pass vacuously"
 
     violations: list[str] = []
-    for path in _doc_files():
+    for path in doc_files():
         for lineno, name in _taught_framework_names(path.read_text(encoding="utf-8")):
             if name in loaded:
                 continue
@@ -152,7 +143,7 @@ def test_doc_fenced_framework_identifiers_are_loaded_class_names() -> None:
     known = loaded | FRAMEWORK_IDENTIFIER_ALLOWLIST
 
     violations: list[str] = []
-    for path in _doc_files():
+    for path in doc_files():
         for lineno, name in _framework_like_identifiers(path.read_text(encoding="utf-8")):
             if name in known:
                 continue
@@ -173,7 +164,7 @@ def test_the_identifier_allowlist_names_no_loaded_class() -> None:
 def test_doc_get_domain_examples_return_a_domain_instance() -> None:
     """Domain.__eq__ returns NotImplemented for non-Domain, so a bare-string return matches nothing."""
     violations: list[str] = []
-    for path in _doc_files():
+    for path in doc_files():
         for body in _bad_get_domain_bodies(path.read_text(encoding="utf-8")):
             violations.append(f"{path}: get_domain body without a Domain return: {_excerpt(body)}")
 


### PR DESCRIPTION
## Summary

Two small, independent docs/test cleanups bundled together:

- `docs/docs/in_depth/feature-chain-parser.md`'s `TimeWindowFeatureGroup` override snippet was missing `TimeReferenceMixin`, a base the real shipped class carries and that the snippet's own body actually calls (`get_reference_time_column` is only defined on that mixin). The other three snippets in the same section already matched their real declarations. Also renamed two `compute-framework-integration.md` examples that reused real class names (`ClusteringFeatureGroup`, `AggregatedFeatureGroup`) in pure pseudocode with an incomplete base list, so they read as illustrative rather than as a real declaration, matching that file's own `Analytical`/`Distributed` examples. Same fix in `framework-connection-object.md`, where a `ComputeFramework` snippet had dropped its real `ABC` base.
- `tests/test_docs_fences.py`, `tests/test_docs_taught_values.py` and `tests/test_docs_near_miss_labels.py` each defined their own `REPO_ROOT`, `DOCS_ROOT` and anti-vacuous markdown file list. Extracted the shared part into `tests/docs_corpus.py`. Fence-block extraction stays per-file since each guard's scanner does a genuinely different job.

## Test plan

- [x] `tox` (full suite, ruff format/check, mypy --strict, bandit) passes
- [x] `tests/test_docs_fences.py`, `tests/test_docs_taught_values.py`, `tests/test_docs_near_miss_labels.py`, `tests/test_documentation/` all pass (239 tests)
