### PR TITLE
fix: canonicalize the mixed-type-key sort fallback in hashable_dict and Feature._reduce

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -10,7 +10,13 @@ if TYPE_CHECKING:
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, HashableDict, _deep_equal, _deep_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import (
+    _CYCLE,
+    HashableDict,
+    _deep_equal,
+    _deep_hashable,
+    _reduce_dict_items,
+)
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -424,17 +430,8 @@ class Feature:
             seen = seen | {id(value)}
         if isinstance(value, dict):
             items = [(key, Feature._reduce(val, seen)) for key, val in value.items()]
-            # Mixed-type keys are unorderable by kv[0]; fall back to the same type-robust sort _deep_hashable uses.
-            # Inherited caveat from that fallback: repr() is not an equality-safe canonical form for
-            # identity-based reprs (e.g. a bare Feature key has no __repr__ override, so its repr embeds id()).
-            try:
-                return tuple(sorted(items, key=lambda kv: kv[0]))
-            except TypeError:
-                return tuple(
-                    sorted(
-                        items, key=lambda kv: (kv[0].__class__.__module__, kv[0].__class__.__qualname__, repr(kv[0]))
-                    )
-                )
+            # Same canonical reduction as _deep_hashable uses.
+            return _reduce_dict_items(items)
         if isinstance(value, (frozenset, set)):
             return frozenset(Feature._reduce(item, seen) for item in value)
         if isinstance(value, (list, tuple)):

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Callable
 from typing import Any
 
@@ -59,6 +60,41 @@ def _node_target(value: Any, dunder: str) -> tuple[type, dict[Any, Any]] | None:
     return None
 
 
+def _bypasses_native_order(key: Any) -> bool:
+    """frozenset's `<` is a partial order and NaN's `<` is always False; neither raises, so native
+    sort silently returns a non-canonical, insertion-order-dependent result for them. Detected by
+    isinstance/math.isnan only, never by comparing the key itself, which could re-enter an unsafe
+    __eq__/__hash__ (see _reduce_dict_items)."""
+    return isinstance(key, frozenset) or (isinstance(key, float) and math.isnan(key))
+
+
+def _canonical_dict_items(items: list[tuple[Any, Any]]) -> tuple[Any, ...]:
+    """Equality-consistent reduction for dict items: buckets by hash(key), since equal keys always
+    share a hash (a == b implies hash(a) == hash(b)), so cross-type-equal keys (1 and True) always
+    land together regardless of which side used which type. A bucket holding more than one item is
+    a genuine hash collision between UNEQUAL keys (e.g. CPython's hash(-1) == hash(-2) == -2); those
+    items fold into a frozenset instead of a type-keyed tiebreak, so the result never depends on
+    which concrete type represented a key elsewhere in the dict."""
+    buckets: dict[int, list[tuple[Any, Any]]] = {}
+    for item in items:
+        buckets.setdefault(hash(item[0]), []).append(item)
+    return tuple(bucket[0] if len(bucket) == 1 else frozenset(bucket) for _, bucket in sorted(buckets.items()))
+
+
+def _reduce_dict_items(items: list[tuple[Any, Any]]) -> tuple[Any, ...]:
+    """Natural key order when every key is safely orderable and none needs canonical bucketing;
+    the hash-bucket form (see _canonical_dict_items) otherwise. Trying native order first (instead
+    of always hashing) keeps hash() off keys whose own __hash__ isn't cycle-safe when re-entered
+    outside this module's recursion guard (e.g. a Feature used as a raw dict key), matching the
+    pre-existing behavior for the common, natively-orderable case."""
+    if not any(_bypasses_native_order(k) for k, _ in items):
+        try:
+            return tuple(sorted(items, key=lambda kv: kv[0]))
+        except TypeError:
+            pass
+    return _canonical_dict_items(items)
+
+
 # _deep_hashable's output is hash-only and deliberately untagged: collisions between unrelated
 # types are legal for its equality-checked callers (Options.__hash__, HashableDict.__hash__, each
 # paired with a _deep_equal tiebreak), since tagging would break hash/eq consistency for subclasses
@@ -74,14 +110,7 @@ def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
         seen = seen | {id(value)}
     if isinstance(value, dict):
         items = [(k, _deep_hashable(v, seen)) for k, v in value.items()]
