### PR TITLE
Unify the python-fence classifier used by the doc runner and the import sweep

### DIFF
--- a/tests/docs_corpus.py
+++ b/tests/docs_corpus.py
@@ -1,11 +1,20 @@
-"""Shared file list for the docs/docs guard tests."""
+"""Shared file list and fence-tag vocabulary for the docs/docs guard tests."""
 
+import re
 from pathlib import Path
 
 # Anchored to this file, not the cwd: a relative glob run from elsewhere yields nothing,
 # so these guards would pass while checking zero files (issue #937).
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_ROOT = REPO_ROOT / "docs" / "docs"
+
+RUNNABLE_TAG = "python"
+ILLUSTRATIVE_TAG = "py"
+OUTPUT_TAG = "text"
+
+PYTHON_LOOKING = re.compile(r"i?py(thon)?[0-9]*(-repl)?|pycon", re.IGNORECASE)
+
+PYTHON_BLOCK_PATTERN = re.compile(rf"```(?:{RUNNABLE_TAG}|{ILLUSTRATIVE_TAG})\n(.*?)```", re.DOTALL)
 
 
 def doc_files() -> list[Path]:
@@ -14,3 +23,10 @@ def doc_files() -> list[Path]:
     if not files:
         raise RuntimeError(f"no markdown files found under {DOCS_ROOT}, doc guard tests would check nothing")
     return files
+
+
+def is_python_fence(info: str) -> bool:
+    """Whether a fence's info string (the text after the opening backticks) tags it as Python."""
+    parts = info.strip().split()
+    tag = parts[0] if parts else ""
+    return bool(PYTHON_LOOKING.fullmatch(tag))

--- a/tests/test_ci_paths_ignore.py
+++ b/tests/test_ci_paths_ignore.py
@@ -63,7 +63,8 @@ def _matches(pattern: str, path: str) -> bool:
 
 
 def _markdown_referenced_by_tests() -> set[str]:
-    """Markdown files that the test suite reads or asserts on, so CI must run when they change."""
+    """Markdown files the test suite references, found via literal "foo.md" strings; a glob- or
+    variable-built path is invisible to this scan."""
     referenced: set[str] = set()
     for source in (PROJECT_ROOT / "tests").rglob("*.py"):
         for line in source.read_text(encoding="utf-8").splitlines():

--- a/tests/test_core/test_prepare/test_resolution_module_split.py
+++ b/tests/test_core/test_prepare/test_resolution_module_split.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import ast
 import importlib
-import re
 import subprocess  # nosec B404
 import sys
 import textwrap
@@ -20,6 +19,7 @@ from types import ModuleType
 import pytest
 
 from mloda.core.prepare import identify_feature_group
+from tests.docs_corpus import is_python_fence
 
 MATCHER_MODULE = "mloda.core.prepare.identify_feature_group"
 TYPES_MODULE = "mloda.core.prepare.resolution_types"
@@ -72,10 +72,6 @@ MATCHER_BASENAME = MATCHER_MODULE.rsplit(".", 1)[-1]
 
 # Package of the matcher as directory names, for the synthetic trees the sweep tests below build under tmp_path.
 MATCHER_PACKAGE_PARTS = tuple(MATCHER_MODULE.split(".")[:-1])
-
-# Opening fence of a markdown python block in every spelling mkdocs renders as python: a space after the
-# backticks, the py and python3 aliases, and any info string behind the language, such as title="x".
-_PYTHON_FENCE = re.compile(r"```\s*(python3?|py)(\s|$)")
 
 _SUBPROCESS_TIMEOUT = 8.0
 
@@ -154,7 +150,8 @@ def _python_blocks(source: str) -> list[tuple[int, str]]:
             continue
         backticks = len(stripped) - len(stripped.lstrip("`"))
         if opened is None:
-            opened, width, is_python = lineno, backticks, _PYTHON_FENCE.match(stripped) is not None
+            # mktestdocs only ever executes an exactly-3-backtick fence: a wider opener is never Python.
+            opened, width, is_python = lineno, backticks, backticks == 3 and is_python_fence(stripped[backticks:])
             continue
         if backticks < width:  # a shorter fence is content of the open block, as in a ``` shown inside a ````
             continue
