### PR TITLE
fix: tolerate mixed-type dict keys in Feature._reduce sort

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -423,9 +423,18 @@ class Feature:
                 return _CYCLE
             seen = seen | {id(value)}
         if isinstance(value, dict):
-            return tuple(
-                sorted(((key, Feature._reduce(val, seen)) for key, val in value.items()), key=lambda kv: kv[0])
-            )
+            items = [(key, Feature._reduce(val, seen)) for key, val in value.items()]
+            # Mixed-type keys are unorderable by kv[0]; fall back to the same type-robust sort _deep_hashable uses.
+            # Inherited caveat from that fallback: repr() is not an equality-safe canonical form for
+            # identity-based reprs (e.g. a bare Feature key has no __repr__ override, so its repr embeds id()).
+            try:
+                return tuple(sorted(items, key=lambda kv: kv[0]))
+            except TypeError:
+                return tuple(
+                    sorted(
+                        items, key=lambda kv: (kv[0].__class__.__module__, kv[0].__class__.__qualname__, repr(kv[0]))
+                    )
+                )
         if isinstance(value, (frozenset, set)):
             return frozenset(Feature._reduce(item, seen) for item in value)
         if isinstance(value, (list, tuple)):

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -59,6 +59,14 @@ def _node_target(value: Any, dunder: str) -> tuple[type, dict[Any, Any]] | None:
     return None
 
 
+# _deep_hashable's output is hash-only and deliberately untagged: collisions between unrelated
+# types are legal for its equality-checked callers (Options.__hash__, HashableDict.__hash__, each
+# paired with a _deep_equal tiebreak), since tagging would break hash/eq consistency for subclasses
+# with inherited dunders. Feature.similarity_hash/base_similarity_hash (feature.py) are the
+# exception: they feed this hash straight into ExecutionPlan's dict-keyed grouping with no equality
+# tiebreak, so a collision there would silently merge unrelated feature groups.
+# Feature._reduce's output (feature.py) is an equality key instead, so it must stay tagged: its
+# ("feature", ...), ("options", ...), ("hashable_dict", ...) markers are load-bearing, not decoration.
 def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
     if isinstance(value, (dict, list, tuple, set)):
         if id(value) in seen:

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_eq_child_options_cycle.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_eq_child_options_cycle.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -107,3 +109,51 @@ def test_feature_eq_nested_in_features_options_distinguished() -> None:
     assert child_a != child_b
     assert parent_a != parent_b, "same-named in_features children with different options must not collapse"
     assert len({parent_a, parent_b}) == 2
+
+
+def test_child_options_key_with_mixed_type_dict_keys_does_not_raise() -> None:
+    """Feature._reduce's dict sort must tolerate mixed-type keys like _deep_hashable already does."""
+    f = Feature("root")
+    f.child_options = Options(group={"a": 1, 2: "b"})  # type: ignore[dict-item]  # mixed key types are the point
+
+    result = f._child_options_key()
+
+    assert result == f._child_options_key(), "repeated calls must be deterministic"
+
+
+def test_child_options_key_with_nested_mixed_type_dict_keys_does_not_raise() -> None:
+    """The mixed-type-key sort fallback must thread through recursion, not just the top level."""
+    f = Feature("root")
+    f.child_options = Options(group={"outer": {"a": 1, 2: "b"}})
+
+    result = f._child_options_key()
+
+    assert result == f._child_options_key(), "repeated calls must be deterministic"
+
+    f2 = Feature("root")
+    f2.child_options = Options(group={"outer": {2: "b", "a": 1}})
+
+    assert result == f2._child_options_key(), "nested dict order must not affect the canonical key"
+
+
+def test_child_options_key_with_mixed_type_dict_keys_matches_across_separate_dict_objects() -> None:
+    f1 = Feature("root")
+    f1.child_options = Options(group={"a": 1, 2: "b"})  # type: ignore[dict-item]  # mixed key types are the point
+
+    f2 = Feature("root")
+    f2.child_options = Options(group={2: "b", "a": 1})  # type: ignore[dict-item]  # mixed key types are the point
+
+    assert f1._child_options_key() == f2._child_options_key()
+    assert hash(f1) == hash(f2)
+
+
+def test_nested_feature_cycle_through_plain_container_still_recursionerrors() -> None:
+    """Deliberately out-of-scope: a Feature reached only via a plain dict/list is hashed as a leaf with a fresh
+    `seen`, so the cycle guard never fires here; pinned to catch accidental behavior changes during normalizer
+    unification."""
+    inner: dict[str, Feature] = {}
+    o = Options(group={"n": inner})
+    inner["back"] = Feature(name="z", options=o)
+
+    with pytest.raises(RecursionError):
+        hash(o)


### PR DESCRIPTION
## Summary

`Feature._reduce`, the walker behind `Feature.__eq__`/`__hash__` for child options, sorted dict items with a plain key function that raises `TypeError` on mixed-type keys (for example a dict holding both string and integer keys). `_deep_hashable`, the sibling walker behind `Options.__hash__`/`__eq__`, already tolerates this with a type-robust fallback sort. The two walkers had diverged: an option dict that `Options` hashed and compared without complaint could make `Feature._child_options_key()` raise.

This adds the same fallback to `Feature._reduce`'s dict branch: the primary sort is unchanged, and only the `TypeError` path (mixed, mutually unorderable key types) falls back to a sort keyed on `(type module, type qualname, repr)`, matching `_deep_hashable` exactly.

Also written down: a short comment on `_deep_hashable` clarifying which of its callers may collide safely (those backed by an equality tiebreak) versus `Feature.similarity_hash`/`base_similarity_hash`, which consume the hash directly as a grouping key with no such tiebreak. This distinction previously lived only as an unstated assumption.

## Test plan

- New tests cover: mixed-type keys no longer raising, the fallback threading through nested containers, and canonical (insertion-order-independent) output across separately constructed dicts.
- A regression test pins a separate, pre-existing, and unrelated limitation (a `Feature` reached only through a plain container, not through `child_options`, still raises `RecursionError` on a cycle) as a deliberately out-of-scope known behavior, so a future change to it is caught rather than silent.
- Full test suite and lint/type/security gates pass.