-        # Mixed-type keys (e.g. reader class plus str) are unorderable; fall back to a
-        # type-robust deterministic sort. The common orderable case stays unchanged.
-        try:
-            return tuple(sorted(items))
-        except TypeError:
-            return tuple(
-                sorted(items, key=lambda kv: (kv[0].__class__.__module__, kv[0].__class__.__qualname__, repr(kv[0])))
-            )
+        return _reduce_dict_items(items)
     if isinstance(value, (list, tuple)):
         return tuple(_deep_hashable(item, seen) for item in value)
     if isinstance(value, set):

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_eq_child_options_cycle.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_eq_child_options_cycle.py
@@ -147,6 +147,27 @@ def test_child_options_key_with_mixed_type_dict_keys_matches_across_separate_dic
     assert hash(f1) == hash(f2)
 
 
+def test_child_options_key_with_int_bool_equal_keys_matches_across_separate_dict_objects() -> None:
+    """1 and True are == and hash-equal; Feature._reduce's fallback sort must not split them apart."""
+    f1 = Feature("root")
+    f1.child_options = Options(group={1: "a", 2.5: "b", "s": "c"})  # type: ignore[dict-item]
+
+    f2 = Feature("root")
+    f2.child_options = Options(group={True: "a", 2.5: "b", "s": "c"})  # type: ignore[dict-item]
+
+    assert f1._child_options_key() == f2._child_options_key()
+    assert hash(f1) == hash(f2)
+
+
+def test_feature_options_field_with_int_bool_equal_keys_hashes_consistently_with_equality() -> None:
+    """Same bug reached through Feature.options (hashable_dict.py's fallback), not just child_options."""
+    left = Feature("root", options={1: "a", 2.5: "b", "s": "c"})  # type: ignore[dict-item]
+    right = Feature("root", options={True: "a", 2.5: "b", "s": "c"})  # type: ignore[dict-item]
+
+    assert left == right
+    assert hash(left) == hash(right)
+
+
 def test_nested_feature_cycle_through_plain_container_still_recursionerrors() -> None:
     """Deliberately out-of-scope: a Feature reached only via a plain dict/list is hashed as a leaf with a fresh
     `seen`, so the cycle guard never fires here; pinned to catch accidental behavior changes during normalizer
@@ -157,3 +178,15 @@ def test_nested_feature_cycle_through_plain_container_still_recursionerrors() ->
 
     with pytest.raises(RecursionError):
         hash(o)
+
+
+def test_feature_eq_with_self_as_raw_child_options_key_does_not_raise() -> None:
+    """A bare Feature used directly as a raw dict key must still compare via pure `==`, with no `hash(key)`
+    call: a single-item dict never needs a comparison to sort, so `_reduce_dict_items` takes the native-order
+    path and never touches the key's `__hash__`, which is not cycle-safe when re-entered outside `_reduce`'s
+    own `seen` tracking. Unlike the sibling plain-container case above (Feature reached only through a
+    container, the guard never applies there, RecursionError is accepted), this one must NOT raise."""
+    f = Feature("root")
+    f.child_options = Options(group={f: "v"})  # type: ignore[dict-item]  # a bare Feature used as a raw dict key
+
+    assert f == f

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -243,6 +243,20 @@ class TestPublicEntryPoints:
         assert left == right
         assert hash(left) == hash(right)
 
+    def test_options_with_int_and_bool_equal_keys_hashes_consistently_with_equality(self) -> None:
+        """Options.__hash__ routes through _deep_hashable's fallback; equal Options must hash equal."""
+        left = Options(group={1: "a", 2.5: "b", "s": "c"})  # type: ignore[dict-item]
+        right = Options(group={True: "a", 2.5: "b", "s": "c"})  # type: ignore[dict-item]
+        assert left == right
+        assert hash(left) == hash(right)
+
+    def test_options_with_int_hash_collision_between_unequal_keys_hashes_consistently_with_equality(self) -> None:
+        """Same CPython hash(-1) == hash(-2) collision as the _deep_hashable-level test, reached via Options."""
+        left = Options(group={-2: "a", -1: "b"})  # type: ignore[dict-item]
+        right = Options(group={-2.0: "a", -1: "b"})  # type: ignore[dict-item]
+        assert left == right
+        assert hash(left) == hash(right)
+
 
 class TestDeepHashableCycleGuard:
     """A self-referential container collapses to a back-reference marker instead of recursing forever."""
@@ -295,6 +309,50 @@ class TestDeepHashableCycleGuard:
         feature = Feature(name="f")
         feature.child_options = Options(group={"a": cyclic})
         assert isinstance(hash(feature), int)