@@ -358,6 +355,25 @@ def test_a_near_miss_language_fence_is_not_scanned(tmp_path: Path, language: str
     assert offenders == [], f"```{language} is not python, yet it was scanned: {offenders}"
 
 
+@pytest.mark.parametrize("language", ["pycon", "ipython", "python-repl"])
+def test_a_python_highlighting_alias_fence_is_scanned(tmp_path: Path, language: str) -> None:
+    """mkdocs highlights ```pycon, ```ipython and ```python-repl as Python; mktestdocs runs none of them."""
+    path = tmp_path / "docs" / "guide.md"
+    source = _markdown_with_block(language, f"from {MATCHER_MODULE} import render_resolution_failure")
+    offenders = _foreign_matcher_imports_in_markdown(path, source, tmp_path)
+    assert offenders == [f"{path}:4 -> render_resolution_failure"], f"```{language} went unscanned: {offenders}"
+
+
+def test_the_fence_classifier_is_the_shared_docs_corpus_helper() -> None:
+    """This module's is_python_fence must be the literal tests.docs_corpus.is_python_fence object, not a copy,
+    so the two fence-classification sweeps cannot drift apart."""
+    import tests.docs_corpus as docs_corpus
+
+    assert is_python_fence is docs_corpus.is_python_fence, (
+        f"{__name__}.is_python_fence must be the literal tests.docs_corpus.is_python_fence object"
+    )
+
+
 def test_an_indented_block_that_does_not_name_the_matcher_is_not_parsed(tmp_path: Path) -> None:
     """A fence indented into a numbered list is not parseable on its own, and it names no import of ours.
 
@@ -454,6 +470,23 @@ def test_prose_in_a_four_backtick_block_is_not_parsed_as_python(tmp_path: Path) 
         ]
     )
     assert _foreign_matcher_imports_in_markdown(path, source, tmp_path) == []
+
+
+def test_a_four_backtick_python_tagged_fence_is_not_scanned(tmp_path: Path) -> None:
+    """mktestdocs slices exactly three backticks, so a ````python fence is never executed either."""
+    path = tmp_path / "docs" / "guide.md"
+    source = "\n".join(
+        [
+            "# Guide",
+            "",
+            "````python",
+            f"from {MATCHER_MODULE} import render_resolution_failure",
+            "````",
+            "",
+        ]
+    )
+    offenders = _foreign_matcher_imports_in_markdown(path, source, tmp_path)
+    assert offenders == [], f"a four-backtick fence is never executed by mktestdocs, yet it was scanned: {offenders}"
 
 
 def test_an_unterminated_python_fence_at_end_of_file_is_scanned(tmp_path: Path) -> None:

--- a/tests/test_docs_corpus.py
+++ b/tests/test_docs_corpus.py
@@ -1,0 +1,46 @@
+"""Pins the fence-tag vocabulary and is_python_fence classifier that tests/docs_corpus.py must expose."""
+
+import pytest
+
+from tests.docs_corpus import ILLUSTRATIVE_TAG, OUTPUT_TAG, RUNNABLE_TAG, is_python_fence
+
+PYTHON_LOOKING_INFO_STRINGS = (
+    "python",
+    " python",
+    "py",
+    "python3",
+    "ipython",
+    "pycon",
+    "python-repl",
+    'python title="x"',
+    ' python title="x"',
+    "Python",
+    "PYTHON",
+)
+
+NON_PYTHON_INFO_STRINGS = (
+    "json",
+    "text",
+    "pythonic",
+    "pytest",
+    "",
+    "bash",
+    "   ",
+    "\t",
+)
+
+
+def test_fence_tag_constants() -> None:
+    assert RUNNABLE_TAG == "python"
+    assert ILLUSTRATIVE_TAG == "py"
+    assert OUTPUT_TAG == "text"
+
+
+@pytest.mark.parametrize("info", PYTHON_LOOKING_INFO_STRINGS)
+def test_is_python_fence_matches_python_looking_info(info: str) -> None:
+    assert is_python_fence(info), f"{info!r} should be recognised as a python fence"
+
+
+@pytest.mark.parametrize("info", NON_PYTHON_INFO_STRINGS)
+def test_is_python_fence_rejects_non_python_info(info: str) -> None:
+    assert not is_python_fence(info), f"{info!r} should not be recognised as a python fence"

--- a/tests/test_docs_fences.py
+++ b/tests/test_docs_fences.py
@@ -12,13 +12,7 @@ from typing import cast
 import pytest
 from mktestdocs import grab_code_blocks
 
-from tests.docs_corpus import REPO_ROOT, doc_files
-
-RUNNABLE_TAG = "python"
-ILLUSTRATIVE_TAG = "py"
-OUTPUT_TAG = "text"
-
-PYTHON_LOOKING = re.compile(r"i?py(thon)?[0-9]*(-repl)?|pycon", re.IGNORECASE)
+from tests.docs_corpus import ILLUSTRATIVE_TAG, OUTPUT_TAG, REPO_ROOT, RUNNABLE_TAG, doc_files, is_python_fence
 
 VOCABULARY_HINT = (
     f"Use ```{RUNNABLE_TAG} when the block runs, ```{ILLUSTRATIVE_TAG} when it is an "
@@ -129,7 +123,7 @@ def _violations_in_file(path: Path) -> list[str]:
     openings, unterminated = _scan_fences(path)
     for fence in openings:
         tag = fence.tag
-        python_looking = bool(PYTHON_LOOKING.fullmatch(tag))
+        python_looking = is_python_fence(fence.info)
         if fence.has_leading_space:
             unspaced = f"```{fence.info.strip()}"
             messages.append(f"{fence.location}: spaced fence {fence.text!r} -> write {unspaced!r}. {VOCABULARY_HINT}")

--- a/tests/test_docs_taught_values.py
+++ b/tests/test_docs_taught_values.py
@@ -17,7 +17,7 @@ from mloda.core.prepare.resolution_failure_renderer import render_resolution_fai
 from mloda.core.prepare.resolution_types import EvaluationResult, RenderFacts
 from mloda.user import PluginLoader
 
-from tests.docs_corpus import REPO_ROOT, doc_files
+from tests.docs_corpus import PYTHON_BLOCK_PATTERN, REPO_ROOT, doc_files
 
 # The doc spellings that teach a framework name: quoted keyword, quoted dict key, and quoted list/set bodies.
 SINGULAR_NAME = re.compile(r"""compute_framework\s*=\s*(?P<quote>["'])(?P<name>[^"']+)(?P=quote)""")
@@ -28,9 +28,8 @@ PLURAL_LIST = re.compile(r"compute_frameworks\s*=\s*\[(?P<body>[^\]]*)\]", re.DO
 PLURAL_SET = re.compile(r"compute_frameworks\s*=\s*\{(?P<body>[^}]*)\}", re.DOTALL)
 QUOTED_NAME = re.compile(r"""(?P<quote>["'])(?P<name>[^"']+)(?P=quote)""")
 
-# These fence-block regexes rely on tests/test_docs_fences.py banning the fence spellings (tilde,
-# four-backtick, spaced, attributed) they would mishandle.
-PYTHON_BLOCK = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
+# This fence-block regex relies on tests/test_docs_fences.py banning the fence spellings (tilde,
+# four-backtick, spaced, attributed) it would mishandle.
 # Any fenced block, whatever its info string: quoted error output teaches framework class names too.
 FENCED_BLOCK = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
 FRAMEWORK_LIKE_IDENTIFIER = re.compile(r"\b[A-Z]\w*(?:DataFrame|Table|Framework)\b")
@@ -73,7 +72,7 @@ def _framework_like_identifiers(text: str) -> list[tuple[int, str]]:
 
 def _get_domain_blocks(text: str) -> list[str]:
     """Return every python/py fenced block that defines get_domain."""
-    return [block for block in PYTHON_BLOCK.findall(text) if GET_DOMAIN_MARKER in block]
+    return [block for block in PYTHON_BLOCK_PATTERN.findall(text) if GET_DOMAIN_MARKER in block]
 
 
 def _get_domain_bodies(block: str) -> list[str]:

--- a/tests/test_documentation/test_doc_fence_vocabulary.py
+++ b/tests/test_documentation/test_doc_fence_vocabulary.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from mktestdocs import grab_code_blocks
 
-from tests.test_docs_fences import ILLUSTRATIVE_TAG, RUNNABLE_TAG
+from tests.docs_corpus import ILLUSTRATIVE_TAG, RUNNABLE_TAG
 from tests.test_documentation.test_documentation import run_md_file_isolated
 
 FAILING_SNIPPET = 'raise RuntimeError("doc fence collection contract")'

--- a/tests/test_documentation/test_documentation.py
+++ b/tests/test_documentation/test_documentation.py
@@ -10,6 +10,7 @@ import pytest
 from typing import Any
 import time
 from mloda.steward import ExtenderHook, Extender
+from tests.docs_corpus import PYTHON_BLOCK_PATTERN, RUNNABLE_TAG
 import logging
 
 logger = logging.getLogger(__name__)
@@ -83,7 +84,7 @@ def run_md_files_isolated(fpaths: Sequence[Path]) -> None:
     the plugin-load cost once; docs sharing one interpreter matches the
     pre-isolation semantics. The last CHECKING line attributes a failure.
     """
-    kept_paths = [fpath for fpath in fpaths if "```python" in fpath.read_text(encoding="utf-8")]
+    kept_paths = [fpath for fpath in fpaths if f"```{RUNNABLE_TAG}" in fpath.read_text(encoding="utf-8")]
     if not kept_paths:
         return
     # Safe: fixed argv (sys.executable, constant driver, file paths), no shell, no user input.
@@ -109,7 +110,6 @@ def test_files_good() -> None:
     run_md_files_isolated(_markdown_files(DOCS_DIR))
 
 
-CODE_BLOCK_PATTERN = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
 TEST_IMPORT_PATTERN = re.compile(r"^\s*from\s+tests\..*$", re.MULTILINE)
 
 
@@ -117,7 +117,7 @@ TEST_IMPORT_PATTERN = re.compile(r"^\s*from\s+tests\..*$", re.MULTILINE)
 def test_no_test_imports_in_docs(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     violations = []
-    for block in CODE_BLOCK_PATTERN.finditer(text):
+    for block in PYTHON_BLOCK_PATTERN.finditer(text):
         for match in TEST_IMPORT_PATTERN.finditer(block.group(1)):
             violations.append(match.group().strip())
     assert not violations, f"{fpath} imports from test modules (not available to users): {violations}"
@@ -130,11 +130,11 @@ def test_test_imports_in_illustrative_blocks_are_scanned() -> None:
     """A ```py block is read by users too, so its test imports must be caught."""
     found = [
         match.group().strip()
-        for block in CODE_BLOCK_PATTERN.finditer(ILLUSTRATIVE_BLOCK_WITH_TEST_IMPORT)
+        for block in PYTHON_BLOCK_PATTERN.finditer(ILLUSTRATIVE_BLOCK_WITH_TEST_IMPORT)
         for match in TEST_IMPORT_PATTERN.finditer(block.group(1))
     ]
     assert found == ["from tests.foo import bar"], (
-        f"CODE_BLOCK_PATTERN matches only ```python, so blocks retagged to ```py go unscanned, got {found}"
+        f"PYTHON_BLOCK_PATTERN matches only ```python, so blocks retagged to ```py go unscanned, got {found}"
     )
 
 


### PR DESCRIPTION
## Summary

The markdown fence vocabulary this repo uses (```python for executed snippets, ```py for illustrative python-highlighted-but-unexecuted fragments) was classified three different, independent ways across the test suite: a doc-execution runner, a fence vocabulary guard, and a matcher-import staleness sweep each carried their own regex or hardcoded literals for "is this fence tag python".

This moves the shared vocabulary and classifier into `tests/docs_corpus.py`, the one module all three already partially depended on for file discovery, and repoints each consumer to import from there instead of reimplementing it. As a side effect, the import sweep now also recognizes the `ipython`/`pycon`/`python-repl` fence aliases mkdocs renders as Python, which its narrower local regex previously missed.

Also fixes an overlong-fence edge case introduced during this consolidation (a four-or-more-backtick fence tagged `python` must never classify as executable Python, matching what the doc runner itself actually executes), and adds a short note next to the CI paths-ignore markdown-dependency scanner documenting that it only sees literal `.md` string references, not ones built from a glob or a variable.

## Test plan

- [x] `tox` (pytest -n 8, ruff format/check, mypy --strict, bandit, pip-licenses) passes clean
- [x] New tests pin the shared classifier's contract and the widened alias coverage