+
+
+class TestDeepHashableFallbackSortIsCanonical:
+    """The type-robust fallback sort key for mixed, unorderable dict keys must itself be canonical."""
+
+    def test_int_and_bool_equal_keys_diverge_under_the_type_keyed_fallback(self) -> None:
+        """1 and True are == and hash-equal; a mid-alphabet-qualname third key exposes the reorder."""
+        dict_with_int_key = {1: "a", 2.5: "b", "s": "c"}
+        dict_with_bool_key = {True: "a", 2.5: "b", "s": "c"}
+        assert dict_with_int_key == dict_with_bool_key
+
+        assert _deep_hashable(dict_with_int_key) == _deep_hashable(dict_with_bool_key)
+
+    def test_frozenset_keys_canonicalize_regardless_of_dict_insertion_order(self) -> None:
+        """frozenset's `<` returns False instead of raising, so the exception-triggered fallback never engages."""
+        dict_built_one_way = {frozenset({1, 2}): "x", frozenset({3, 4}): "y"}
+        dict_built_the_other_way = {frozenset({3, 4}): "y", frozenset({1, 2}): "x"}
+        assert dict_built_one_way == dict_built_the_other_way
+
+        assert _deep_hashable(dict_built_one_way) == _deep_hashable(dict_built_the_other_way)
+
+    def test_differently_constructed_equal_frozenset_keys_normalize_identically(self) -> None:
+        """A companion unorderable-type key forces the fallback; equal frozensets built two ways must still match."""
+        dict_with_set_literal_key = {frozenset({1, 2, 3}): "v", "other": "w"}
+        dict_with_list_built_key = {frozenset([3, 2, 1]): "v", "other": "w"}
+        assert dict_with_set_literal_key == dict_with_list_built_key
+
+        assert _deep_hashable(dict_with_set_literal_key) == _deep_hashable(dict_with_list_built_key)
+
+    def test_nan_key_does_not_raise_and_is_deterministic_on_the_same_dict(self) -> None:
+        """Accepted limitation: two distinct nan objects need not normalize alike, only self-consistency is required."""
+        data = {float("nan"): "x", "other": "y"}
+
+        assert _deep_hashable(data) == _deep_hashable(data)
+        assert hash(HashableDict(data)) == hash(HashableDict(data))
+
+    def test_int_hash_collision_between_unequal_keys_still_canonicalizes(self) -> None:
+        """CPython remaps hash(-1) to -2, so -1 and -2 collide; the qualname/repr tiebreak must not leak
+        through when a same-hash-bucket key's type also differs between two equal dicts (#1191 finding 1)."""
+        dict_with_int_key = {-2: "a", -1: "b"}
+        dict_with_float_key = {-2.0: "a", -1: "b"}
+        assert dict_with_int_key == dict_with_float_key
+
+        assert _deep_hashable(dict_with_int_key) == _deep_hashable(dict_with_float_key)
 
 
 class TestCrossModuleImportsFollowTheRename:


### PR DESCRIPTION
## Summary

The dict-item sort used to normalize mixed, mutually-unorderable dict keys for hashing and equality (shared by `_deep_hashable` and `Feature._reduce`) ordered items by concrete type identity (module, qualname) when native comparison raised `TypeError`. That made the normalized form depend on which concrete type represented a key rather than the key's value:

- Cross-type-but-equal keys (`1` and `True`) could normalize to different orderings, even though they compare equal and hash equal, so value-equal `Options`/`Feature` instances could compare or hash unequal depending on which type was used.
- Key types whose `<` doesn't raise but also isn't a true total order (`frozenset`, NaN floats) never triggered the fallback at all, so the "primary" native sort silently returned an insertion-order-dependent result.

## Fix

Try the natural key order first, exactly matching the previous behavior for the common, natively-orderable case. Only escalate to a canonical reduction when native order can't be trusted: either it raises (genuinely incomparable types), or the key is one of the two documented non-raising offenders (`frozenset`, NaN).

The canonical reduction buckets items by `hash(key)`: equal keys always share a hash, so cross-type-equal keys always land in the same bucket regardless of which concrete type represents them. A bucket holding more than one item is a genuine collision between unequal keys (for example CPython's `hash(-1) == hash(-2)`); those items fold into a `frozenset` instead of an order based on concrete type, so the result never depends on which type happened to represent an equal key elsewhere in the dict.

Both call sites now share one helper, so they can't drift apart again.

## Tests

Added coverage for: cross-type-equal keys normalizing identically through both `_deep_hashable` and `Feature._reduce`, a hash-collision-between-unequal-keys case, frozenset keys canonicalizing regardless of construction order, NaN keys hashing deterministically without crashing, and equality on a self-referential key not raising.