### PR TITLE
minor: unify PROPERTY_MAPPING across feature groups and readers

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -140,7 +140,7 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `PREFIX_PATTERN` | `str` | Required | Regex pattern for matching feature names |
-| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | omit to leave the configuration path off; `{}` is an explicit universal matcher | Parameter validation configuration |
+| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | omit for no configuration path; `{}` is an explicit universal matcher | Parameter validation configuration |
 | `MIN_IN_FEATURES` | `int` | `1` | Minimum required in_features |
 | `MAX_IN_FEATURES` | `int \| None` | `None` | Maximum allowed in_features (None = unlimited) |
 | `IN_FEATURE_SEPARATOR` | `str` | `"&"` | Separator for multiple in_features |

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -140,7 +140,7 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `PREFIX_PATTERN` | `str` | Required | Regex pattern for matching feature names |
-| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | Required | Parameter validation configuration |
+| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | `{}` (merged across the class hierarchy) | Parameter validation configuration |
 | `MIN_IN_FEATURES` | `int` | `1` | Minimum required in_features |
 | `MAX_IN_FEATURES` | `int \| None` | `None` | Maximum allowed in_features (None = unlimited) |
 | `IN_FEATURE_SEPARATOR` | `str` | `"&"` | Separator for multiple in_features |

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -140,7 +140,7 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `PREFIX_PATTERN` | `str` | Required | Regex pattern for matching feature names |
-| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | `{}` (merged across the class hierarchy) | Parameter validation configuration |
+| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | omit to leave the configuration path off; `{}` is an explicit universal matcher | Parameter validation configuration |
 | `MIN_IN_FEATURES` | `int` | `1` | Minimum required in_features |
 | `MAX_IN_FEATURES` | `int \| None` | `None` | Maximum allowed in_features (None = unlimited) |
 | `IN_FEATURE_SEPARATOR` | `str` | `"&"` | Separator for multiple in_features |

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -40,8 +40,8 @@ PROPERTY_MAPPING = {
 | `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
 | `allow_explicit_none` | `bool` | `False` | Opt-in so an explicit `None` is honored (not treated as absent) and flows through validation. |
 | `deferred_binding` | `bool` | `False` | Exempts a required key from the string-named path presence check only; its value is bound outside match-time name capture. Not optionality: the key stays required on the config path. See [Required presence on the string-named path](#required-presence-on-the-string-named-path). |
-| `framework_set` | `bool` | `False` | Reader-only: marks the one framework-written key, which is exempt from enforcement. Rejected on a feature group. |
-| `scalar_only` | `bool` | `False` | Reader-only: reject a list/tuple/set/frozenset value outright instead of unpacking it element-wise. Requires `strict_validation=True`. Rejected on a feature group. |
+| `framework_set` | `bool` | `False` | Reader-only: marks the framework-written key, exempt from enforcement. Rejected on a feature group. |
+| `scalar_only` | `bool` | `False` | Reader-only: rejects a list/tuple/set/frozenset value outright instead of unpacking it. Requires `strict_validation=True`. Rejected on a feature group. |
 
 **`property_spec(...)` is the authoring path to reach for.** It is a thin builder over the
 same fields, its keyword is `strict=` (which sets `strict_validation`), and it keeps the
@@ -68,12 +68,11 @@ The type IS the schema. A raw dict spec is rejected at class definition
 constructor `TypeError` that mypy already flags where the spec is written. Nothing a spec
 does not understand can be absorbed silently.
 
-**Declarations merge across the class hierarchy.** On both surfaces a subclass adds or overrides
-keys and redeclares nothing: the most-derived declaration of a key wins. `declared_option_specs()`
-(feature group) and `reader_option_specs()` (reader) return the merged view; the attribute itself
-stays the class's own declaration. The merged view is computed at class definition and cached, so a
-later write to the attribute is not seen. `PROPERTY_MAPPING = None` is rejected at class definition,
-because `None` cannot clear inherited keys.
+**Declarations merge across the class hierarchy.** A subclass adds or overrides keys; the
+most-derived declaration wins. `declared_option_specs()` (feature group) and `reader_option_specs()`
+(reader) return the merged, cached-at-definition view; the attribute itself stays the class's own
+declaration. `PROPERTY_MAPPING = None` is rejected at class definition: `None` cannot clear
+inherited keys.
 
 ## The lifecycle: which invariant fires when
 
@@ -81,7 +80,7 @@ because `None` cannot clear inherited keys.
 | --- | --- | --- | --- | --- |
 | Author time | `mypy --strict` | The field exists and its declared type fits: `strict_validaton=True` (typo), `strict_validation=1`, `allowed_values=5` | The constructor call | mypy error at the spec literal. Without mypy: an unknown field is a `TypeError`; a wrong type falls through to the row below |
 | Construction (`PropertySpec(...)`) | `__post_init__` | `allowed_values` is not a str/bytes and is a Mapping or an iterable; `strict_validation` is a real bool; the validators are callable; `element_validator` implies strict; strict has a non-empty value space or an `element_validator`; a strict, non-`None` `default` is accepted by the key's own rules | The spec being built | `ValueError` at import, prefixed `PropertySpec('<explanation>')` |
-| Class definition (`__init_subclass__` of `FeatureGroup` or `BaseInputData`) | Spec type + surface rules | Every value in the class's own declaration, and in any plain mixin reaching it through the merge, IS a `PropertySpec` and declares nothing inert on that surface (feature group: `framework_set`, `scalar_only`; reader: `match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key); the reserved reader key's **winning** declaration keeps `framework_set=True`; the declaration is a dict (`None` rejected) | Every value in that class's declaration, plus mixin declarations, plus the reserved key as the merge resolves it | `ValueError` naming class, key and field (and the reaching class for a mixin) |
+| Class definition (`__init_subclass__` of `FeatureGroup` or `BaseInputData`) | Spec type + surface rules | Every value, own or reached through a mixin, IS a `PropertySpec` and declares nothing inert on that surface (feature group: `framework_set`, `scalar_only`; reader: `match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key); the reserved reader key's **winning** declaration keeps `framework_set=True`; the declaration is a dict (`None` rejected) | Every value in that class's declaration, plus mixin declarations, plus the reserved key as the merge resolves it | `ValueError` naming class, key and field (and the reaching class for a mixin) |
 | Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | Required presence (config path) | A key that declares no `default` and no `required_when` was provided | The options | Non-match (`False`) |
@@ -128,8 +127,8 @@ See [One spec type, two surfaces](#one-spec-type-two-surfaces).
 ## One spec type, two surfaces
 
 One attribute (`PROPERTY_MAPPING`), one spec type (`PropertySpec`), one declaration mechanism (an
-MRO merge with a per-class cache, and one validator parameterized by surface), and two owners that
-consume the values at different moments.
+MRO merge with a per-class cache, one validator per surface), and two owners consuming the values
+at different moments.
 
 | Surface | Declared on | What the framework does with it |
 | --- | --- | --- |
@@ -150,27 +149,25 @@ consequences keep the shared type honest on this surface:
 - **The shared validator rejects, per surface, the fields that are inert there.** `match_guard`,
   `deferred_binding=True` and `context=False` describe name matching and value placement, which a
   reader does not have, so a reader declaration carrying them is rejected at class definition instead
-  of leaving them silently inert. `framework_set=True` marks the one framework-written key, the
-  reserved `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by
-  `init_reader`. Such keys are exempt from enforcement, so enforcement fields on them are rejected
-  too, as is `allow_explicit_none`, which the admit path never reads on a framework-written key; on a
-  feature group the field is rejected outright. The reserved key is checked as the MRO merge resolves
-  it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a plain
-  mixin can turn the framework-written key into a user-enforced one.
+  of leaving them silently inert. `framework_set=True` marks the one framework-written key, the reserved
+  `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by `init_reader`. Such
+  keys are exempt from enforcement, so enforcement fields on them are rejected too, as is
+  `allow_explicit_none`; on a feature group the field is rejected outright. The reserved key's
+  **winning** declaration across the MRO must keep `framework_set=True`, so no subclass or mixin can
+  turn it into a user-enforced key.
 - **The reverse also holds: a reader-only field has no feature-group meaning.** `scalar_only`
   rejects a collection value outright instead of unpacking it element-wise, so a feature group
-  declaring it is rejected at class definition, the same way `match_guard`/`deferred_binding`/
-  `context=False` are rejected on the reader surface.
+  declaring it is rejected the same way.
 
-The merge holds on both surfaces: `declared_option_specs()` on a feature group and
-`reader_option_specs()` on a reader return the merged declarations, most-derived winning, so a
-concrete class inherits its family's keys and redeclares nothing; `declared_option_keys()` and
-`declared_reader_option_keys()` are the merged key sets. The merged view of an undeclared class is
-`{}` on both surfaces. Whether a feature group has a configuration matcher is a separate question: it
-does when some class beyond `FeatureGroup` itself declared a mapping, an explicit empty one included
-(see [Guarding against a universal configuration matcher](#guarding-against-a-universal-configuration-matcher)).
-Both `reader_option()` and `reader_option_default()` raise for a key no declaration carries, so a
-typo in *reader* code is loud instead of a silent `None`.
+The merge holds on both surfaces: `declared_option_specs()` (feature group) and
+`reader_option_specs()` (reader) return the merged declarations, most-derived winning, so a concrete
+class inherits its family's keys and redeclares nothing. `declared_option_keys()` and
+`declared_reader_option_keys()` are the merged key sets; the merged view of an undeclared class is
+`{}` on both surfaces. Whether a feature group has a configuration matcher is separate: it does when
+some class beyond `FeatureGroup` declared a mapping, an explicit empty one included (see
+[Guarding against a universal configuration matcher](#guarding-against-a-universal-configuration-matcher)).
+`reader_option()` and `reader_option_default()` raise for a key no declaration carries, so a typo in
+*reader* code is loud instead of a silent `None`.
 
 What a plugin author may rely on:
 
@@ -183,11 +180,11 @@ What a plugin author may rely on:
 
 The surfaces used to be two types: reader selection had no rejection channel, so enforcement
 fields on a reader would have been silently inert (#865). The shared channel (#727) made declines
-attributable and collapsed the types back into one (#949). The surfaces then still diverged in
-inheritance, validation and empty shape under two names; they now share one attribute, one merge
-and one validator, and the old reader name `READER_OPTIONS` raises at class definition naming the
-rename. Migration edge: a bare `PropertySpec("...")` is required at selection; the old bare
-`ReaderOptionSpec("...")` is `PropertySpec("...", default=None)`.
+attributable and collapsed the types back into one (#949). They then still diverged in inheritance,
+validation and empty shape under two names; they now share one attribute, one merge and one
+validator, and a leftover `READER_OPTIONS` raises at class definition naming the rename. Migration
+edge: a bare `PropertySpec("...")` is required at selection; the old bare `ReaderOptionSpec("...")`
+is `PropertySpec("...", default=None)`.
 
 ### A pattern-less feature group sits in between
 
@@ -646,16 +643,16 @@ Both surfaces declare under one attribute, and declarations merge across the cla
 
 | Retired | Now |
 | --- | --- |
-| `READER_OPTIONS` on a reader | `PROPERTY_MAPPING`; a leftover `READER_OPTIONS` raises at class definition naming the rename |
-| A subclass declaration replacing its parent's | Declarations merge, most-derived winning. A subclass that meant to drop a parent key must override it with the spec it wants; there is no way to un-declare a key |
+| `READER_OPTIONS` on a reader | `PROPERTY_MAPPING`; a leftover `READER_OPTIONS` raises at class definition |
+| A subclass declaration replacing its parent's | Declarations merge, most-derived winning; there is no way to un-declare a key |
 | `PROPERTY_MAPPING = None` | Remove the line, or declare a dict |
 | `{**Parent.PROPERTY_MAPPING, ...}` | Declare only what changes |
 | Reading `cls.PROPERTY_MAPPING` for the effective mapping | `declared_option_specs()` on a feature group, `reader_option_specs()` on a reader |
-| Assigning or mutating `PROPERTY_MAPPING` after the class body | Unsupported: the merge is read at class definition and cached; declare everything in the class body |
+| Assigning or mutating `PROPERTY_MAPPING` after the class body | Unsupported; the merge is cached at class definition |
 
 One behavior change: a subclass that declared its own mapping while omitting parent keys now
-inherits them, so a parent default materializes into `Options` at intake and a parent key without a
-default is required. Check subclass hierarchies that declared their own mapping.
+inherits them, so a parent default materializes at intake and a parent key without a default is
+required. Check subclass hierarchies that declared their own mapping.
 
 ## Where each invariant is pinned
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -149,14 +149,14 @@ consequences keep the shared type honest on this surface:
 - **The shared validator rejects, per surface, the fields that are inert there.** `match_guard`,
   `deferred_binding=True` and `context=False` describe name matching and value placement, which a
   reader does not have, so a reader declaration carrying them is rejected at class definition instead
-  of leaving them silently inert (#865). `framework_set=True` marks the one framework-written key, the
+  of leaving them silently inert. `framework_set=True` marks the one framework-written key, the
   reserved `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by
   `init_reader`. Such keys are exempt from enforcement, so enforcement fields on them are rejected
   too, as is `allow_explicit_none`, which the admit path never reads on a framework-written key; on a
   feature group the field is rejected outright. The reserved key is checked as the MRO merge resolves
   it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a plain
   mixin can turn the framework-written key into a user-enforced one.
-- **The reverse also holds: a reader-only field has no feature-group meaning.** `scalar_only` (#1154)
+- **The reverse also holds: a reader-only field has no feature-group meaning.** `scalar_only`
   rejects a collection value outright instead of unpacking it element-wise, so a feature group
   declaring it is rejected at class definition, the same way `match_guard`/`deferred_binding`/
   `context=False` are rejected on the reader surface.

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -71,7 +71,8 @@ does not understand can be absorbed silently.
 **Declarations merge across the class hierarchy.** On both surfaces a subclass adds or overrides
 keys and redeclares nothing: the most-derived declaration of a key wins. `declared_option_specs()`
 (feature group) and `reader_option_specs()` (reader) return the merged view; the attribute itself
-stays the class's own declaration. `PROPERTY_MAPPING = None` is rejected at class definition,
+stays the class's own declaration. The merged view is computed at class definition and cached, so a
+later write to the attribute is not seen. `PROPERTY_MAPPING = None` is rejected at class definition,
 because `None` cannot clear inherited keys.
 
 ## The lifecycle: which invariant fires when
@@ -164,10 +165,10 @@ consequences keep the shared type honest on this surface:
 The merge holds on both surfaces: `declared_option_specs()` on a feature group and
 `reader_option_specs()` on a reader return the merged declarations, most-derived winning, so a
 concrete class inherits its family's keys and redeclares nothing; `declared_option_keys()` and
-`declared_reader_option_keys()` are the merged key sets. "Nothing declared" is `{}` on both. On a
-feature group it is whether any class beyond `FeatureGroup` itself declared a mapping that turns the
-configuration matcher on (see
-[Guarding against a universal configuration matcher](#guarding-against-a-universal-configuration-matcher)).
+`declared_reader_option_keys()` are the merged key sets. The merged view of an undeclared class is
+`{}` on both surfaces. Whether a feature group has a configuration matcher is a separate question: it
+does when some class beyond `FeatureGroup` itself declared a mapping, an explicit empty one included
+(see [Guarding against a universal configuration matcher](#guarding-against-a-universal-configuration-matcher)).
 Both `reader_option()` and `reader_option_default()` raise for a key no declaration carries, so a
 typo in *reader* code is loud instead of a silent `None`.
 
@@ -650,6 +651,7 @@ Both surfaces declare under one attribute, and declarations merge across the cla
 | `PROPERTY_MAPPING = None` | Remove the line, or declare a dict |
 | `{**Parent.PROPERTY_MAPPING, ...}` | Declare only what changes |
 | Reading `cls.PROPERTY_MAPPING` for the effective mapping | `declared_option_specs()` on a feature group, `reader_option_specs()` on a reader |
+| Assigning or mutating `PROPERTY_MAPPING` after the class body | Unsupported: the merge is read at class definition and cached; declare everything in the class body |
 
 One behavior change: a subclass that declared its own mapping while omitting parent keys now
 inherits them, so a parent default materializes into `Options` at intake and a parent key without a

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -1,10 +1,10 @@
 # PROPERTY_MAPPING Configuration
 
-`PROPERTY_MAPPING` maps every option key a feature group accepts to a `PropertySpec`: the
-typed, frozen spec that declares how that option is validated. This page is the single
-source of truth for that model: what a spec may contain, which invariant is checked at
-which moment, what runs against end-user values in what order, and what each failure
-produces.
+`PROPERTY_MAPPING` maps every option key a feature group or a reader accepts to a
+`PropertySpec`: the typed, frozen spec that declares how that option is validated. This page
+is the single source of truth for that model: what a spec may contain, which invariant is
+checked at which moment, what runs against end-user values in what order, and what each
+failure produces.
 
 Two rules carry most of the model:
 
@@ -40,6 +40,8 @@ PROPERTY_MAPPING = {
 | `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
 | `allow_explicit_none` | `bool` | `False` | Opt-in so an explicit `None` is honored (not treated as absent) and flows through validation. |
 | `deferred_binding` | `bool` | `False` | Exempts a required key from the string-named path presence check only; its value is bound outside match-time name capture. Not optionality: the key stays required on the config path. See [Required presence on the string-named path](#required-presence-on-the-string-named-path). |
+| `framework_set` | `bool` | `False` | Reader-only: marks the one framework-written key, which is exempt from enforcement. Rejected on a feature group. |
+| `scalar_only` | `bool` | `False` | Reader-only: reject a list/tuple/set/frozenset value outright instead of unpacking it element-wise. Requires `strict_validation=True`. Rejected on a feature group. |
 
 **`property_spec(...)` is the authoring path to reach for.** It is a thin builder over the
 same fields, its keyword is `strict=` (which sets `strict_validation`), and it keeps the
@@ -66,13 +68,19 @@ The type IS the schema. A raw dict spec is rejected at class definition
 constructor `TypeError` that mypy already flags where the spec is written. Nothing a spec
 does not understand can be absorbed silently.
 
+**Declarations merge across the class hierarchy.** On both surfaces a subclass adds or overrides
+keys and redeclares nothing: the most-derived declaration of a key wins. `declared_option_specs()`
+(feature group) and `reader_option_specs()` (reader) return the merged view; the attribute itself
+stays the class's own declaration. `PROPERTY_MAPPING = None` is rejected at class definition,
+because `None` cannot clear inherited keys.
+
 ## The lifecycle: which invariant fires when
 
 | Moment | Mechanism | Checks | Receives | On failure |
 | --- | --- | --- | --- | --- |
 | Author time | `mypy --strict` | The field exists and its declared type fits: `strict_validaton=True` (typo), `strict_validation=1`, `allowed_values=5` | The constructor call | mypy error at the spec literal. Without mypy: an unknown field is a `TypeError`; a wrong type falls through to the row below |
 | Construction (`PropertySpec(...)`) | `__post_init__` | `allowed_values` is not a str/bytes and is a Mapping or an iterable; `strict_validation` is a real bool; the validators are callable; `element_validator` implies strict; strict has a non-empty value space or an `element_validator`; a strict, non-`None` `default` is accepted by the key's own rules | The spec being built | `ValueError` at import, prefixed `PropertySpec('<explanation>')` |
-| Class definition (`FeatureGroup.__init_subclass__`) | Spec type | Every spec IS a `PropertySpec` | Every value in the mapping | `ValueError` naming the class and the key |
+| Class definition (`__init_subclass__` of `FeatureGroup` or `BaseInputData`) | Spec type + surface rules | Every value in the class's own declaration, and in any plain mixin reaching it through the merge, IS a `PropertySpec` and declares nothing inert on that surface (feature group: `framework_set`, `scalar_only`; reader: `match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key); the reserved reader key's **winning** declaration keeps `framework_set=True`; the declaration is a dict (`None` rejected) | Every value in that class's declaration, plus mixin declarations, plus the reserved key as the merge resolves it | `ValueError` naming class, key and field (and the reaching class for a mixin) |
 | Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | Required presence (config path) | A key that declares no `default` and no `required_when` was provided | The options | Non-match (`False`) |
@@ -81,13 +89,11 @@ does not understand can be absorbed silently.
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
 | Class definition (mixin) | Universal-matcher diagnostic | An all-optional `PROPERTY_MAPPING` inherits the configuration matcher, so it matches any name with empty options | The class | `logger.warning`, unless `ALLOW_UNIVERSAL_MATCHER = True` |
-| Author time (reader surface) | `mypy --strict` | `READER_OPTIONS` holds `PropertySpec` values | The constructor call | mypy error at the declaration |
-| Class definition (`BaseInputData.__init_subclass__`) | Spec type + surface guard | Every value IS a `PropertySpec` and declares nothing inert on a reader (`match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key); the reserved key's **winning** declaration across the MRO keeps `framework_set=True` | Every value in that class's declaration, plus the reserved key as the MRO merge resolves it | `ValueError` naming class, key and field |
 | Match time (reader selection) | Presence + strict validation | Required keys are present and present strict values pass, element-wise unless `scalar_only` rejects a collection outright; `framework_set` keys exempt | The candidate's merged specs and the options | Reader non-match. Addressed-reader and supplied-value failures record a `stage="input_data"` rejection; unaddressed absence and an unjudgeable predicate decline silently |
 | Match time (reader code) | `reader_option(key, options)` | Supplied value, else the declared `default` | The key name and the options | `ValueError` for an undeclared key or an absent `NO_DEFAULT` one |
 
 A spec is constructed inside the class body, so its own rules fire before the class exists.
-Class definition is left with exactly one rule: the type itself. Within `__post_init__` the
+Class definition checks the type plus the surface rules. Within `__post_init__` the
 declared-default check runs last, after the shape rules, because it calls the validators the
 shape rules just certified: a non-callable `element_validator` would otherwise be blamed on
 the default.
@@ -112,21 +118,22 @@ declares it gets its resolved `match_feature_group_criteria` wrapped at class de
 and the wrapper runs the predicates after that matcher returns `True`. Overriding the
 matcher therefore keeps the contract, whether the override delegates or not.
 
-The last four rows are the whole reader surface, and the match-time ones sit outside the ordered
-sequence above: a user-facing `READER_OPTIONS` key is consumed during reader selection, and no other
-moment fires for it. The reserved `"BaseInputData"` key is the exception, written at selection and read
-back at load time by `BaseInputData.init_reader` and by `SQLITEReader.get_table`.
+The last two rows are the reader's match-time surface, and they sit outside the ordered sequence
+above: a user-facing reader key is consumed during reader selection, and no other moment fires for
+it. The reserved `"BaseInputData"` key is the exception, written at selection and read back at load
+time by `BaseInputData.init_reader` and by `SQLITEReader.get_table`.
 See [One spec type, two surfaces](#one-spec-type-two-surfaces).
 
 ## One spec type, two surfaces
 
-Option keys are declared in two places, with one spec type, and the two surfaces enforce it
-differently because they consume values at different moments.
+One attribute (`PROPERTY_MAPPING`), one spec type (`PropertySpec`), one declaration mechanism (an
+MRO merge with a per-class cache, and one validator parameterized by surface), and two owners that
+consume the values at different moments.
 
 | Surface | Declared on | What the framework does with it |
 | --- | --- | --- |
 | `PROPERTY_MAPPING` | a `FeatureGroup` | Enforces it and applies it: value validation (`allowed_values`, `element_validator`), presence and `required_when`, and materialization of declared defaults into `Options`. |
-| `READER_OPTIONS` | a `BaseInputData` reader | Enforces it at reader selection: presence, `required_when` and strict values are checked before a candidate probes, and a failure vetoes that reader, recording per the ownership rule above. Defaults are never materialized; only the reader's own code applies them. |
+| `PROPERTY_MAPPING` | a `BaseInputData` reader | Enforces it at reader selection: presence, `required_when` and strict values are checked before a candidate probes, and a failure vetoes that reader, recording per the ownership rule above. Defaults are never materialized; only the reader's own code applies them. |
 
 A reader consumes its option keys during reader **selection** (`match_subclass_data_access`, reached
 through `BaseInputData.matches` from the matcher), before the framework materializes anything. Two
@@ -139,26 +146,30 @@ consequences keep the shared type honest on this surface:
   `reader_option` raises for it. The declaration is load-bearing: `ReadFile` and `ReadDocument`
   resolve `document_suffixes` this way (for `ReadDocument` only in its `DataAccessCollection`
   branch; the bare str/Path branch passes no `document_suffixes`).
-- **Fields with no reader meaning are rejected where they are written.** `match_guard`,
+- **The shared validator rejects, per surface, the fields that are inert there.** `match_guard`,
   `deferred_binding=True` and `context=False` describe name matching and value placement, which a
-  reader does not have, so `BaseInputData.__init_subclass__` rejects them instead of leaving them
-  silently inert (#865). `framework_set=True` marks the one framework-written key, the reserved
-  `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by `init_reader`.
-  Such keys are exempt from enforcement, so enforcement fields on them are rejected too, as is
-  `allow_explicit_none`, which the admit path never reads on a framework-written key; on
-  `PROPERTY_MAPPING` the field is rejected outright. The reserved key is checked as the MRO merge
-  resolves it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a
-  plain mixin can turn the framework-written key into a user-enforced one.
-- **The reverse also holds: a reader-only field has no `PROPERTY_MAPPING` meaning.** `scalar_only` (#1154)
-  rejects a collection value outright instead of unpacking it element-wise, so `FeatureChainParser` rejects
-  it on `PROPERTY_MAPPING` at class definition, the same way `match_guard`/`deferred_binding`/`context=False`
-  are rejected on the reader surface.
+  reader does not have, so a reader declaration carrying them is rejected at class definition instead
+  of leaving them silently inert (#865). `framework_set=True` marks the one framework-written key, the
+  reserved `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by
+  `init_reader`. Such keys are exempt from enforcement, so enforcement fields on them are rejected
+  too, as is `allow_explicit_none`, which the admit path never reads on a framework-written key; on a
+  feature group the field is rejected outright. The reserved key is checked as the MRO merge resolves
+  it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a plain
+  mixin can turn the framework-written key into a user-enforced one.
+- **The reverse also holds: a reader-only field has no feature-group meaning.** `scalar_only` (#1154)
+  rejects a collection value outright instead of unpacking it element-wise, so a feature group
+  declaring it is rejected at class definition, the same way `match_guard`/`deferred_binding`/
+  `context=False` are rejected on the reader surface.
 
-`READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
-so a concrete reader inherits its family's keys and redeclares nothing, and
-`declared_reader_option_keys()` is the merged key set. Both `reader_option()` and
-`reader_option_default()` raise for a key no declaration carries, so a typo in *reader* code is loud
-instead of a silent `None`.
+The merge holds on both surfaces: `declared_option_specs()` on a feature group and
+`reader_option_specs()` on a reader return the merged declarations, most-derived winning, so a
+concrete class inherits its family's keys and redeclares nothing; `declared_option_keys()` and
+`declared_reader_option_keys()` are the merged key sets. "Nothing declared" is `{}` on both. On a
+feature group it is whether any class beyond `FeatureGroup` itself declared a mapping that turns the
+configuration matcher on (see
+[Guarding against a universal configuration matcher](#guarding-against-a-universal-configuration-matcher)).
+Both `reader_option()` and `reader_option_default()` raise for a key no declaration carries, so a
+typo in *reader* code is loud instead of a silent `None`.
 
 What a plugin author may rely on:
 
@@ -171,9 +182,11 @@ What a plugin author may rely on:
 
 The surfaces used to be two types: reader selection had no rejection channel, so enforcement
 fields on a reader would have been silently inert (#865). The shared channel (#727) made declines
-attributable and collapsed the types back into one (#949). Migration edge: a bare
-`PropertySpec("...")` is required at selection; the old bare `ReaderOptionSpec("...")` is
-`PropertySpec("...", default=None)`.
+attributable and collapsed the types back into one (#949). The surfaces then still diverged in
+inheritance, validation and empty shape under two names; they now share one attribute, one merge
+and one validator, and the old reader name `READER_OPTIONS` raises at class definition naming the
+rename. Migration edge: a bare `PropertySpec("...")` is required at selection; the old bare
+`ReaderOptionSpec("...")` is `PropertySpec("...", default=None)`.
 
 ### A pattern-less feature group sits in between
 
@@ -588,7 +601,9 @@ A key is unconditionally required only when it declares no `default` and no `req
 `PROPERTY_MAPPING` with only declared-default keys (and, as the degenerate case, an empty mapping)
 has no such key, so on the configuration path it matches any feature name with empty options. A
 feature group that inherits the mixin's `match_feature_group_criteria` and declares such a mapping
-is a universal matcher: it claims features it was never meant to.
+is a universal matcher: it claims features it was never meant to. An undeclared feature group (no
+class in its hierarchy beyond `FeatureGroup` declares a `PROPERTY_MAPPING`) has no configuration
+matcher at all, so it is never universal; an explicit empty declaration is.
 
 At class definition the mixin warns about this, naming the class and the escape hatch. A key that is
 unconditionally required, or conditionally required via `required_when`, gates the match, so the
@@ -624,6 +639,22 @@ per call for every container type; the old `validation_function` saw a stringifi
 (`isinstance(x, list) and all(...)`) must become a per-element rule, or move to `match_guard`
 if it really is a whole-value check.
 
+## Migrating to the merged declaration
+
+Both surfaces declare under one attribute, and declarations merge across the class hierarchy.
+
+| Retired | Now |
+| --- | --- |
+| `READER_OPTIONS` on a reader | `PROPERTY_MAPPING`; a leftover `READER_OPTIONS` raises at class definition naming the rename |
+| A subclass declaration replacing its parent's | Declarations merge, most-derived winning. A subclass that meant to drop a parent key must override it with the spec it wants; there is no way to un-declare a key |
+| `PROPERTY_MAPPING = None` | Remove the line, or declare a dict |
+| `{**Parent.PROPERTY_MAPPING, ...}` | Declare only what changes |
+| Reading `cls.PROPERTY_MAPPING` for the effective mapping | `declared_option_specs()` on a feature group, `reader_option_specs()` on a reader |
+
+One behavior change: a subclass that declared its own mapping while omitting parent keys now
+inherits them, so a parent default materializes into `Options` at intake and a parent key without a
+default is required. Check subclass hierarchies that declared their own mapping.
+
 ## Where each invariant is pinned
 
 | Invariant | Test |
@@ -638,7 +669,9 @@ if it really is a whole-value check.
 | Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
 | Declared defaults materialized at intake, canonicalizing default-equivalent twins | `tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py` |
 | Filter criteria matching observes effective options | `tests/test_core/test_filter/test_filter_criteria_effective_options.py` |
-| The reader surface: the single spec type and its surface guards, the reserved framework key, the MRO merge, the loud undeclared key, the presence rule of `reader_option()` | `tests/.../test_components/test_reader_option_declarations.py` |
+| The shared declaration surface: MRO merge and per-class cache, declared-beyond-the-base, one validator per surface, the `None`/non-dict rejection | `tests/.../test_components/test_property_mapping_surface.py` |
+| Feature-group declarations merge across the hierarchy: accessors, materialization, config-path matching and the guards read the merged view | `tests/.../test_feature_group/test_property_mapping_merge.py` |
+| The reader surface: the surface guards, the reserved framework key, the MRO merge, the loud undeclared key, the presence rule of `reader_option()`, and the `READER_OPTIONS` rename as a hard break | `tests/.../test_components/test_reader_option_declarations.py` |
 | Reader selection enforcement: strict values, requiredness, the `framework_set` exemption, the attributable `input_data` rejection | `tests/.../test_components/test_reader_option_enforcement.py` |
 | Per-reader declarations, the declared `default` that is load-bearing at selection, and the bare-path branch it does not reach | `tests/.../input_data/test_reader_option_declarations.py` |
 | A pattern-less group: enforced `required_when`, and defaults it applies itself | `tests/.../input_data/test_read_context_files_option_declarations.py` |

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
@@ -26,6 +26,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.property_mapping import configuration_property_mapping
 from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
     contained_raise_reason,
@@ -109,7 +110,7 @@ def validate_name_binding(owner: type[Any]) -> None:
     explicit for it); a captureless one has nothing to misbind. Called from both FeatureGroup and
     FeatureChainParserMixin at class definition.
     """
-    property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+    property_mapping = configuration_property_mapping(owner)
     if not isinstance(property_mapping, dict):
         return
 
@@ -152,7 +153,7 @@ def warn_captureless_without_binding(owner: type[Any]) -> None:
         return
     if getattr(owner, "RECOGNITION_ONLY_PATTERN", False):
         return
-    property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+    property_mapping = configuration_property_mapping(owner)
     if not isinstance(property_mapping, dict) or not property_mapping:
         return
     patterns = FeatureChainParser.prefix_patterns_of(owner)
@@ -185,9 +186,9 @@ def warn_universal_optional_matcher(owner: type[Any]) -> None:
     """
     if getattr(owner, "ALLOW_UNIVERSAL_MATCHER", False):
         return
-    property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
-    # A None mapping is not a configuration matcher; an EMPTY dict is the strongest universal
-    # matcher (it validates vacuously), so it stays in scope.
+    property_mapping = configuration_property_mapping(owner)
+    # An undeclared class is not a configuration matcher; an explicit empty declaration is the
+    # strongest universal matcher (it validates vacuously), so it stays in scope.
     if not isinstance(property_mapping, dict):
         return
     for spec in property_mapping.values():
@@ -351,7 +352,7 @@ def install_required_when_guard(owner: type[Any]) -> None:
     Class definition is the install site, so a PROPERTY_MAPPING mutated, or a matcher replaced,
     AFTER the class body is not seen by the guard.
     """
-    property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+    property_mapping = configuration_property_mapping(owner)
     if not isinstance(property_mapping, dict) or not FeatureChainParser.has_required_when_predicates(property_mapping):
         return
 
@@ -387,7 +388,7 @@ def install_required_when_guard(owner: type[Any]) -> None:
                 guarded_cls.__name__,
                 feature_name,
                 FeatureChainParser.prefix_patterns_of(guarded_cls),
-                getattr(guarded_cls, "PROPERTY_MAPPING", None),
+                configuration_property_mapping(guarded_cls),
                 options,
             )
         finally:
@@ -406,7 +407,7 @@ def install_name_path_presence_guard(owner: type[Any]) -> None:
     duplicated. Nesting order relative to the required_when guard is behaviorally irrelevant:
     each guard ANDs its own predicate onto the inner verdict and passes False through unchanged.
     """
-    property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+    property_mapping = configuration_property_mapping(owner)
     if not isinstance(property_mapping, dict):
         return
     if not FeatureChainParser.prefix_patterns_of(owner):
@@ -450,7 +451,7 @@ def install_name_path_presence_guard(owner: type[Any]) -> None:
             if options is None:
                 return True
 
-            mapping = getattr(guarded_cls, "PROPERTY_MAPPING", None)
+            mapping = configuration_property_mapping(guarded_cls)
             if not isinstance(mapping, dict):
                 return True
             # Flattened, because a matcher passes a list-valued pattern attribute straight to

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -270,15 +270,15 @@ class FeatureChainParser:
             # Contained: a framework_set spec is that candidate's own defect, so the seam reads it as a non-match.
             raise ValueError(
                 f"{owner_name}.PROPERTY_MAPPING['{key}'] declares framework_set=True, which marks a "
-                f"reader-surface (READER_OPTIONS) key written by the framework; PROPERTY_MAPPING keys "
-                f"are user-set."
+                f"reader-surface (BaseInputData PROPERTY_MAPPING) key written by the framework; a "
+                f"FeatureGroup's PROPERTY_MAPPING keys are user-set."
             )
         if spec.scalar_only:
             # Contained: a scalar_only spec is that candidate's own defect, so the seam reads it as a non-match.
             raise ValueError(
                 f"{owner_name}.PROPERTY_MAPPING['{key}'] declares scalar_only=True, which marks a "
-                f"reader-surface (READER_OPTIONS) key rejected outright as a collection; PROPERTY_MAPPING "
-                f"keys always unpack element-wise."
+                f"reader-surface (BaseInputData PROPERTY_MAPPING) key rejected outright as a collection; a "
+                f"FeatureGroup's PROPERTY_MAPPING keys always unpack element-wise."
             )
         return spec
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+from mloda.core.abstract_plugins.components.property_mapping import DeclarationSurface, validate_property_spec
 from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
     contained_raise_reason,
@@ -257,30 +258,9 @@ class FeatureChainParser:
 
     @classmethod
     def _require_spec(cls, owner_name: str, key: str, spec: Any) -> PropertySpec:
-        """Reject anything that is not a reader-free ``PropertySpec``; the parser entry point is
-        public and takes caller mappings, so neither rule can live at class-definition time alone."""
-        if not isinstance(spec, PropertySpec):
-            # Contained: a raw dict spec is that candidate's own defect, so the seam reads it as a non-match.
-            raise ValueError(
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
-                f"Raw dict specs are no longer accepted; construct PropertySpec(...) or use the "
-                f"property_spec(...) helper."
-            )
-        if spec.framework_set:
-            # Contained: a framework_set spec is that candidate's own defect, so the seam reads it as a non-match.
-            raise ValueError(
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares framework_set=True, which marks a "
-                f"reader-surface (BaseInputData PROPERTY_MAPPING) key written by the framework; a "
-                f"FeatureGroup's PROPERTY_MAPPING keys are user-set."
-            )
-        if spec.scalar_only:
-            # Contained: a scalar_only spec is that candidate's own defect, so the seam reads it as a non-match.
-            raise ValueError(
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares scalar_only=True, which marks a "
-                f"reader-surface (BaseInputData PROPERTY_MAPPING) key rejected outright as a collection; a "
-                f"FeatureGroup's PROPERTY_MAPPING keys always unpack element-wise."
-            )
-        return spec
+        """Thin seam onto the shared FEATURE_GROUP surface rules; the parser entry point is public
+        and takes caller mappings, so neither rule can live at class-definition time alone."""
+        return validate_property_spec(owner_name, key, spec, DeclarationSurface.FEATURE_GROUP)
 
     @classmethod
     def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -57,7 +57,7 @@ import inspect
 import logging
 import os
 from collections.abc import Callable
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -79,6 +79,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.property_mapping import configuration_property_mapping
 from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
     contained_raise_reason,
@@ -588,10 +589,8 @@ class FeatureChainParserMixin:
 
     @classmethod
     def _get_property_mapping(cls) -> Optional[dict[str, PropertySpec]]:
-        """Get property mapping from class attribute."""
-        if hasattr(cls, "PROPERTY_MAPPING"):
-            return cast(Optional[dict[str, PropertySpec]], cls.PROPERTY_MAPPING)
-        return None
+        """The MRO-merged mapping when declared beyond the surface base, else None."""
+        return configuration_property_mapping(cls)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -88,7 +88,7 @@ class PropertySpec:
     # outside match-time name capture (parsed from the name by the plugin, or supplied downstream).
     # It does NOT change config-path requiredness.
     deferred_binding: bool = False
-    # Marks a reader-surface key the framework writes rather than the user; rejected on the PROPERTY_MAPPING surface.
+    # Marks a reader-surface key the framework writes rather than the user; rejected on the FeatureGroup surface.
     framework_set: bool = False
     # Reader-only: rejects a list/tuple/set/frozenset value outright instead of unpacking it element-wise.
     scalar_only: bool = False

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -13,6 +13,12 @@ from mloda.core.abstract_plugins.components.match_rejection import (
     restamp_match_rejections_since,
 )
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.property_mapping import (
+    DeclarationSurface,
+    merged_property_mapping,
+    reject_merge_cache_assignment,
+    validate_property_mapping,
+)
 
 
 from mloda.core.abstract_plugins.components.utils import (
@@ -28,7 +34,9 @@ RESERVED_READER_OPTION_KEY = "BaseInputData"
 
 
 class BaseInputData(ABC):
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING_SURFACE: ClassVar[DeclarationSurface] = DeclarationSurface.READER
+
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         RESERVED_READER_OPTION_KEY: PropertySpec(
             "The matched (ReaderClass, data_access) pair, written by add_base_input_data_to_options "
             "and read back by init_reader.",
@@ -37,157 +45,60 @@ class BaseInputData(ABC):
         ),
     }
 
-    _reader_option_specs_cache: ClassVar[Optional[dict[str, PropertySpec]]] = None
-    """Merged declarations of ONE class, written into that class's own __dict__ by _merged_reader_option_specs."""
-
     def __init__(self) -> None:
         pass
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Guards run at class definition only: mutating READER_OPTIONS afterwards or overriding
+        """Guards run at class definition only: mutating PROPERTY_MAPPING afterwards or overriding
         __init_subclass__ without calling super() defeats them."""
         # Checked before super(): a cooperative later-in-MRO hook may warm the cache during the
         # super() chain; here cls.__dict__ still holds only what the class body wrote.
-        if "_reader_option_specs_cache" in cls.__dict__:
-            raise ValueError(
-                f"{cls.__name__} assigns _reader_option_specs_cache in its class body; the merge cache "
-                f"is framework-written and must never be declared by a reader."
-            )
+        reject_merge_cache_assignment(cls)
         super().__init_subclass__(**kwargs)
-        cls._validate_reader_options()
+        for klass in cls.__mro__:
+            if "READER_OPTIONS" in klass.__dict__:
+                raise ValueError(
+                    f"{klass.__name__} declares READER_OPTIONS, which was renamed to PROPERTY_MAPPING; "
+                    f"rename the class attribute to PROPERTY_MAPPING."
+                )
+        cls._validate_reserved_reader_option_key()
+        validate_property_mapping(cls)
 
     @classmethod
     def _validate_reserved_reader_option_key(cls) -> None:
         """The reserved key must survive the MRO MERGE, not just cls's own dict: a plain mixin is never
         validated itself, yet its declaration outranks the base's and is what selection reads."""
         for klass in cls.__mro__:
-            declared = klass.__dict__.get("READER_OPTIONS", {})
-            if RESERVED_READER_OPTION_KEY not in declared:
+            declared = klass.__dict__.get("PROPERTY_MAPPING", {})
+            # A malformed declaration (None, a list, ...) is not this check's concern; own_property_mapping
+            # rejects its shape loudly once validate_property_mapping reaches it.
+            if not isinstance(declared, dict) or RESERVED_READER_OPTION_KEY not in declared:
                 continue
             spec = declared[RESERVED_READER_OPTION_KEY]
             if not isinstance(spec, PropertySpec) or not spec.framework_set:
                 raise ValueError(
-                    f"{cls.__name__} merges READER_OPTIONS['{RESERVED_READER_OPTION_KEY}'] to the declaration on "
+                    f"{cls.__name__} merges PROPERTY_MAPPING['{RESERVED_READER_OPTION_KEY}'] to the declaration on "
                     f"{klass.__name__}, which is not a PropertySpec with framework_set=True; the framework writes "
                     f"this reserved key itself, so the admit path would judge a value no user ever supplies."
                 )
             return
 
     @classmethod
-    def _validate_reader_options(cls) -> None:
-        """Reject a reader-invalid declaration where it is written, not later deep in reader matching;
-        checks this class's own declaration plus any plain-mixin declaration reaching its merge."""
-        cls._validate_reserved_reader_option_key()
-        for key, spec in cls._reader_options_declaration(cls).items():
-            cls._validate_reader_option_spec(cls.__name__, key, spec)
-        for klass in cls.__mro__[1:]:
-            # Real inheritance only: an ABC.register virtual subclass answers issubclass True
-            # without ever running __init_subclass__, so it never validated itself.
-            if BaseInputData in klass.__mro__:
-                continue
-            for key, spec in cls._reader_options_declaration(klass).items():
-                cls._validate_reader_option_spec(klass.__name__, key, spec, via=cls.__name__)
-
-    @staticmethod
-    def _reader_options_declaration(klass: type) -> dict[str, Any]:
-        """The class's own READER_OPTIONS, rejected loudly when it is not a dict."""
-        declared = klass.__dict__.get("READER_OPTIONS", {})
-        if not isinstance(declared, dict):
-            raise ValueError(
-                f"{klass.__name__}.READER_OPTIONS is a {type(declared).__name__}, not a dict. "
-                f"Declare a dict mapping option keys to PropertySpec instances."
-            )
-        return declared
-
-    @staticmethod
-    def _validate_reader_option_spec(owner: str, key: str, spec: Any, via: Optional[str] = None) -> None:
-        """The per-key reader rules; owner names the class the declaration is written on,
-        via names the class definition that reached it through the merge."""
-        suffix = "" if via is None else f" (reached defining {via})"
-        if not isinstance(spec, PropertySpec):
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
-                f"Construct PropertySpec(...) instead.{suffix}"
-            )
-        if spec.match_guard is not None:
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] declares a match_guard, which is name-matching "
-                f"machinery and silently inert on a reader.{suffix}"
-            )
-        if spec.deferred_binding:
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] declares deferred_binding=True, which is the "
-                f"name-capture exemption; a reader key has no name path.{suffix}"
-            )
-        if spec.context is False:
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] declares context=False, which places a "
-                f"materialized value; readers place none.{suffix}"
-            )
-        if spec.framework_set:
-            if spec.strict_validation:
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with "
-                    f"strict_validation=True; the framework-written key is exempt from user-value "
-                    f"validation, so strictness would be silently inert.{suffix}"
-                )
-            if spec.required_when is not None:
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with a "
-                    f"required_when predicate; the framework-written key is exempt from user-value "
-                    f"validation, so the predicate would be silently inert.{suffix}"
-                )
-            if spec.allow_explicit_none:
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with "
-                    f"allow_explicit_none=True; the admit path skips the framework-written key, "
-                    f"so the flag cannot affect reader selection.{suffix}"
-                )
-            if is_no_default(spec.default):
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] declares framework_set=True without a "
-                    f"declared default; the framework-written key must declare its absent-state "
-                    f"default explicitly, None included.{suffix}"
-                )
-
-    @classmethod
-    def _merged_reader_option_specs(cls) -> dict[str, PropertySpec]:
-        """The merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out.
-
-        Reader selection is a hot path, so the MRO walk runs once per class. The cache is read back
-        with cls.__dict__.get so a subclass never answers from a warm parent cache, and it lives on
-        the class itself rather than in a class-keyed registry so it holds no reference to any class.
-        """
-        cached: Optional[dict[str, PropertySpec]] = cls.__dict__.get("_reader_option_specs_cache")
-        if cached is not None:
-            return cached
-
-        merged: dict[str, PropertySpec] = {}
-        for klass in reversed(cls.__mro__):
-            merged.update(klass.__dict__.get("READER_OPTIONS", {}))
-        cls._reader_option_specs_cache = merged
-        return merged
-
-    @classmethod
     def reader_option_specs(cls) -> dict[str, PropertySpec]:
-        """The declarations of this reader family, most-derived winning; a fresh dict per call.
-
-        Merged across cls.__mro__ from each class's own __dict__ so an inherited attribute is not
-        merged twice, walking the MRO in reverse so a derived declaration wins on a key collision.
-        """
-        return dict(cls._merged_reader_option_specs())
+        """The declarations of this reader family, most-derived winning; a fresh dict per call."""
+        return dict(merged_property_mapping(cls))
 
     @classmethod
     def declared_reader_option_keys(cls) -> frozenset[str]:
         """Every option key this reader family declares."""
-        return frozenset(cls._merged_reader_option_specs())
+        return frozenset(merged_property_mapping(cls))
 
     @classmethod
     def _declared_reader_option_spec(cls, key: str) -> PropertySpec:
         """The declaration of key; an undeclared key is a typo, not a silent None."""
-        specs = cls._merged_reader_option_specs()
+        specs = merged_property_mapping(cls)
         if key not in specs:
-            raise ValueError(f"Reader option '{key}' is not declared in READER_OPTIONS of {cls.__name__}.")
+            raise ValueError(f"Reader option '{key}' is not declared in PROPERTY_MAPPING of {cls.__name__}.")
         return specs[key]
 
     @classmethod
@@ -216,7 +127,7 @@ class BaseInputData(ABC):
     def _reader_options_admit(cls, options: Optional[Options], record_absence: bool) -> bool:
         """Check this candidate's merged declarations BEFORE its probe runs; a veto is its own non-match.
         record_absence doubles as the ownership signal: it gates absence recordings and stages present-value ones."""
-        for key, spec in cls._merged_reader_option_specs().items():
+        for key, spec in merged_property_mapping(cls).items():
             if spec.framework_set:
                 continue
             if options is None:

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -73,8 +73,8 @@ class BaseInputData(ABC):
         validated itself, yet its declaration outranks the base's and is what selection reads."""
         for klass in cls.__mro__:
             declared = klass.__dict__.get(PROPERTY_MAPPING_ATTR, {})
-            # A malformed declaration (None, a list, ...) is not this check's concern; own_property_mapping
-            # rejects its shape loudly once validate_property_mapping reaches it.
+            # Shape is not this check's concern; own_property_mapping rejects it once
+            # validate_property_mapping reaches it.
             if not isinstance(declared, dict) or RESERVED_READER_OPTION_KEY not in declared:
                 continue
             spec = declared[RESERVED_READER_OPTION_KEY]

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -14,9 +14,11 @@ from mloda.core.abstract_plugins.components.match_rejection import (
 )
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.property_mapping import (
+    PROPERTY_MAPPING_ATTR,
     DeclarationSurface,
     merged_property_mapping,
     reject_merge_cache_assignment,
+    reject_surface_marker_assignment,
     validate_property_mapping,
 )
 
@@ -54,6 +56,7 @@ class BaseInputData(ABC):
         # Checked before super(): a cooperative later-in-MRO hook may warm the cache during the
         # super() chain; here cls.__dict__ still holds only what the class body wrote.
         reject_merge_cache_assignment(cls)
+        reject_surface_marker_assignment(cls)
         super().__init_subclass__(**kwargs)
         for klass in cls.__mro__:
             if "READER_OPTIONS" in klass.__dict__:
@@ -69,7 +72,7 @@ class BaseInputData(ABC):
         """The reserved key must survive the MRO MERGE, not just cls's own dict: a plain mixin is never
         validated itself, yet its declaration outranks the base's and is what selection reads."""
         for klass in cls.__mro__:
-            declared = klass.__dict__.get("PROPERTY_MAPPING", {})
+            declared = klass.__dict__.get(PROPERTY_MAPPING_ATTR, {})
             # A malformed declaration (None, a list, ...) is not this check's concern; own_property_mapping
             # rejects its shape loudly once validate_property_mapping reaches it.
             if not isinstance(declared, dict) or RESERVED_READER_OPTION_KEY not in declared:

--- a/mloda/core/abstract_plugins/components/property_mapping.py
+++ b/mloda/core/abstract_plugins/components/property_mapping.py
@@ -45,39 +45,80 @@ def surface_base(cls: type) -> type | None:
     return None
 
 
-def merged_property_mapping(cls: type) -> dict[str, PropertySpec]:
+class _MergedMapping(dict[str, PropertySpec]):
+    """The framework merge cache: the merged mapping itself, plus whether some class beyond the
+    surface base declared it, so a cooperative pre-super() read is never mistaken for an assignment."""
+
+    declared_beyond_base: bool = False
+
+
+def _merged_property_mapping(cls: type) -> _MergedMapping:
     """The MRO-merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out."""
-    cached: dict[str, PropertySpec] | None = cls.__dict__.get(CACHE_ATTR)
+    cached: _MergedMapping | None = cls.__dict__.get(CACHE_ATTR)
     if cached is not None:
         return cached
 
-    merged: dict[str, PropertySpec] = {}
+    base = surface_base(cls)
+    merged = _MergedMapping()
     for klass in reversed(cls.__mro__):
         merged.update(own_property_mapping(klass))
+    merged.declared_beyond_base = any(
+        klass is not base and PROPERTY_MAPPING_ATTR in klass.__dict__ for klass in cls.__mro__
+    )
     setattr(cls, CACHE_ATTR, merged)
     return merged
 
 
+def merged_property_mapping(cls: type) -> dict[str, PropertySpec]:
+    """The MRO-merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out."""
+    return _merged_property_mapping(cls)
+
+
 def declares_property_mapping(cls: type) -> bool:
     """True when some class OTHER THAN the surface base declares its own PROPERTY_MAPPING."""
-    base = surface_base(cls)
-    return any(klass is not base and PROPERTY_MAPPING_ATTR in klass.__dict__ for klass in cls.__mro__)
+    return _merged_property_mapping(cls).declared_beyond_base
 
 
 def configuration_property_mapping(cls: type) -> dict[str, PropertySpec] | None:
-    """The merged mapping when declared beyond the surface base, else None."""
-    if not declares_property_mapping(cls):
-        return None
-    return dict(merged_property_mapping(cls))
+    """The cached merged mapping itself when declared beyond the surface base, else None; no copy,
+    since internal callers only ever read it."""
+    merged = _merged_property_mapping(cls)
+    return merged if merged.declared_beyond_base else None
 
 
 def reject_merge_cache_assignment(cls: type) -> None:
-    """The merge cache is framework-written; a class body assigning it is a mistake."""
-    if CACHE_ATTR in cls.__dict__:
+    """The merge cache is framework-written; a class body assigning it is a mistake. A cache warmed
+    by a cooperative __init_subclass__ hook before calling super() is a _MergedMapping and is not
+    blamed: only a class body literally assigning the attribute produces something else."""
+    if CACHE_ATTR not in cls.__dict__:
+        return
+    if isinstance(cls.__dict__[CACHE_ATTR], _MergedMapping):
+        return
+    raise ValueError(
+        f"{cls.__name__} assigns {CACHE_ATTR} in its class body; the merge cache is "
+        f"framework-written and must never be declared."
+    )
+
+
+def reject_surface_marker_assignment(cls: type) -> None:
+    """The surface marker is framework-written; only FeatureGroup and BaseInputData set it."""
+    if SURFACE_ATTR in cls.__dict__:
         raise ValueError(
-            f"{cls.__name__} assigns {CACHE_ATTR} in its class body; the merge cache is "
-            f"framework-written and must never be declared."
+            f"{cls.__name__} assigns {SURFACE_ATTR} in its class body; the marker is set only by "
+            f"the framework's own base classes (FeatureGroup, BaseInputData)."
         )
+
+
+def _reject_conflicting_surface_bases(cls: type) -> None:
+    """Exactly one surface may govern cls; two distinct surface-marked classes in its MRO is an
+    author mistake, whether that is FeatureGroup and BaseInputData both, or a plain mixin carrying
+    the marker alongside either. Runs before any per-key validation, so a reader-only key merged
+    from the wrong surface never produces a misleading error first."""
+    bases = [klass for klass in cls.__mro__ if SURFACE_ATTR in klass.__dict__]
+    if len(bases) <= 1:
+        return
+    names = " and ".join(base.__name__ for base in bases)
+    raise ValueError(f"{cls.__name__} inherits both {names}; a class declares on one {SURFACE_ATTR} surface only.")
 
 
 def _reader_inert_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
@@ -148,7 +189,12 @@ def validate_property_spec(
             f"Construct PropertySpec(...) or use the property_spec(...) helper.{suffix}"
         )
 
-    checks = _feature_group_checks(spec) if surface is DeclarationSurface.FEATURE_GROUP else _reader_inert_checks(spec)
+    if surface is DeclarationSurface.FEATURE_GROUP:
+        checks = _feature_group_checks(spec)
+    elif surface is DeclarationSurface.READER:
+        checks = _reader_inert_checks(spec)
+    else:
+        raise ValueError(f"Unknown DeclarationSurface {surface!r}.")
     for triggered, message in checks:
         if triggered:
             raise ValueError(f"{owner}.PROPERTY_MAPPING['{key}'] {message}{suffix}")
@@ -163,6 +209,7 @@ def validate_property_spec(
 
 def validate_property_mapping(cls: type) -> None:
     """Validate cls's own declaration, plus every plain mixin's, against the surface cls declares."""
+    _reject_conflicting_surface_bases(cls)
     base = surface_base(cls)
     if base is None:
         return
@@ -172,6 +219,8 @@ def validate_property_mapping(cls: type) -> None:
         validate_property_spec(cls.__name__, key, spec, surface)
 
     for klass in cls.__mro__[1:]:
+        # Real inheritance only: an ABC.register virtual subclass answers issubclass True without
+        # ever running __init_subclass__, so it never validated itself.
         if base in klass.__mro__:
             continue
         for key, spec in own_property_mapping(klass).items():

--- a/mloda/core/abstract_plugins/components/property_mapping.py
+++ b/mloda/core/abstract_plugins/components/property_mapping.py
@@ -46,8 +46,7 @@ def surface_base(cls: type) -> type | None:
 
 
 class _MergedMapping(dict[str, PropertySpec]):
-    """The framework merge cache: the merged mapping itself, plus whether some class beyond the
-    surface base declared it, so a cooperative pre-super() read is never mistaken for an assignment."""
+    """The merge cache: the merged mapping, plus whether a class beyond the surface base declared it."""
 
     declared_beyond_base: bool = False
 
@@ -70,7 +69,7 @@ def _merged_property_mapping(cls: type) -> _MergedMapping:
 
 
 def merged_property_mapping(cls: type) -> dict[str, PropertySpec]:
-    """The MRO-merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out."""
+    """Public entry point onto the cache above; hands back the same object, not a copy."""
     return _merged_property_mapping(cls)
 
 
@@ -80,16 +79,15 @@ def declares_property_mapping(cls: type) -> bool:
 
 
 def configuration_property_mapping(cls: type) -> dict[str, PropertySpec] | None:
-    """The cached merged mapping itself when declared beyond the surface base, else None; no copy,
-    since internal callers only ever read it."""
+    """The cached merged mapping when declared beyond the surface base, else None; no copy, callers
+    only read it."""
     merged = _merged_property_mapping(cls)
     return merged if merged.declared_beyond_base else None
 
 
 def reject_merge_cache_assignment(cls: type) -> None:
-    """The merge cache is framework-written; a class body assigning it is a mistake. A cache warmed
-    by a cooperative __init_subclass__ hook before calling super() is a _MergedMapping and is not
-    blamed: only a class body literally assigning the attribute produces something else."""
+    """The merge cache is framework-written; assigning it in a class body is rejected. A cache warmed
+    by a cooperative __init_subclass__ hook before super() is a _MergedMapping and is not blamed."""
     if CACHE_ATTR not in cls.__dict__:
         return
     if isinstance(cls.__dict__[CACHE_ATTR], _MergedMapping):
@@ -111,9 +109,8 @@ def reject_surface_marker_assignment(cls: type) -> None:
 
 def _reject_conflicting_surface_bases(cls: type) -> None:
     """Exactly one surface may govern cls; two distinct surface-marked classes in its MRO is an
-    author mistake, whether that is FeatureGroup and BaseInputData both, or a plain mixin carrying
-    the marker alongside either. Runs before any per-key validation, so a reader-only key merged
-    from the wrong surface never produces a misleading error first."""
+    author mistake. Runs before any per-key validation, so a wrong-surface key never produces a
+    misleading error first."""
     bases = [klass for klass in cls.__mro__ if SURFACE_ATTR in klass.__dict__]
     if len(bases) <= 1:
         return

--- a/mloda/core/abstract_plugins/components/property_mapping.py
+++ b/mloda/core/abstract_plugins/components/property_mapping.py
@@ -1,0 +1,178 @@
+"""The PROPERTY_MAPPING declaration surface shared by FeatureGroup and BaseInputData: MRO merge,
+per-class cache, author-time rules. Two surfaces, one attribute name and one spec type
+(``PropertySpec``); the surface (``DeclarationSurface``) only changes which fields are inert.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+
+
+class DeclarationSurface(Enum):
+    FEATURE_GROUP = "FeatureGroup"
+    READER = "BaseInputData"
+
+
+SURFACE_ATTR = "PROPERTY_MAPPING_SURFACE"
+CACHE_ATTR = "_property_mapping_cache"
+PROPERTY_MAPPING_ATTR = "PROPERTY_MAPPING"
+
+
+def own_property_mapping(klass: type) -> dict[str, Any]:
+    """The class's own PROPERTY_MAPPING, rejected loudly when it is None or not a dict."""
+    declared = klass.__dict__.get(PROPERTY_MAPPING_ATTR, {})
+    if declared is None:
+        raise ValueError(
+            f"{klass.__name__}.PROPERTY_MAPPING is None. Declarations merge across the class "
+            f"hierarchy, so None cannot clear inherited keys. Remove the assignment or declare a dict."
+        )
+    if not isinstance(declared, dict):
+        raise ValueError(
+            f"{klass.__name__}.PROPERTY_MAPPING is a {type(declared).__name__}, not a dict. "
+            f"Declare a dict mapping option keys to PropertySpec instances."
+        )
+    return declared
+
+
+def surface_base(cls: type) -> type | None:
+    """The first class in cls.__mro__ that declares the surface in its own __dict__."""
+    for klass in cls.__mro__:
+        if SURFACE_ATTR in klass.__dict__:
+            return klass
+    return None
+
+
+def merged_property_mapping(cls: type) -> dict[str, PropertySpec]:
+    """The MRO-merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out."""
+    cached: dict[str, PropertySpec] | None = cls.__dict__.get(CACHE_ATTR)
+    if cached is not None:
+        return cached
+
+    merged: dict[str, PropertySpec] = {}
+    for klass in reversed(cls.__mro__):
+        merged.update(own_property_mapping(klass))
+    setattr(cls, CACHE_ATTR, merged)
+    return merged
+
+
+def declares_property_mapping(cls: type) -> bool:
+    """True when some class OTHER THAN the surface base declares its own PROPERTY_MAPPING."""
+    base = surface_base(cls)
+    return any(klass is not base and PROPERTY_MAPPING_ATTR in klass.__dict__ for klass in cls.__mro__)
+
+
+def configuration_property_mapping(cls: type) -> dict[str, PropertySpec] | None:
+    """The merged mapping when declared beyond the surface base, else None."""
+    if not declares_property_mapping(cls):
+        return None
+    return dict(merged_property_mapping(cls))
+
+
+def reject_merge_cache_assignment(cls: type) -> None:
+    """The merge cache is framework-written; a class body assigning it is a mistake."""
+    if CACHE_ATTR in cls.__dict__:
+        raise ValueError(
+            f"{cls.__name__} assigns {CACHE_ATTR} in its class body; the merge cache is "
+            f"framework-written and must never be declared."
+        )
+
+
+def _reader_inert_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
+    """Fields inert on a reader spec regardless of framework_set."""
+    return (
+        (
+            spec.match_guard is not None,
+            "declares a match_guard, which is name-matching machinery and silently inert on a reader.",
+        ),
+        (
+            spec.deferred_binding,
+            "declares deferred_binding=True, which is the name-capture exemption; a reader key has no name path.",
+        ),
+        (spec.context is False, "declares context=False, which places a materialized value; readers place none."),
+    )
+
+
+def _reader_framework_set_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
+    """Combinations that are inert once a reader spec declares framework_set=True."""
+    return (
+        (
+            spec.strict_validation,
+            "combines framework_set=True with strict_validation=True; the framework-written key is "
+            "exempt from user-value validation, so strictness would be silently inert.",
+        ),
+        (
+            spec.required_when is not None,
+            "combines framework_set=True with a required_when predicate; the framework-written key is "
+            "exempt from user-value validation, so the predicate would be silently inert.",
+        ),
+        (
+            spec.allow_explicit_none,
+            "combines framework_set=True with allow_explicit_none=True; the admit path skips the "
+            "framework-written key, so the flag cannot affect reader selection.",
+        ),
+        (
+            is_no_default(spec.default),
+            "declares framework_set=True without a declared default; the framework-written key must "
+            "declare its absent-state default explicitly, None included.",
+        ),
+    )
+
+
+def _feature_group_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
+    """Fields that are reader-only and therefore inert on a FeatureGroup spec."""
+    return (
+        (
+            spec.framework_set,
+            "declares framework_set=True, which marks a reader-only field; PROPERTY_MAPPING keys on a "
+            "FeatureGroup are user-set.",
+        ),
+        (
+            spec.scalar_only,
+            "declares scalar_only=True, which marks a reader-only field; PROPERTY_MAPPING keys on a "
+            "FeatureGroup always unpack element-wise.",
+        ),
+    )
+
+
+def validate_property_spec(
+    owner: str, key: str, spec: Any, surface: DeclarationSurface, via: str | None = None
+) -> PropertySpec:
+    """The per-key rules for one surface; via appends the reached-through suffix to any raised message."""
+    suffix = "" if via is None else f" (reached defining {via})"
+    if not isinstance(spec, PropertySpec):
+        raise ValueError(
+            f"{owner}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
+            f"Construct PropertySpec(...) or use the property_spec(...) helper.{suffix}"
+        )
+
+    checks = _feature_group_checks(spec) if surface is DeclarationSurface.FEATURE_GROUP else _reader_inert_checks(spec)
+    for triggered, message in checks:
+        if triggered:
+            raise ValueError(f"{owner}.PROPERTY_MAPPING['{key}'] {message}{suffix}")
+
+    if surface is DeclarationSurface.READER and spec.framework_set:
+        for triggered, message in _reader_framework_set_checks(spec):
+            if triggered:
+                raise ValueError(f"{owner}.PROPERTY_MAPPING['{key}'] {message}{suffix}")
+
+    return spec
+
+
+def validate_property_mapping(cls: type) -> None:
+    """Validate cls's own declaration, plus every plain mixin's, against the surface cls declares."""
+    base = surface_base(cls)
+    if base is None:
+        return
+    surface: DeclarationSurface = base.__dict__[SURFACE_ATTR]
+
+    for key, spec in own_property_mapping(cls).items():
+        validate_property_spec(cls.__name__, key, spec, surface)
+
+    for klass in cls.__mro__[1:]:
+        if base in klass.__mro__:
+            continue
+        for key, spec in own_property_mapping(klass).items():
+            validate_property_spec(klass.__name__, key, spec, surface, via=cls.__name__)

--- a/mloda/core/abstract_plugins/components/property_mapping.py
+++ b/mloda/core/abstract_plugins/components/property_mapping.py
@@ -1,6 +1,6 @@
 """The PROPERTY_MAPPING declaration surface shared by FeatureGroup and BaseInputData: MRO merge,
-per-class cache, author-time rules. Two surfaces, one attribute name and one spec type
-(``PropertySpec``); the surface (``DeclarationSurface``) only changes which fields are inert.
+per-class cache, and author-time rules. One attribute, one spec type; DeclarationSurface only
+changes which fields are inert.
 """
 
 from __future__ import annotations

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -25,6 +25,12 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     option_key_is_present,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+from mloda.core.abstract_plugins.components.property_mapping import (
+    DeclarationSurface,
+    merged_property_mapping,
+    reject_merge_cache_assignment,
+    validate_property_mapping,
+)
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
@@ -88,12 +94,12 @@ class FeatureGroup(ABC):
     for the full PROPERTY_MAPPING reference.
     """
 
-    PROPERTY_MAPPING: ClassVar[Optional[dict[str, PropertySpec]]] = None
+    PROPERTY_MAPPING_SURFACE: ClassVar[DeclarationSurface] = DeclarationSurface.FEATURE_GROUP
+
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {}
     """Override in subclasses to declare configurable parameters.
 
-    Each key is a parameter name. Each value is a ``PropertySpec`` carrying the
-    explanation, the value space (``allowed_values``), flags (``context``,
-    ``strict_validation``), and optional validators. See
+    Declarations merge across the class hierarchy, most-derived winning; see
     ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 
@@ -102,8 +108,9 @@ class FeatureGroup(ABC):
     The derived accessors below are ``@final`` (type-checker enforced) and derived from SUBTYPES."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
+        reject_merge_cache_assignment(cls)
         super().__init_subclass__(**kwargs)
-        FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
+        validate_property_mapping(cls)
         validate_name_binding(cls)
         warn_captureless_without_binding(cls)
         install_name_path_presence_guard(cls)
@@ -155,20 +162,24 @@ class FeatureGroup(ABC):
                     )
 
     @classmethod
+    def declared_option_specs(cls) -> dict[str, PropertySpec]:
+        """The MRO-merged PROPERTY_MAPPING declarations of cls, most-derived winning; a fresh copy."""
+        return dict(merged_property_mapping(cls))
+
+    @classmethod
     def declared_option_keys(cls) -> frozenset[str]:
         """Return the top-level parameter names declared in ``PROPERTY_MAPPING``."""
-        if cls.PROPERTY_MAPPING is None:
-            return frozenset()
-        return frozenset(str(key) for key in cls.PROPERTY_MAPPING)
+        return frozenset(str(key) for key in merged_property_mapping(cls))
 
     @final
     @classmethod
     def declared_option_values(cls, key: str) -> frozenset[str]:
         """Return the stringified enumerable value space of a ``PROPERTY_MAPPING`` key;
         predicate-only and absent keys yield an empty set."""
-        if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
+        mapping = merged_property_mapping(cls)
+        if key not in mapping:
             return frozenset()
-        extracted = FeatureChainParser.extract_property_values(cls.PROPERTY_MAPPING[key])
+        extracted = FeatureChainParser.extract_property_values(mapping[key])
         if not isinstance(extracted, (Mapping, Collection)) or isinstance(extracted, (str, bytes)):
             return frozenset()
         return frozenset(str(value) for value in extracted)
@@ -232,7 +243,7 @@ class FeatureGroup(ABC):
                     return parsed
 
         key = declaration.key
-        spec = (cls.PROPERTY_MAPPING or {}).get(key)
+        spec = merged_property_mapping(cls).get(key)
         value = cls.options_with_defaults(options).get(key)
         if value is None:
             return None
@@ -251,7 +262,7 @@ class FeatureGroup(ABC):
     def options_with_defaults(cls, options: Options) -> Options:
         """Return an Options with every absent PROPERTY_MAPPING key that declares a concrete default
         materialized from its spec (context or group per the spec); present values are never overridden (#766)."""
-        mapping = cls.PROPERTY_MAPPING or {}
+        mapping = merged_property_mapping(cls)
         memo: dict[int, Any] = {}
         fills_group: dict[str, Any] = {}
         fills_context: dict[str, Any] = {}

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -29,6 +29,7 @@ from mloda.core.abstract_plugins.components.property_mapping import (
     DeclarationSurface,
     merged_property_mapping,
     reject_merge_cache_assignment,
+    reject_surface_marker_assignment,
     validate_property_mapping,
 )
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
@@ -109,6 +110,7 @@ class FeatureGroup(ABC):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         reject_merge_cache_assignment(cls)
+        reject_surface_marker_assignment(cls)
         super().__init_subclass__(**kwargs)
         validate_property_mapping(cls)
         validate_name_binding(cls)

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -98,11 +98,8 @@ class FeatureGroup(ABC):
     PROPERTY_MAPPING_SURFACE: ClassVar[DeclarationSurface] = DeclarationSurface.FEATURE_GROUP
 
     PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {}
-    """Override in subclasses to declare configurable parameters.
-
-    Declarations merge across the class hierarchy, most-derived winning; see
-    ``docs/in_depth/property-mapping.md`` for the full specification.
-    """
+    """Override in subclasses to declare configurable parameters; declarations merge across the
+    class hierarchy, most-derived winning. See ``docs/in_depth/property-mapping.md``."""
 
     SUBTYPES: ClassVar[Optional[SubtypeDeclaration]] = None
     """Declarative subtype dimension of the family; ``None`` means no subtype dimension.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -9,6 +9,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import option_key_is_present
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
+from mloda.core.abstract_plugins.components.property_mapping import merged_property_mapping
 from mloda.core.abstract_plugins.components.utils import as_str, safe_field
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options, _isolate_forwarded_value
@@ -285,7 +286,7 @@ class GlobalFilter:
         """
         if feature_group is None:
             return None
-        spec = feature_group.declared_option_specs().get(key)
+        spec = merged_property_mapping(feature_group).get(key)
         if spec is None or is_no_default(spec.default) or spec.default is None:
             return None
         # Absence, not None-ness: an allow_explicit_none key is present, so its None survives.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -285,7 +285,7 @@ class GlobalFilter:
         """
         if feature_group is None:
             return None
-        spec = (feature_group.PROPERTY_MAPPING or {}).get(key)
+        spec = feature_group.declared_option_specs().get(key)
         if spec is None or is_no_default(spec.default) or spec.default is None:
             return None
         # Absence, not None-ness: an allow_explicit_none key is present, so its None survives.

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -24,7 +24,7 @@ class ReadDB(BaseInputData):
 
     _auto_load_group: str = "feature_group/input_data/read_dbs"
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         "data_access_handle": PropertySpec(
             "Hint naming which DataAccessCollection credentials handle to prefer while matching.",
             default=None,

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -35,7 +35,7 @@ class ReadDocument(BaseInputData):
 
     _auto_load_group: str = "feature_group/input_data/read_files"
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         "document_suffixes": PropertySpec(
             "Structured suffixes this document reader claims instead of leaving them to ReadFile.",
             default=frozenset(),

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -40,7 +40,7 @@ class ReadFile(BaseInputData):
 
     _auto_load_group: str = "feature_group/input_data/read_files"
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         "document_suffixes": PropertySpec(
             "Suffixes handed over to document readers; ReadFile auto-excludes them from its own matching.",
             default=frozenset(),

--- a/tests/test_core/test_abstract_plugins/test_components/test_owned_content_decline_gates_name_rules.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_owned_content_decline_gates_name_rules.py
@@ -436,5 +436,5 @@ class TestModuleLeakPolicy:
                 if spec.framework_set:
                     continue
                 assert not (is_no_default(spec.default) and spec.required_when is None), (
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] would fire on every foreign probe"
+                    f"{cls.__name__}.PROPERTY_MAPPING['{key}'] would fire on every foreign probe"
                 )

--- a/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
@@ -1,0 +1,546 @@
+"""Pins the shared PROPERTY_MAPPING declaration-surface module (Phase 1 of issue #949 follow-up):
+the merge/validation machinery both ``BaseInputData`` (READER, this phase) and, later, ``FeatureGroup``
+(FEATURE_GROUP, phase 2) build on. Plain classes exercise the generic mechanics; ``BaseInputData``
+subclasses exercise the READER surface wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.property_mapping import (
+    CACHE_ATTR,
+    SURFACE_ATTR,
+    DeclarationSurface,
+    configuration_property_mapping,
+    declares_property_mapping,
+    merged_property_mapping,
+    own_property_mapping,
+    reject_merge_cache_assignment,
+    validate_property_mapping,
+    validate_property_spec,
+)
+
+
+def _pmsurf_match_guard(value: Any) -> bool:
+    """A match_guard predicate; only its presence on a spec matters here."""
+    return True
+
+
+def _pmsurf_required_when(options: Any) -> bool:
+    """A required_when predicate; only its presence on a spec matters here."""
+    return False
+
+
+class TestDeclarationSurfaceEnum:
+    """The enum names the two declaration surfaces by their base class."""
+
+    def test_feature_group_member_value(self) -> None:
+        assert DeclarationSurface.FEATURE_GROUP.value == "FeatureGroup"
+
+    def test_reader_member_value(self) -> None:
+        assert DeclarationSurface.READER.value == "BaseInputData"
+
+    def test_exactly_two_members(self) -> None:
+        assert {member.name for member in DeclarationSurface} == {"FEATURE_GROUP", "READER"}
+
+
+class TestSurfaceAndCacheAttrConstants:
+    """The attribute-name constants, and BaseInputData's own use of ``SURFACE_ATTR``."""
+
+    def test_surface_attr_constant(self) -> None:
+        assert SURFACE_ATTR == "PROPERTY_MAPPING_SURFACE"
+
+    def test_cache_attr_constant(self) -> None:
+        assert CACHE_ATTR == "_property_mapping_cache"
+
+    def test_base_input_data_declares_the_reader_surface_in_its_own_dict(self) -> None:
+        """The surface base sets the attribute in its own class body, not merely inherits it."""
+        assert BaseInputData.__dict__[SURFACE_ATTR] is DeclarationSurface.READER
+
+    def test_base_input_data_surface_attribute_reads_the_same_value(self) -> None:
+        assert BaseInputData.PROPERTY_MAPPING_SURFACE is DeclarationSurface.READER
+
+
+class TestOwnPropertyMapping:
+    """``own_property_mapping`` reads exactly the class's OWN ``__dict__``, never the merge."""
+
+    def test_no_own_declaration_returns_empty_dict(self) -> None:
+        class PmsurfNoOwnDecl:
+            pass
+
+        assert own_property_mapping(PmsurfNoOwnDecl) == {}
+
+    def test_own_dict_declaration_is_returned(self) -> None:
+        spec = PropertySpec("x", default=None)
+
+        class PmsurfOwnDictDecl:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_a": spec}
+
+        assert own_property_mapping(PmsurfOwnDictDecl) == {"pmsurf_a": spec}
+
+    def test_none_own_declaration_raises_naming_the_class_with_the_merge_remedy(self) -> None:
+        class PmsurfNoneOwnDecl:
+            PROPERTY_MAPPING = None
+
+        with pytest.raises(ValueError) as exc_info:
+            own_property_mapping(PmsurfNoneOwnDecl)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfNoneOwnDecl" in message
+        assert "hierarchy" in message
+        assert "inherited" in message
+        assert "None" in message
+
+    def test_non_dict_own_declaration_raises_naming_the_type(self) -> None:
+        class PmsurfListOwnDecl:
+            PROPERTY_MAPPING = ["not", "a", "dict"]
+
+        with pytest.raises(ValueError) as exc_info:
+            own_property_mapping(PmsurfListOwnDecl)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfListOwnDecl.PROPERTY_MAPPING is a list, not a dict." in message
+
+    def test_non_dict_int_own_declaration_raises_naming_the_type(self) -> None:
+        class PmsurfIntOwnDecl:
+            PROPERTY_MAPPING = 42
+
+        with pytest.raises(ValueError) as exc_info:
+            own_property_mapping(PmsurfIntOwnDecl)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfIntOwnDecl.PROPERTY_MAPPING is a int, not a dict." in message
+
+
+class TestMergedPropertyMapping:
+    """Reversed-MRO merge, most-derived winning, cached in the class's own ``__dict__``."""
+
+    def test_parent_only_declaration_merges_alone(self) -> None:
+        a_spec = PropertySpec("a", default="parent_a")
+
+        class PmsurfMergeParentOnly:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_a": a_spec}
+
+        assert merged_property_mapping(PmsurfMergeParentOnly) == {"pmsurf_a": a_spec}
+
+    def test_child_merges_parent_and_own_keys(self) -> None:
+        a_spec = PropertySpec("a", default="parent_a")
+        b_spec = PropertySpec("b", default="child_b")
+
+        class PmsurfMergeParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_a": a_spec}
+
+        class PmsurfMergeChild(PmsurfMergeParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_b": b_spec}
+
+        assert merged_property_mapping(PmsurfMergeChild) == {"pmsurf_a": a_spec, "pmsurf_b": b_spec}
+
+    def test_most_derived_declaration_wins_on_a_key_collision(self) -> None:
+        parent_spec = PropertySpec("a", default="parent")
+        child_spec = PropertySpec("a", default="child")
+
+        class PmsurfCollideParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_key": parent_spec}
+
+        class PmsurfCollideChild(PmsurfCollideParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_key": child_spec}
+
+        assert merged_property_mapping(PmsurfCollideChild)["pmsurf_key"] is child_spec
+        assert merged_property_mapping(PmsurfCollideParent)["pmsurf_key"] is parent_spec
+
+    def test_child_declaration_does_not_leak_into_the_parent(self) -> None:
+        class PmsurfLeakParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {}
+
+        class PmsurfLeakChild(PmsurfLeakParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_only_child": PropertySpec("x", default=None),
+            }
+
+        assert "pmsurf_only_child" not in merged_property_mapping(PmsurfLeakParent)
+
+    def test_cache_lives_in_the_class_own_dict(self) -> None:
+        class PmsurfCacheClass:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_k": PropertySpec("x", default=None)}
+
+        merged_property_mapping(PmsurfCacheClass)
+
+        assert CACHE_ATTR in PmsurfCacheClass.__dict__
+
+    def test_a_subclass_defined_after_a_warm_parent_cache_sees_its_own_declaration(self) -> None:
+        class PmsurfColdParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_cache_key": PropertySpec("p", default="parent"),
+            }
+
+        assert merged_property_mapping(PmsurfColdParent)["pmsurf_cache_key"].default == "parent"
+
+        class PmsurfLateChild(PmsurfColdParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_cache_key": PropertySpec("c", default="child"),
+            }
+
+        assert merged_property_mapping(PmsurfLateChild)["pmsurf_cache_key"].default == "child"
+        assert merged_property_mapping(PmsurfColdParent)["pmsurf_cache_key"].default == "parent"
+
+    def test_a_key_added_by_a_late_subclass_is_visible_after_a_warm_parent_cache(self) -> None:
+        class PmsurfKeysParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_parent_key": PropertySpec("Parent only.", default=None),
+            }
+
+        assert set(merged_property_mapping(PmsurfKeysParent)) == {"pmsurf_parent_key"}
+
+        class PmsurfKeysChild(PmsurfKeysParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_child_key": PropertySpec("Child only.", default=None),
+            }
+
+        assert set(merged_property_mapping(PmsurfKeysChild)) == {"pmsurf_parent_key", "pmsurf_child_key"}
+        assert "pmsurf_child_key" not in merged_property_mapping(PmsurfKeysParent)
+
+    def test_repeated_reads_return_the_same_cached_object(self) -> None:
+        """Internal accessor: the SAME cached dict is handed back; a caller-facing wrapper copies it."""
+
+        class PmsurfRepeat:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_k": PropertySpec("x", default=None)}
+
+        first = merged_property_mapping(PmsurfRepeat)
+        second = merged_property_mapping(PmsurfRepeat)
+
+        assert first is second
+
+
+class TestDeclaresPropertyMapping:
+    """True when some class OTHER THAN the surface base declares its own PROPERTY_MAPPING."""
+
+    def test_false_when_only_the_surface_base_declares(self) -> None:
+        class PmsurfNoOwnReader(BaseInputData):
+            pass
+
+        assert declares_property_mapping(PmsurfNoOwnReader) is False
+
+    def test_true_for_a_non_empty_own_declaration(self) -> None:
+        class PmsurfOwnReader(BaseInputData):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_k": PropertySpec("x", default=None),
+            }
+
+        assert declares_property_mapping(PmsurfOwnReader) is True
+
+    def test_true_for_an_explicit_empty_own_declaration(self) -> None:
+        class PmsurfEmptyDeclReader(BaseInputData):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {}
+
+        assert declares_property_mapping(PmsurfEmptyDeclReader) is True
+
+    def test_true_for_a_plain_mixin_declaration_in_the_mro(self) -> None:
+        class PmsurfDeclaresMixin:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_mixin_k": PropertySpec("x", default=None),
+            }
+
+        class PmsurfMixinReader(PmsurfDeclaresMixin, BaseInputData):
+            pass
+
+        assert declares_property_mapping(PmsurfMixinReader) is True
+
+    def test_plain_hierarchy_without_a_surface_base_counts_any_own_declaration(self) -> None:
+        class PmsurfPlainBase:
+            pass
+
+        class PmsurfPlainChild(PmsurfPlainBase):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_k": PropertySpec("x", default=None),
+            }
+
+        assert declares_property_mapping(PmsurfPlainChild) is True
+        assert declares_property_mapping(PmsurfPlainBase) is False
+
+
+class TestConfigurationPropertyMapping:
+    """``None`` when nothing is declared beyond the surface base, else the merged mapping."""
+
+    def test_none_when_declares_property_mapping_is_false(self) -> None:
+        class PmsurfConfigNoneReader(BaseInputData):
+            pass
+
+        assert configuration_property_mapping(PmsurfConfigNoneReader) is None
+
+    def test_merged_result_when_declares_property_mapping_is_true(self) -> None:
+        spec = PropertySpec("x", default=None)
+
+        class PmsurfConfigReader(BaseInputData):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_config_k": spec}
+
+        result = configuration_property_mapping(PmsurfConfigReader)
+
+        assert result is not None
+        assert result["pmsurf_config_k"] is spec
+
+
+class TestRejectMergeCacheAssignment:
+    """The merge cache is framework-written; a class body assigning it is rejected where written."""
+
+    def test_raises_when_cache_attr_present_in_own_dict(self) -> None:
+        class PmsurfCacheAssign:
+            _property_mapping_cache: ClassVar[Any] = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            reject_merge_cache_assignment(PmsurfCacheAssign)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfCacheAssign" in message
+        assert "_property_mapping_cache" in message
+        assert "framework" in message
+
+    def test_no_raise_when_cache_attr_absent(self) -> None:
+        class PmsurfNoCacheAssign:
+            pass
+
+        reject_merge_cache_assignment(PmsurfNoCacheAssign)
+
+
+class TestValidatePropertySpec:
+    """The per-key rules, parametrized by surface; ``via`` appends the reached-through suffix."""
+
+    def test_non_property_spec_value_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", "not a spec", DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert message == (
+            "PmsurfOwner.PROPERTY_MAPPING['pmsurf_key'] is a str, not a PropertySpec. "
+            "Construct PropertySpec(...) or use the property_spec(...) helper."
+        )
+
+    def test_non_property_spec_value_rejected_on_feature_group_surface_too(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", 42, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfOwner.PROPERTY_MAPPING['pmsurf_key'] is a int, not a PropertySpec." in message
+
+    def test_via_suffix_is_appended(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfMixin", "pmsurf_key", 42, DeclarationSurface.READER, via="PmsurfReader")
+
+        message = str(exc_info.value)
+        del exc_info
+        assert message.endswith(" (reached defining PmsurfReader)")
+
+    def test_no_via_suffix_when_via_is_none(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", 42, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "(reached defining" not in message
+
+    def test_feature_group_rejects_framework_set(self) -> None:
+        spec = PropertySpec("x", default=None, framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "reader-only" in message
+
+    def test_feature_group_rejects_scalar_only(self) -> None:
+        spec = PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, scalar_only=True, default="a")
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "scalar_only" in message
+        assert "reader-only" in message
+
+    def test_reader_rejects_match_guard(self) -> None:
+        spec = PropertySpec("x", match_guard=_pmsurf_match_guard, default=None)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "match_guard" in message
+
+    def test_reader_rejects_deferred_binding(self) -> None:
+        spec = PropertySpec("x", deferred_binding=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "deferred_binding" in message
+
+    def test_reader_rejects_context_false(self) -> None:
+        spec = PropertySpec("x", context=False, default=None)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "context" in message
+
+    def test_reader_rejects_framework_set_with_strict_validation(self) -> None:
+        spec = PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, default="a", framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "strict_validation" in message
+
+    def test_reader_rejects_framework_set_with_required_when(self) -> None:
+        spec = PropertySpec("x", required_when=_pmsurf_required_when, default=None, framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "required_when" in message
+
+    def test_reader_rejects_framework_set_with_allow_explicit_none(self) -> None:
+        spec = PropertySpec("x", allow_explicit_none=True, default=None, framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "allow_explicit_none" in message
+
+    def test_reader_rejects_framework_set_with_no_declared_default(self) -> None:
+        spec = PropertySpec("x", framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "default" in message
+
+    def test_reader_accepts_framework_set_with_none_default(self) -> None:
+        spec = PropertySpec("x", default=None, framework_set=True)
+
+        result = validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        assert result is spec
+
+    def test_feature_group_accepts_match_guard(self) -> None:
+        spec = PropertySpec("x", match_guard=_pmsurf_match_guard, default=None)
+
+        result = validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        assert result is spec
+
+    def test_feature_group_accepts_context_false(self) -> None:
+        spec = PropertySpec("x", context=False, default=None)
+
+        result = validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        assert result is spec
+
+    def test_reader_accepts_scalar_only_strict_with_allowed_values(self) -> None:
+        spec = PropertySpec("x", scalar_only=True, strict_validation=True, allowed_values=("a", "b"), default="a")
+
+        result = validate_property_spec("PmsurfOwner", "pmsurf_key", spec, DeclarationSurface.READER)
+
+        assert result is spec
+
+    def test_no_message_ever_mentions_the_retired_reader_options_spelling(self) -> None:
+        """All error text says PROPERTY_MAPPING, never the retired READER_OPTIONS spelling."""
+        messages = []
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("PmsurfOwner", "pmsurf_key", "bad", DeclarationSurface.READER)
+        messages.append(str(exc_info.value))
+        del exc_info
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec(
+                "PmsurfOwner",
+                "pmsurf_key",
+                PropertySpec("x", framework_set=True, default=None),
+                DeclarationSurface.FEATURE_GROUP,
+            )
+        messages.append(str(exc_info.value))
+        del exc_info
+
+        for message in messages:
+            assert "READER_OPTIONS" not in message
+
+
+class TestValidatePropertyMapping:
+    """Class-definition validation for a class whose MRO contains a surface base (here: BaseInputData)."""
+
+    def test_a_mixin_reader_invalid_spec_is_rejected_with_via_naming_the_subclass(self) -> None:
+        class PmsurfBadMixin:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_bad_key": PropertySpec("Guarded.", match_guard=_pmsurf_match_guard, default=None),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfBadMixinReader(PmsurfBadMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfBadMixin" in message
+        assert "pmsurf_bad_key" in message
+        assert "match_guard" in message
+        assert "(reached defining PmsurfBadMixinReader)" in message
+
+    def test_a_valid_mixin_declaration_defines_fine_and_merges(self) -> None:
+        spec = PropertySpec("Valid, declared on the mixin.", default="pmsurf_mixin_default")
+
+        class PmsurfGoodMixin:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmsurf_good_key": spec}
+
+        class PmsurfGoodMixinReader(PmsurfGoodMixin, BaseInputData):
+            pass
+
+        assert merged_property_mapping(PmsurfGoodMixinReader)["pmsurf_good_key"] is spec
+
+    def test_own_none_declaration_on_cls_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfNoneOwnReader(BaseInputData):
+                PROPERTY_MAPPING = None  # type: ignore[assignment]  # invalid shape is the point
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfNoneOwnReader" in message
+
+    def test_direct_call_on_a_clean_subclass_does_not_raise(self) -> None:
+        class PmsurfCleanReader(BaseInputData):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_clean_key": PropertySpec("Valid.", default=None),
+            }
+
+        validate_property_mapping(PmsurfCleanReader)

--- a/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
@@ -1,7 +1,7 @@
-"""Pins the shared PROPERTY_MAPPING declaration-surface module (Phase 1 of issue #949 follow-up):
-the merge/validation machinery both ``BaseInputData`` (READER, this phase) and, later, ``FeatureGroup``
-(FEATURE_GROUP, phase 2) build on. Plain classes exercise the generic mechanics; ``BaseInputData``
-subclasses exercise the READER surface wiring.
+"""Pins the shared PROPERTY_MAPPING declaration-surface module: the merge/validation machinery
+both ``BaseInputData`` (READER surface) and ``FeatureGroup`` (FEATURE_GROUP surface) build on.
+Plain classes exercise the generic mechanics; ``BaseInputData`` subclasses exercise the READER
+surface wiring.
 """
 
 from __future__ import annotations

--- a/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
@@ -24,6 +24,7 @@ from mloda.core.abstract_plugins.components.property_mapping import (
     validate_property_mapping,
     validate_property_spec,
 )
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
 
 def _pmsurf_match_guard(value: Any) -> bool:
@@ -544,3 +545,131 @@ class TestValidatePropertyMapping:
             }
 
         validate_property_mapping(PmsurfCleanReader)
+
+
+class TestSurfaceMarkerIsFrameworkOwned:
+    """PROPERTY_MAPPING_SURFACE is framework-written; a class body assigning it is rejected."""
+
+    def test_feature_group_subclass_assigning_surface_marker_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfFgAssignsSurface(FeatureGroup):
+                PROPERTY_MAPPING_SURFACE = DeclarationSurface.FEATURE_GROUP
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfFgAssignsSurface" in message
+        assert SURFACE_ATTR in message
+
+    def test_base_input_data_subclass_assigning_surface_marker_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfReaderAssignsSurface(BaseInputData):
+                PROPERTY_MAPPING_SURFACE = "not_a_real_surface"  # type: ignore[assignment]  # invalid shape is the point
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfReaderAssignsSurface" in message
+        assert SURFACE_ATTR in message
+
+    def test_mixin_carrying_surface_marker_mixed_into_feature_group_raises(self) -> None:
+        class PmsurfMixinAssignsSurface:
+            PROPERTY_MAPPING_SURFACE = DeclarationSurface.FEATURE_GROUP
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfMixinSurfaceMixed(PmsurfMixinAssignsSurface, FeatureGroup):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfMixinAssignsSurface" in message
+        assert SURFACE_ATTR in message
+
+
+class TestTwoSurfaceBasesInOneMroAreRejected:
+    """A class whose MRO carries two distinct surface bases (FeatureGroup and BaseInputData) is
+    an author mistake: exactly one surface may govern PROPERTY_MAPPING validation for a class."""
+
+    def test_feature_group_then_base_input_data_raises(self) -> None:
+        """Naming SURFACE_ATTR pins the dedicated two-surface-bases guard, not an unrelated,
+        incidental rejection (e.g. the reader's framework_set key looking FeatureGroup-invalid)."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfTwoBasesFgFirst(FeatureGroup, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfTwoBasesFgFirst" in message
+        assert "FeatureGroup" in message
+        assert "BaseInputData" in message
+        assert SURFACE_ATTR in message
+
+    def test_base_input_data_then_feature_group_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmsurfTwoBasesReaderFirst(BaseInputData, FeatureGroup):  # type: ignore[misc]  # wrong shape is the point
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmsurfTwoBasesReaderFirst" in message
+        assert "FeatureGroup" in message
+        assert "BaseInputData" in message
+        assert SURFACE_ATTR in message
+
+
+class TestCooperativeHookReadingBeforeSuperIsNotBlamed:
+    """A mixin's __init_subclass__ may read the merge before calling super(); that warm read must
+    not be mistaken for the class body itself assigning the merge cache."""
+
+    def test_feature_group_side_mixin_reading_before_super_defines_fine(self) -> None:
+        class PmsurfFgEarlyReadMixin:
+            def __init_subclass__(cls, **kwargs: Any) -> None:
+                cls.declared_option_keys()  # type: ignore[attr-defined]
+                super().__init_subclass__(**kwargs)
+
+        class PmsurfFgEarlyReadSub(PmsurfFgEarlyReadMixin, FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_early_fg_key": PropertySpec("x", default=None),
+            }
+
+        result = PmsurfFgEarlyReadSub.declared_option_keys()
+        del PmsurfFgEarlyReadSub
+        del PmsurfFgEarlyReadMixin
+
+        assert "pmsurf_early_fg_key" in result
+
+    def test_reader_side_mixin_reading_before_super_defines_fine(self) -> None:
+        class PmsurfReaderEarlyReadMixin:
+            def __init_subclass__(cls, **kwargs: Any) -> None:
+                cls.declared_reader_option_keys()  # type: ignore[attr-defined]
+                super().__init_subclass__(**kwargs)
+
+        class PmsurfReaderEarlyReadSub(PmsurfReaderEarlyReadMixin, BaseInputData):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_early_reader_key": PropertySpec("x", default=None),
+            }
+
+        result = PmsurfReaderEarlyReadSub.declared_reader_option_keys()
+        del PmsurfReaderEarlyReadSub
+        del PmsurfReaderEarlyReadMixin
+
+        assert "pmsurf_early_reader_key" in result
+
+
+class TestConfigurationPropertyMappingHotPath:
+    """The hot path hands back the cached merged mapping directly (``is``), not a fresh copy."""
+
+    def test_repeated_calls_return_the_same_cached_object(self) -> None:
+        class PmsurfHotPathClass(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmsurf_hot_key": PropertySpec("x", default=None),
+            }
+
+        first = configuration_property_mapping(PmsurfHotPathClass)
+        second = configuration_property_mapping(PmsurfHotPathClass)
+        del PmsurfHotPathClass
+
+        assert first is second

--- a/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_property_mapping_surface.py
@@ -1,7 +1,6 @@
 """Pins the shared PROPERTY_MAPPING declaration-surface module: the merge/validation machinery
-both ``BaseInputData`` (READER surface) and ``FeatureGroup`` (FEATURE_GROUP surface) build on.
-Plain classes exercise the generic mechanics; ``BaseInputData`` subclasses exercise the READER
-surface wiring.
+both ``BaseInputData`` and ``FeatureGroup`` build on. Plain classes exercise the generic
+mechanics; ``BaseInputData`` subclasses exercise the READER surface wiring.
 """
 
 from __future__ import annotations
@@ -28,18 +27,14 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
 
 def _pmsurf_match_guard(value: Any) -> bool:
-    """A match_guard predicate; only its presence on a spec matters here."""
     return True
 
 
 def _pmsurf_required_when(options: Any) -> bool:
-    """A required_when predicate; only its presence on a spec matters here."""
     return False
 
 
 class TestDeclarationSurfaceEnum:
-    """The enum names the two declaration surfaces by their base class."""
-
     def test_feature_group_member_value(self) -> None:
         assert DeclarationSurface.FEATURE_GROUP.value == "FeatureGroup"
 
@@ -51,8 +46,6 @@ class TestDeclarationSurfaceEnum:
 
 
 class TestSurfaceAndCacheAttrConstants:
-    """The attribute-name constants, and BaseInputData's own use of ``SURFACE_ATTR``."""
-
     def test_surface_attr_constant(self) -> None:
         assert SURFACE_ATTR == "PROPERTY_MAPPING_SURFACE"
 
@@ -474,7 +467,6 @@ class TestValidatePropertySpec:
         assert result is spec
 
     def test_no_message_ever_mentions_the_retired_reader_options_spelling(self) -> None:
-        """All error text says PROPERTY_MAPPING, never the retired READER_OPTIONS spelling."""
         messages = []
 
         with pytest.raises(ValueError) as exc_info:
@@ -548,8 +540,6 @@ class TestValidatePropertyMapping:
 
 
 class TestSurfaceMarkerIsFrameworkOwned:
-    """PROPERTY_MAPPING_SURFACE is framework-written; a class body assigning it is rejected."""
-
     def test_feature_group_subclass_assigning_surface_marker_raises(self) -> None:
         with pytest.raises(ValueError) as exc_info:
 
@@ -588,12 +578,8 @@ class TestSurfaceMarkerIsFrameworkOwned:
 
 
 class TestTwoSurfaceBasesInOneMroAreRejected:
-    """A class whose MRO carries two distinct surface bases (FeatureGroup and BaseInputData) is
-    an author mistake: exactly one surface may govern PROPERTY_MAPPING validation for a class."""
-
     def test_feature_group_then_base_input_data_raises(self) -> None:
-        """Naming SURFACE_ATTR pins the dedicated two-surface-bases guard, not an unrelated,
-        incidental rejection (e.g. the reader's framework_set key looking FeatureGroup-invalid)."""
+        """Naming SURFACE_ATTR pins the dedicated guard, not an incidental rejection elsewhere."""
         with pytest.raises(ValueError) as exc_info:
 
             class PmsurfTwoBasesFgFirst(FeatureGroup, BaseInputData):
@@ -621,8 +607,7 @@ class TestTwoSurfaceBasesInOneMroAreRejected:
 
 
 class TestCooperativeHookReadingBeforeSuperIsNotBlamed:
-    """A mixin's __init_subclass__ may read the merge before calling super(); that warm read must
-    not be mistaken for the class body itself assigning the merge cache."""
+    """A mixin's warm read before super() must not be mistaken for the class body assigning the cache."""
 
     def test_feature_group_side_mixin_reading_before_super_defines_fine(self) -> None:
         class PmsurfFgEarlyReadMixin:

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -1,4 +1,4 @@
-"""Pins the collapsed ``READER_OPTIONS`` surface on ``BaseInputData`` (issue #949): one spec type,
+"""Pins the collapsed ``PROPERTY_MAPPING`` surface on ``BaseInputData`` (issue #949): one spec type,
 ``PropertySpec`` plus ``framework_set``, read via ``reader_option`` / ``reader_option_default``.
 Leak policy: the throwaway readers here leak deliberately; none is final, so selection never collects them.
 """
@@ -17,6 +17,7 @@ import mloda.provider as mloda_provider
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_positive_int
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.property_mapping import validate_property_mapping
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 
@@ -42,7 +43,7 @@ def _decl_family() -> tuple[type[BaseInputData], type[BaseInputData], type[BaseI
     class RodDeclParentReader(BaseInputData):
         """Parent declaring key A only; inherits the reserved framework key."""
 
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             "rod_key_a": PropertySpec("Key A, declared on the parent.", default="parent_a"),
         }
 
@@ -53,14 +54,14 @@ def _decl_family() -> tuple[type[BaseInputData], type[BaseInputData], type[BaseI
     class RodDeclChildReader(RodDeclParentReader):
         """Child declaring key B only; A and the reserved key must still be visible."""
 
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             "rod_key_b": PropertySpec("Key B, declared on the child.", default="child_b"),
         }
 
     class RodDeclOverrideReader(RodDeclParentReader):
         """Child redeclaring key A with a different default; the most-derived declaration wins."""
 
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             "rod_key_a": PropertySpec("Key A, redeclared on the child.", default="child_a"),
         }
 
@@ -196,9 +197,9 @@ class TestReservedFrameworkKey:
 
     def test_base_declares_reader_options_locally(self) -> None:
         """The declaration lives on ``BaseInputData``, not only on some subclass."""
-        assert "READER_OPTIONS" in BaseInputData.__dict__
-        assert isinstance(BaseInputData.READER_OPTIONS, dict)
-        assert "BaseInputData" in BaseInputData.READER_OPTIONS
+        assert "PROPERTY_MAPPING" in BaseInputData.__dict__
+        assert isinstance(BaseInputData.PROPERTY_MAPPING, dict)
+        assert "BaseInputData" in BaseInputData.PROPERTY_MAPPING
 
     def test_declared_keys_contain_the_reserved_key(self) -> None:
         """``declared_reader_option_keys()`` on the base contains the reserved key."""
@@ -225,7 +226,8 @@ class TestReservedFrameworkKey:
 
     def test_base_declaration_passes_its_own_guard(self) -> None:
         """``__init_subclass__`` never validates the base itself; this pin keeps the base honest."""
-        BaseInputData._validate_reader_options()
+        validate_property_mapping(BaseInputData)
+        BaseInputData._validate_reserved_reader_option_key()
 
     def test_reserved_key_is_the_key_the_framework_actually_writes(self) -> None:
         """``add_base_input_data_to_options`` writes exactly the keys declared ``framework_set``.
@@ -436,7 +438,7 @@ class TestAllowExplicitNoneIsHonoured:
         """A fresh reader whose one key opts into explicit None."""
 
         class RodOptInNoneReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_opt_in_none_key": PropertySpec(
                     "Opts into explicit None.", default="declared", allow_explicit_none=True
                 ),
@@ -473,7 +475,7 @@ class TestNoDefaultMakesTheKeyRequired:
         """A fresh reader whose one key declares no default."""
 
         class RodRequiredKeyReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_required_key": PropertySpec("Required at read time; no declared fallback."),
             }
 
@@ -525,7 +527,7 @@ class TestReaderOptionToleratesNoneOptions:
         """The ``allow_explicit_none`` presence read (``key in options``) must tolerate None too."""
 
         class RodNoneOptionsOptInReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_none_opt_in_key": PropertySpec(
                     "Opts into explicit None.", default="declared", allow_explicit_none=True
                 ),
@@ -539,7 +541,7 @@ class TestReaderOptionToleratesNoneOptions:
         """A NO_DEFAULT key with no Options raises EXACTLY the absent-key ValueError."""
 
         class RodNoneOptionsRequiredReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_none_required_key": PropertySpec("Required at read time; no declared fallback."),
             }
 
@@ -570,14 +572,14 @@ class TestMergedSpecCacheStaysFresh:
         """Warming the parent must not answer for a child that redeclares the key."""
 
         class RodColdParentReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Declared on the parent.", default="parent"),
             }
 
         assert RodColdParentReader.reader_option("rod_cache_key", Options()) == "parent"
 
         class RodLateChildReader(RodColdParentReader):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Redeclared on the child.", default="child"),
             }
 
@@ -588,12 +590,12 @@ class TestMergedSpecCacheStaysFresh:
         """The reverse order: reading the child first leaves the parent's answer alone."""
 
         class RodParentReadSecond(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Declared on the parent.", default="parent"),
             }
 
         class RodChildReadFirst(RodParentReadSecond):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Redeclared on the child.", default="child"),
             }
 
@@ -604,14 +606,14 @@ class TestMergedSpecCacheStaysFresh:
         """``declared_reader_option_keys`` shares the cache, so it must not go stale either."""
 
         class RodKeysParentReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_parent_key": PropertySpec("Parent only.", default=None),
             }
 
         assert RodKeysParentReader.declared_reader_option_keys() == {"rod_cache_parent_key", "BaseInputData"}
 
         class RodKeysChildReader(RodKeysParentReader):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_child_key": PropertySpec("Child only.", default=None),
             }
 
@@ -626,7 +628,7 @@ class TestMergedSpecCacheStaysFresh:
         """The guard reads the cached mapping, so warming it cannot make a typo silent."""
 
         class RodWarmGuardReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Declared.", default="declared"),
             }
 
@@ -639,7 +641,7 @@ class TestMergedSpecCacheStaysFresh:
         """The caller-facing mapping stays a fresh copy: a cache must not be handed out by reference."""
 
         class RodCopyProbeReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Declared.", default="declared"),
             }
 
@@ -654,7 +656,7 @@ class TestMergedSpecCacheStaysFresh:
         """Caching is invisible: two reads of the same key on the same class agree."""
 
         class RodRepeatReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_key": PropertySpec("Declared.", default=frozenset({".json"})),
             }
 
@@ -666,14 +668,14 @@ class TestMergedSpecCacheStaysFresh:
 
 
 class TestReaderOptionsAreValidatedAtClassDefinition:
-    """``READER_OPTIONS`` accepts reader-shaped ``PropertySpec`` instances and NOTHING else, rejected where written."""
+    """``PROPERTY_MAPPING`` accepts reader-shaped ``PropertySpec`` instances and NOTHING else, rejected where written."""
 
     def test_string_value_rejected_at_class_definition(self) -> None:
         """``{"k": "just a string"}`` names the class, the key and the ``PropertySpec`` remedy."""
         with pytest.raises(ValueError) as exc_info:
 
             class RodBadStringSpecReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_bad_key": "just a string"}  # type: ignore[dict-item]  # wrong type is the point
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_bad_key": "just a string"}  # type: ignore[dict-item]  # wrong type is the point
 
         message = str(exc_info.value)
         del exc_info
@@ -686,7 +688,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodBadDictSpecReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_bad_key": {"explanation": "x", "default": None}  # type: ignore[dict-item]  # wrong type is the point
                 }
 
@@ -701,7 +703,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodBadIntSpecReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_bad_key": 42}  # type: ignore[dict-item]  # wrong type is the point
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_bad_key": 42}  # type: ignore[dict-item]  # wrong type is the point
 
         message = str(exc_info.value)
         del exc_info
@@ -714,7 +716,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodMatchGuardReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_guarded_key": PropertySpec("Guarded.", match_guard=_rod_match_guard, default=None),
                 }
 
@@ -729,7 +731,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodDeferredBindingReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_deferred_key": PropertySpec("Deferred.", deferred_binding=True),
                 }
 
@@ -744,7 +746,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodContextFalseReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_group_key": PropertySpec("Group-categorized.", context=False, default=None),
                 }
 
@@ -759,7 +761,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodContextZeroReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_zero_key": _spec("Group-categorized by stealth.", context=0, default=None),
                 }
 
@@ -773,7 +775,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodFrameworkStrictReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_fw_strict_key": PropertySpec(
                         "Framework-written.",
                         allowed_values=("a", "b"),
@@ -795,7 +797,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodFrameworkRequiredWhenReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_fw_required_key": PropertySpec(
                         "Framework-written.",
                         required_when=_rod_never_required,
@@ -816,7 +818,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodFrameworkNoDefaultReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_fw_bare_key": PropertySpec("Framework-written.", framework_set=True),
                 }
 
@@ -832,7 +834,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodFrameworkAllowNoneReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "rod_fw_allow_none_key": PropertySpec(
                         "Framework-written.",
                         allow_explicit_none=True,
@@ -853,7 +855,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodReservedShadowReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "BaseInputData": PropertySpec("shadowed", allow_explicit_none=True, default=None),
                 }
 
@@ -869,7 +871,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodReservedShadowNoDefaultReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "BaseInputData": PropertySpec("shadowed"),
                 }
 
@@ -885,7 +887,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         with pytest.raises(ValueError) as exc_info:
 
             class RodReservedShadowPlainReader(BaseInputData):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                     "BaseInputData": PropertySpec("shadowed", default=None),
                 }
 
@@ -900,7 +902,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """A plain mixin runs no guard of its own, yet wins the merge ahead of the base; the subclass must raise."""
 
         class RodShadowMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "BaseInputData": PropertySpec("shadowed"),
             }
 
@@ -920,7 +922,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """Base-first ordering ranks the mixin BELOW the base, so the framework declaration wins and nothing raises."""
 
         class RodLosingShadowMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "BaseInputData": PropertySpec("shadowed"),
             }
 
@@ -938,7 +940,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """Control: a legitimate redeclaration keeping the flag, a sharpened explanation, still defines."""
 
         class RodReservedKeptFrameworkReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "BaseInputData": PropertySpec(
                     "The matched (ReaderClass, data_access) pair, sharpened for this family.",
                     default=None,
@@ -954,7 +956,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """Strict specs are the point of the collapse; a valued one with an in-space default defines."""
 
         class RodStrictValuesReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_strict_values_key": PropertySpec(
                     "Strictly validated (value enforcement lands in cycle 2).",
                     allowed_values=("a", "b"),
@@ -969,7 +971,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """A validator-backed strict spec with a passing default defines fine too."""
 
         class RodStrictValidatorReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_strict_validator_key": PropertySpec(
                     "Validator-backed strict key.",
                     element_validator=is_positive_int,
@@ -984,7 +986,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """Control: the check rejects only reader-invalid specs, never a real declaration."""
 
         class RodValidSpecReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_valid_key": PropertySpec("Valid.", default=frozenset()),
             }
 
@@ -1002,7 +1004,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """An explicitly empty mapping declares nothing new and is not an error."""
 
         class RodEmptyDeclarationReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {}
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {}
 
         assert RodEmptyDeclarationReader.declared_reader_option_keys() == {"BaseInputData"}
 
@@ -1010,14 +1012,14 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         """The check runs per class, so inheriting a valid declaration does not buy a free pass."""
 
         class RodGoodBaseReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_good_key": PropertySpec("Valid.", default=None),
             }
 
         with pytest.raises(ValueError) as exc_info:
 
             class RodBadChildReader(RodGoodBaseReader):
-                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_bad_key": 42}  # type: ignore[dict-item]  # wrong type is the point
+                PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_bad_key": 42}  # type: ignore[dict-item]  # wrong type is the point
 
         message = str(exc_info.value)
         del exc_info
@@ -1026,13 +1028,13 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
 
 
 class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
-    """A plain mixin's ``READER_OPTIONS`` reaches the merge, so the subclass definition validates it too."""
+    """A plain mixin's ``PROPERTY_MAPPING`` reaches the merge, so the subclass definition validates it too."""
 
     def test_mixin_string_value_rejected_at_subclass_definition(self) -> None:
         """A non-spec mixin value raises where the subclass is written, naming the mixin and the key."""
 
         class RodStrValueMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_mixin_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_mixin_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
 
         with pytest.raises(ValueError) as exc_info:
 
@@ -1049,7 +1051,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         """A mixin spec declaring ``match_guard`` is rejected like an own declaration."""
 
         class RodGuardedMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_mixin_guarded_key": PropertySpec("Guarded.", match_guard=_rod_match_guard, default=None),
             }
 
@@ -1068,7 +1070,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         """The framework_set combination rules apply to a mixin declaration too."""
 
         class RodFrameworkStrictMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_mixin_fw_strict_key": PropertySpec(
                     "Framework-written.",
                     allowed_values=("a", "b"),
@@ -1094,7 +1096,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         """A mixin framework key without a declared default is rejected like an own one."""
 
         class RodFrameworkBareMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_mixin_fw_bare_key": PropertySpec("Framework-written.", framework_set=True),
             }
 
@@ -1114,7 +1116,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         """Control: a valid mixin spec passes the guard and its key merges into the subclass."""
 
         class RodValidMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_mixin_valid_key": PropertySpec("Valid, declared on the mixin.", default="mixin_default"),
             }
 
@@ -1124,7 +1126,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         assert "rod_mixin_valid_key" in RodValidMixinReader.declared_reader_option_keys()
         assert (
             RodValidMixinReader.reader_option_specs()["rod_mixin_valid_key"]
-            is RodValidMixin.READER_OPTIONS["rod_mixin_valid_key"]
+            is RodValidMixin.PROPERTY_MAPPING["rod_mixin_valid_key"]
         )
         assert RodValidMixinReader.reader_option_default("rod_mixin_valid_key") == "mixin_default"
 
@@ -1132,12 +1134,12 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         """The guard runs per class definition, so a valid parent buys no free pass for a bad mixin."""
 
         class RodDeepGoodReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_deep_good_key": PropertySpec("Valid.", default=None),
             }
 
         class RodDeepBadMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_deep_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_deep_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
 
         with pytest.raises(ValueError) as exc_info:
 
@@ -1163,7 +1165,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         class RodVirtRegisteredBadMixin:
             """Registered virtually below; never a real reader, so the registry leak stays inert."""
 
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_virt_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_virt_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
 
         BaseInputData.register(RodVirtRegisteredBadMixin)
 
@@ -1181,7 +1183,7 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
         """The error must name the class statement that triggered validation, not only the mixin."""
 
         class RodTrigBadMixin:
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_trig_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"rod_trig_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
 
         with pytest.raises(ValueError) as exc_info:
 
@@ -1195,26 +1197,26 @@ class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
 
 
 class TestNonMappingReaderOptionsAreRejected:
-    """A ``READER_OPTIONS`` that is not a dict is a loud ``ValueError`` where written, not an ``AttributeError``."""
+    """A ``PROPERTY_MAPPING`` that is not a dict is a loud ``ValueError`` where written, not an ``AttributeError``."""
 
     def test_a_list_valued_own_declaration_raises_value_error_naming_the_class(self) -> None:
         """A list-shaped own declaration is rejected as not-a-dict, naming the declaring class."""
         with pytest.raises(ValueError) as exc_info:
 
             class RodListOwnDeclReader(BaseInputData):
-                READER_OPTIONS = ["rod_list_entry"]  # type: ignore[assignment]  # wrong shape is the point
+                PROPERTY_MAPPING = ["rod_list_entry"]  # type: ignore[assignment]  # wrong shape is the point
 
         message = str(exc_info.value)
         del exc_info
         assert "RodListOwnDeclReader" in message
-        assert "READER_OPTIONS" in message
+        assert "PROPERTY_MAPPING" in message
         assert "dict" in message
 
     def test_a_list_valued_mixin_declaration_raises_value_error_naming_the_mixin(self) -> None:
         """A list-shaped mixin declaration reaching the merge is rejected the same way."""
 
         class RodListDeclMixin:
-            READER_OPTIONS = ["rod_list_entry"]
+            PROPERTY_MAPPING = ["rod_list_entry"]
 
         with pytest.raises(ValueError) as exc_info:
 
@@ -1224,38 +1226,38 @@ class TestNonMappingReaderOptionsAreRejected:
         message = str(exc_info.value)
         del exc_info
         assert "RodListDeclMixin" in message
-        assert "READER_OPTIONS" in message
+        assert "PROPERTY_MAPPING" in message
         assert "dict" in message
 
 
 class TestCacheAttributeAssignmentIsRejected:
-    """A class body assigning ``_reader_option_specs_cache`` bypasses the merge and is rejected where written."""
+    """A class body assigning ``_property_mapping_cache`` bypasses the merge and is rejected where written."""
 
     def test_dict_cache_assignment_rejected_at_class_definition(self) -> None:
         """A hand-built cache dict raises, naming the class and the attribute."""
         with pytest.raises(ValueError) as exc_info:
 
             class RodCacheAssignReader(BaseInputData):
-                _reader_option_specs_cache: ClassVar[dict[str, PropertySpec] | None] = {
+                _property_mapping_cache: ClassVar[dict[str, PropertySpec] | None] = {
                     "BaseInputData": PropertySpec("Shadowed.", default=None, framework_set=True),
                 }
 
         message = str(exc_info.value)
         del exc_info
         assert "RodCacheAssignReader" in message
-        assert "_reader_option_specs_cache" in message
+        assert "_property_mapping_cache" in message
 
     def test_none_cache_assignment_rejected_at_class_definition(self) -> None:
         """Even a ``None`` assignment is rejected; any class-body write to the cache is a mistake."""
         with pytest.raises(ValueError) as exc_info:
 
             class RodCacheNoneReader(BaseInputData):
-                _reader_option_specs_cache: ClassVar[dict[str, PropertySpec] | None] = None
+                _property_mapping_cache: ClassVar[dict[str, PropertySpec] | None] = None
 
         message = str(exc_info.value)
         del exc_info
         assert "RodCacheNoneReader" in message
-        assert "_reader_option_specs_cache" in message
+        assert "_property_mapping_cache" in message
 
     def test_a_cooperative_hook_warming_the_cache_is_not_rejected(self) -> None:
         """Only a class-body assignment is a mistake; a cooperative hook warming the cache defines fine."""
@@ -1275,7 +1277,7 @@ class TestCacheAttributeAssignmentIsRejected:
         """Control: only a class body writing the attribute is rejected, not ordinary subclassing."""
 
         class RodCacheUntouchedReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
                 "rod_cache_untouched_key": PropertySpec("Valid.", default=None),
             }
 
@@ -1300,3 +1302,46 @@ class TestDeclarationsDoNotAffectDiscovery:
 
         assert local, "expected this module's throwaway readers to be reachable through __subclasses__()"
         assert [cls.__name__ for cls in local if cls.is_final_reader()] == []
+
+
+class TestReaderOptionsIsAHardBreak:
+    """``READER_OPTIONS`` is retired outright (renamed to ``PROPERTY_MAPPING``): a class body still
+    writing the old name is a loud break at class definition, never silent inheritance."""
+
+    def test_a_subclass_declaring_reader_options_raises_naming_both_spellings(self) -> None:
+        """The rename is a hard break: the retired attribute name is rejected where it is written."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodHardBreakReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                    "rod_hard_break_key": PropertySpec("Old spelling.", default=None),
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "READER_OPTIONS" in message
+        assert "PROPERTY_MAPPING" in message
+        assert "RodHardBreakReader" in message
+
+    def test_a_mixin_declaring_reader_options_raises_naming_the_mixin(self) -> None:
+        """A plain mixin still using the retired spelling is rejected the same way, naming the mixin."""
+
+        class RodHardBreakMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_hard_break_mixin_key": PropertySpec("Old spelling on a mixin.", default=None),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodHardBreakMixinReader(RodHardBreakMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "READER_OPTIONS" in message
+        assert "PROPERTY_MAPPING" in message
+        assert "RodHardBreakMixin" in message
+
+    def test_base_input_data_no_longer_has_reader_options(self) -> None:
+        """The retired attribute is gone from the base itself, not merely shadowed by the new one."""
+        assert hasattr(BaseInputData, "READER_OPTIONS") is False

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -1305,10 +1305,10 @@ class TestDeclarationsDoNotAffectDiscovery:
 
 
 class TestReaderOptionsIsAHardBreak:
-    """``READER_OPTIONS`` is retired outright (renamed to ``PROPERTY_MAPPING``); a class body still writing the old name is a loud break at class definition, never silent inheritance."""
+    """A class body still writing the retired ``READER_OPTIONS`` name breaks loudly at class
+    definition, never silent inheritance."""
 
     def test_a_subclass_declaring_reader_options_raises_naming_both_spellings(self) -> None:
-        """The rename is a hard break: the retired attribute name is rejected where it is written."""
         with pytest.raises(ValueError) as exc_info:
 
             class RodHardBreakReader(BaseInputData):
@@ -1323,8 +1323,6 @@ class TestReaderOptionsIsAHardBreak:
         assert "RodHardBreakReader" in message
 
     def test_a_mixin_declaring_reader_options_raises_naming_the_mixin(self) -> None:
-        """A plain mixin still using the retired spelling is rejected the same way, naming the mixin."""
-
         class RodHardBreakMixin:
             READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
                 "rod_hard_break_mixin_key": PropertySpec("Old spelling on a mixin.", default=None),
@@ -1342,5 +1340,4 @@ class TestReaderOptionsIsAHardBreak:
         assert "RodHardBreakMixin" in message
 
     def test_base_input_data_no_longer_has_reader_options(self) -> None:
-        """The retired attribute is gone from the base itself, not merely shadowed by the new one."""
         assert hasattr(BaseInputData, "READER_OPTIONS") is False

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -1,4 +1,4 @@
-"""Pins the collapsed ``PROPERTY_MAPPING`` surface on ``BaseInputData`` (issue #949): one spec type,
+"""Pins the collapsed ``PROPERTY_MAPPING`` surface on ``BaseInputData``: one spec type,
 ``PropertySpec`` plus ``framework_set``, read via ``reader_option`` / ``reader_option_default``.
 Leak policy: the throwaway readers here leak deliberately; none is final, so selection never collects them.
 """
@@ -1305,8 +1305,7 @@ class TestDeclarationsDoNotAffectDiscovery:
 
 
 class TestReaderOptionsIsAHardBreak:
-    """``READER_OPTIONS`` is retired outright (renamed to ``PROPERTY_MAPPING``): a class body still
-    writing the old name is a loud break at class definition, never silent inheritance."""
+    """``READER_OPTIONS`` is retired outright (renamed to ``PROPERTY_MAPPING``); a class body still writing the old name is a loud break at class definition, never silent inheritance."""
 
     def test_a_subclass_declaring_reader_options_raises_naming_both_spellings(self) -> None:
         """The rename is a hard break: the retired attribute name is rejected where it is written."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
@@ -1,4 +1,4 @@
-"""Pins selection-time enforcement of ``READER_OPTIONS`` specs (issue #949, cycle 2): per-candidate
+"""Pins selection-time enforcement of ``PROPERTY_MAPPING`` specs (issue #949, cycle 2): per-candidate
 vetoes before the probe; absence vetoes record only on the feature-scope (ownership) path.
 Leak policy: leaked final readers are foreign-inert (TestModuleLeakPolicy pins it); absence-firing ones are test-local.
 """
@@ -124,7 +124,7 @@ class RoeStrictValuesReader(RoeStrictFamily):
     ROE_ACCESS = ROE_STRICT_ACCESS
     ROE_HANDLE = ROE_STRICT_HANDLE
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_FORMAT_KEY: PropertySpec(
             "Strict membership over a Mapping value space, so an unhashable value is a clean rejection.",
             allowed_values={"roe_csv": "comma separated", "roe_parquet": "columnar"},
@@ -149,7 +149,7 @@ class RoeScalarOnlyReader(_RoeMarkedReader):
 
     ROE_ACCESS = ROE_SCALAR_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_SCALAR_KEY: PropertySpec(
             "Scalar-only strict key: a container value is rejected before any element-wise check.",
             element_validator=is_positive_int,
@@ -169,7 +169,7 @@ class RoeValidatorReader(_RoeMarkedReader):
 
     ROE_ACCESS = ROE_VALIDATOR_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_COUNT_KEY: PropertySpec(
             "The declared element_validator REPLACES the also-declared membership space.",
             allowed_values=("roe_member",),
@@ -195,7 +195,7 @@ class RoeLenientReader(_RoeMarkedReader):
 
     ROE_ACCESS = ROE_LENIENT_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_LAX_KEY: PropertySpec(
             "Non-strict despite a declared value space; a present value is never validated.",
             allowed_values=("roe_only",),
@@ -220,7 +220,7 @@ class RoeConditionalReader(RoeCondFamily):
     ROE_ACCESS = ROE_COND_ACCESS
     ROE_HANDLE = ROE_COND_HANDLE
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_COND_KEY: PropertySpec("Required iff the trigger key is supplied.", required_when=_roe_trigger_required),
     }
 
@@ -234,7 +234,7 @@ class RoeRaisingPredicateReader(_RoeMarkedReader):
 
     ROE_ACCESS = ROE_FUSSY_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_FUSSY_KEY: PropertySpec("Requiredness undecidable by design.", required_when=_roe_raising_predicate),
     }
 
@@ -250,7 +250,7 @@ class RoeProbeCountingReader(_RoeMarkedReader):
 
     roe_calls: ClassVar[list[Any]] = []
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_PROBE_KEY: PropertySpec(
             "Strict key of the instrumented reader.",
             allowed_values=("roe_ok",),
@@ -285,7 +285,7 @@ class RoePairVetoedReader(RoePairVetoedFamily):
     ROE_ACCESS = ROE_PAIR_VETOED_ACCESS
     ROE_HANDLE = ROE_PAIR_HANDLE
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_PAIR_KEY: PropertySpec(
             "Strict key shared by the pair scenario.",
             allowed_values=("roe_ok",),
@@ -319,7 +319,7 @@ class RoeEngineReader(RoeEngineFamily):
 
     ROE_ACCESS = ROE_ENGINE_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         ROE_ENGINE_KEY: PropertySpec(
             "Strict key whose veto must surface as an input_data elimination.",
             allowed_values=("roe_ok",),
@@ -355,7 +355,7 @@ def _roe_required_family(tag: str) -> tuple[type[BaseInputData], type[BaseInputD
         ROE_ACCESS = ROE_REQUIRED_ACCESS
         ROE_HANDLE = ROE_REQUIRED_HANDLE
 
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             ROE_REQUIRED_KEY: PropertySpec("Unconditionally required: declares no default, no required_when."),
         }
 
@@ -376,7 +376,7 @@ def _roe_nullable_reader(tag: str) -> type[BaseInputData]:
     class RoeLocalNullableReader(_RoeMarkedReader):
         ROE_ACCESS = ROE_NULLABLE_ACCESS
 
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             ROE_NULLABLE_KEY: PropertySpec(
                 "Required, but an explicit None counts as present.", allow_explicit_none=True
             ),
@@ -961,5 +961,5 @@ class TestModuleLeakPolicy:
                 if spec.framework_set:
                     continue
                 assert not (is_no_default(spec.default) and spec.required_when is None), (
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] would fire on every foreign probe"
+                    f"{cls.__name__}.PROPERTY_MAPPING['{key}'] would fire on every foreign probe"
                 )

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
@@ -1,5 +1,5 @@
-"""Pins selection-time enforcement of ``PROPERTY_MAPPING`` specs (issue #949, cycle 2): per-candidate
-vetoes before the probe; absence vetoes record only on the feature-scope (ownership) path.
+"""Pins selection-time enforcement of ``PROPERTY_MAPPING`` specs: per-candidate vetoes before the
+probe; absence vetoes record only on the feature-scope (ownership) path.
 Leak policy: leaked final readers are foreign-inert (TestModuleLeakPolicy pins it); absence-firing ones are test-local.
 """
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_veto_gates_name_rules.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_veto_gates_name_rules.py
@@ -1,5 +1,5 @@
 """Pins issue #954, corrected: ONLY an OWNED reader veto (the user addressed the reader via its
-``data_access_name()`` key and its READER_OPTIONS declined) gates the name-based OR rules of
+``data_access_name()`` key and its PROPERTY_MAPPING declined) gates the name-based OR rules of
 ``match_feature_group_criteria``; unowned global-probe declines, the MatchData rule, sibling probing,
 input-data-free candidates and valid values keep resolving. Leaked vg954 fixtures stay foreign-inert."""
 
@@ -86,7 +86,7 @@ class Vg954GateReader(Vg954GateFamily):
 
     VG954_ACCESS = VG954_GATE_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         VG954_FORMAT_KEY: PropertySpec(
             "Strict membership key: it fires only on a PRESENT out-of-space value.",
             allowed_values=("vg954_ok",),
@@ -124,7 +124,7 @@ class Vg954VetoedSiblingReader(Vg954SiblingFamily):
 
     VG954_ACCESS = VG954_VETOED_ACCESS
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         VG954_SIBLING_KEY: PropertySpec(
             "Strict key of the vetoed sibling; module-level safe because it declares a default.",
             allowed_values=("vg954_ok",),
@@ -217,7 +217,7 @@ class Vg954UnownedReader(Vg954UnownedFamily):
     VG954_ACCESS = VG954_UNOWNED_ACCESS
     VG954_HANDLE = VG954_UNOWNED_HANDLE
 
-    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         VG954_UNOWNED_KEY: PropertySpec(
             "Strict membership key with a default, so it is not absence-firing and stays module-level safe.",
             allowed_values=("vg954_ok",),
@@ -276,7 +276,7 @@ def _vg954_required_setup(tag: str) -> tuple[type[BaseInputData], type[FeatureGr
     class Vg954LocalRequiredReader(Vg954LocalRequiredFamily):
         VG954_ACCESS = VG954_REQUIRED_ACCESS
 
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             VG954_REQUIRED_KEY: PropertySpec("Unconditionally required: declares no default, no required_when."),
         }
 
@@ -497,5 +497,5 @@ class TestModuleLeakPolicy:
                 if spec.framework_set:
                     continue
                 assert not (is_no_default(spec.default) and spec.required_when is None), (
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] would fire on every foreign probe"
+                    f"{cls.__name__}.PROPERTY_MAPPING['{key}'] would fire on every foreign probe"
                 )

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
@@ -12,11 +12,11 @@ from mloda.provider import FeatureGroup, PropertySpec, property_spec
 
 
 class DefaultMappingFeatureGroup(FeatureGroup):
-    """No PROPERTY_MAPPING override -- exercises the None default."""
+    """No PROPERTY_MAPPING override -- exercises the empty default."""
 
 
 class EmptyMappingFeatureGroup(FeatureGroup):
-    """PROPERTY_MAPPING explicitly set to an empty dict -- distinct from the None default."""
+    """PROPERTY_MAPPING explicitly set to an empty dict -- the explicit empty declaration."""
 
     PROPERTY_MAPPING = {}
 
@@ -70,8 +70,8 @@ class MultiKeyMappingFeatureGroup(FeatureGroup):
     }
 
 
-def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_none() -> None:
-    """PROPERTY_MAPPING unset (None, the default) yields an empty frozenset."""
+def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_undeclared() -> None:
+    """PROPERTY_MAPPING unset (the default) yields an empty frozenset."""
     result = DefaultMappingFeatureGroup.declared_option_keys()
 
     assert result == frozenset()

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
@@ -1,8 +1,7 @@
 """Pins the FeatureGroup PROPERTY_MAPPING merge: a subclass's declared options are the MRO-merged
 view, most-derived winning, not a plain-attribute replacement. Some children below would be
 accidental universal matchers if declared at module level, so they are built fresh per test via
-function-local factories, with the local reference dropped before any assertion that may fail.
-"""
+function-local factories, with the local reference dropped before any assertion that may fail."""
 
 from __future__ import annotations
 
@@ -139,8 +138,6 @@ class TestDeclaredOptionMerge:
 
 
 class TestMaterializationFollowsTheMerge:
-    """options_with_defaults and GlobalFilter._intake_fill read the merged view."""
-
     def test_options_with_defaults_fills_the_inherited_default(self) -> None:
         child = _make_merge_child()
         materialized = child.options_with_defaults(Options())
@@ -257,8 +254,6 @@ class TestGuardsReadTheMergedViewAtCallTime:
 
 
 class TestExplicitNoneOrNonDictPropertyMappingRaisesAtClassDefinition:
-    """PROPERTY_MAPPING = None or a non-dict raises ValueError at class-definition time."""
-
     def test_property_mapping_none_raises_naming_the_class_with_none_and_merge(self) -> None:
         with pytest.raises(ValueError) as exc_info:
 
@@ -359,8 +354,6 @@ class PmfgNoDeclMixin(FeatureChainParserMixin):
 
 
 class TestMixinOnlyClassesKeepWorking:
-    """A bare FeatureChainParserMixin subclass, with or without a declaration."""
-
     def test_mixin_only_class_returns_its_own_mapping(self) -> None:
         mapping = PmfgOnlyMixin._get_property_mapping()
 
@@ -380,10 +373,9 @@ class TestMixinOnlyClassesKeepWorking:
 
 
 class TestMergeReadFreezesAtFirstRead:
-    """Only the read-then-write order is pinned: once declared_option_keys()/declared_option_specs()
-    has read the merge, a later PROPERTY_MAPPING reassignment or in-place mutation on the subclass
-    itself does not change what the merge reports. The cold-write order (write before any read) is
-    deliberately not pinned here."""
+    """Only read-then-write is pinned: once declared_option_keys()/declared_option_specs() has read
+    the merge, a later PROPERTY_MAPPING reassignment or mutation is not seen. Cold-write (write
+    before any read) is deliberately not pinned here."""
 
     def test_late_reassignment_after_a_warm_read_does_not_change_declared_option_keys(self) -> None:
         class PmfgFreezeReassignSub(FeatureGroup):
@@ -465,8 +457,7 @@ class TestResolveSubtypeFollowsTheMerge:
 
 
 class TestTwoDeclaringFeatureGroupBasesMergeLeftmostWins:
-    """Two declaring FeatureGroup bases in a diamond: the leftmost base wins a key collision, and
-    the other base's non-colliding key is still present."""
+    """The other base's non-colliding key is still present."""
 
     def test_leftmost_base_wins_on_a_key_collision_and_the_other_bases_key_is_present(self) -> None:
         left_spec = PropertySpec("left", default="left_default")

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
@@ -17,6 +17,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.user import Options
 
@@ -97,14 +98,10 @@ class TestDeclaredOptionMerge:
     def test_child_declared_option_specs_returns_every_inherited_spec(self) -> None:
         child = _make_merge_child()
         try:
-            # hasattr, not a direct call: an AttributeError on the class itself would pin it via the
-            # exception's own `.obj` attribute, which outlives this test's teardown gc.collect().
-            has_method = hasattr(child, "declared_option_specs")
-            specs = child.declared_option_specs() if has_method else {}
+            specs = child.declared_option_specs()
         finally:
             del child
 
-        assert has_method, "declared_option_specs is not implemented yet"
         assert set(specs) == {PMFG_A_KEY, PMFG_B_KEY, PMFG_C_KEY}
         assert specs[PMFG_A_KEY].default == "parent_a_default"
         assert specs[PMFG_C_KEY].default == "child_c_default"
@@ -112,17 +109,12 @@ class TestDeclaredOptionMerge:
     def test_declared_option_specs_returns_a_fresh_copy_each_call(self) -> None:
         child = _make_merge_child()
         try:
-            has_method = hasattr(child, "declared_option_specs")
-            if has_method:
-                first = child.declared_option_specs()
-                first["pmfg_injected"] = PropertySpec("injected", default=None)
-                second = child.declared_option_specs()
-            else:
-                second = {}
+            first = child.declared_option_specs()
+            first["pmfg_injected"] = PropertySpec("injected", default=None)
+            second = child.declared_option_specs()
         finally:
             del child
 
-        assert has_method, "declared_option_specs is not implemented yet"
         assert "pmfg_injected" not in second
 
     def test_parent_declared_option_keys_excludes_the_child_only_key(self) -> None:
@@ -131,12 +123,10 @@ class TestDeclaredOptionMerge:
     def test_a_second_child_redeclaring_a_key_sees_its_own_spec(self) -> None:
         child2 = _make_merge_child2()
         try:
-            has_method = hasattr(child2, "declared_option_specs")
-            specs = child2.declared_option_specs() if has_method else {}
+            specs = child2.declared_option_specs()
         finally:
             del child2
 
-        assert has_method, "declared_option_specs is not implemented yet"
         assert specs[PMFG_A_KEY].default == "child2_a_default"
 
     def test_child_own_property_mapping_attribute_is_only_its_own_declaration(self) -> None:
@@ -282,17 +272,13 @@ class TestExplicitNoneOrNonDictPropertyMappingRaisesAtClassDefinition:
         assert "merge" in message
 
     def test_property_mapping_non_dict_raises_naming_the_class(self) -> None:
-        """Widened to (ValueError, AttributeError): today's ``.items()`` call on a list raises
-        AttributeError, not the target ValueError; the type assertion below fails for that reason."""
-        with pytest.raises((ValueError, AttributeError)) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
 
             class PmfgListDecl(FeatureGroup):
                 PROPERTY_MAPPING = ["x"]  # type: ignore[assignment]
 
-        error_type = type(exc_info.value)
         message = str(exc_info.value)
         del exc_info
-        assert error_type is ValueError, f"expected ValueError, got {error_type.__name__}: {message}"
         assert "PmfgListDecl" in message
 
 
@@ -388,3 +374,140 @@ class TestMixinOnlyClassesKeepWorking:
 
     def test_mixin_subclass_without_a_declaration_returns_none(self) -> None:
         assert PmfgNoDeclMixin._get_property_mapping() is None
+
+
+# --- The merge is read (and cached) at class definition; a later write does not invalidate it. ---
+
+
+class TestMergeReadFreezesAtFirstRead:
+    """Only the read-then-write order is pinned: once declared_option_keys()/declared_option_specs()
+    has read the merge, a later PROPERTY_MAPPING reassignment or in-place mutation on the subclass
+    itself does not change what the merge reports. The cold-write order (write before any read) is
+    deliberately not pinned here."""
+
+    def test_late_reassignment_after_a_warm_read_does_not_change_declared_option_keys(self) -> None:
+        class PmfgFreezeReassignSub(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmfg_freeze_original": PropertySpec("x", default=None),
+            }
+
+        before = PmfgFreezeReassignSub.declared_option_keys()
+        PmfgFreezeReassignSub.PROPERTY_MAPPING = {
+            "pmfg_freeze_late": PropertySpec("y", default=None),
+        }
+        after = PmfgFreezeReassignSub.declared_option_keys()
+        del PmfgFreezeReassignSub
+
+        assert before == {"pmfg_freeze_original"}
+        assert after == before
+
+    def test_late_in_place_mutation_after_a_warm_read_does_not_change_declared_option_specs(self) -> None:
+        class PmfgFreezeMutateSub(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmfg_freeze_mutate_key": PropertySpec("x", default=None),
+            }
+
+        before = PmfgFreezeMutateSub.declared_option_specs()
+        PmfgFreezeMutateSub.PROPERTY_MAPPING["pmfg_freeze_late_added"] = PropertySpec("z", default=None)
+        after = PmfgFreezeMutateSub.declared_option_specs()
+        del PmfgFreezeMutateSub
+
+        assert "pmfg_freeze_late_added" not in before
+        assert "pmfg_freeze_late_added" not in after
+
+
+# --- Unpinned merge consumers: declared_option_values, resolve_subtype, two declaring bases, a
+# plain mixin declaring PROPERTY_MAPPING = None. ---
+
+
+class TestDeclaredOptionValuesFollowsTheMerge:
+    """declared_option_values reads the MRO-merged spec, not only the class's own declaration."""
+
+    def test_child_declared_option_values_returns_the_inherited_allowed_values(self) -> None:
+        class PmfgValuesParentLocal(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmfg_values_key": PropertySpec(
+                    "x", allowed_values=("alpha", "beta", "gamma"), strict_validation=True, default="alpha"
+                ),
+            }
+
+        class PmfgValuesChildLocal(PmfgValuesParentLocal):
+            pass
+
+        result = PmfgValuesChildLocal.declared_option_values("pmfg_values_key")
+        del PmfgValuesChildLocal
+        del PmfgValuesParentLocal
+
+        assert result == {"alpha", "beta", "gamma"}
+
+
+class TestResolveSubtypeFollowsTheMerge:
+    """resolve_subtype reads the SUBTYPES key through the MRO-merged PROPERTY_MAPPING, not only the
+    declaring class's own dict; built compactly via shape A (SubtypeDeclaration(key=...))."""
+
+    def test_child_resolve_subtype_reads_the_inherited_subtype_key(self) -> None:
+        class PmfgSubtypeParentLocal(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmfg_subtype_key": PropertySpec(
+                    "x", allowed_values=("alpha", "beta"), strict_validation=True, default="alpha"
+                ),
+            }
+            SUBTYPES: ClassVar[SubtypeDeclaration] = SubtypeDeclaration(key="pmfg_subtype_key")
+
+        class PmfgSubtypeChildLocal(PmfgSubtypeParentLocal):
+            pass
+
+        result = PmfgSubtypeChildLocal.resolve_subtype("PmfgSubtypeChildLocal", Options({"pmfg_subtype_key": "beta"}))
+        del PmfgSubtypeChildLocal
+        del PmfgSubtypeParentLocal
+
+        assert result == "beta"
+
+
+class TestTwoDeclaringFeatureGroupBasesMergeLeftmostWins:
+    """Two declaring FeatureGroup bases in a diamond: the leftmost base wins a key collision, and
+    the other base's non-colliding key is still present."""
+
+    def test_leftmost_base_wins_on_a_key_collision_and_the_other_bases_key_is_present(self) -> None:
+        left_spec = PropertySpec("left", default="left_default")
+        right_spec_a = PropertySpec("right_a", default="right_a_default")
+        right_spec_b = PropertySpec("right_b", default="right_b_default")
+
+        class PmfgTwoBaseLeftLocal(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"pmfg_two_base_a": left_spec}
+
+        class PmfgTwoBaseRightLocal(FeatureGroup):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmfg_two_base_a": right_spec_a,
+                "pmfg_two_base_b": right_spec_b,
+            }
+
+        class PmfgTwoBaseBothLocal(PmfgTwoBaseLeftLocal, PmfgTwoBaseRightLocal):
+            pass
+
+        specs = PmfgTwoBaseBothLocal.declared_option_specs()
+        del PmfgTwoBaseBothLocal
+        del PmfgTwoBaseRightLocal
+        del PmfgTwoBaseLeftLocal
+
+        assert specs["pmfg_two_base_a"] is left_spec
+        assert "pmfg_two_base_b" in specs
+
+
+class TestPlainMixinDeclaringNonePropertyMappingRaises:
+    """A plain mixin declaring PROPERTY_MAPPING = None mixed into a FeatureGroup subclass raises,
+    naming the mixin (not the FeatureGroup subclass) and the None value."""
+
+    def test_mixin_none_declaration_raises_naming_the_mixin_and_none(self) -> None:
+        class PmfgNoneMixinLocal:
+            PROPERTY_MAPPING = None
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmfgNoneMixedLocal(PmfgNoneMixinLocal, FeatureGroup):  # type: ignore[misc]  # wrong shape is the point
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmfgNoneMixinLocal" in message
+        assert "None" in message

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
@@ -1,16 +1,7 @@
-"""Pins Phase 2 of issue #949's follow-up: FeatureGroup.PROPERTY_MAPPING moves onto the shared
-declaration-surface module (``mloda/core/abstract_plugins/components/property_mapping.py``), so a
-subclass's declared options are the MRO-merged view, most-derived winning, not a plain-attribute
-replacement. Covers the FEATURE_GROUP surface identity, the merge accessors, materialization
-(``options_with_defaults`` / ``GlobalFilter._intake_fill``), config-path matching, guards reading
-the merged view, author-time rejections, and plain-mixin declarations.
-
-Today's bug (a child's own, incomplete PROPERTY_MAPPING masks its parent's) makes several of these
-children an accidental "universal matcher" (issue #771): they'd match any unrelated feature name
-resolved elsewhere in the same test session. Those helpers are therefore built fresh, function-local,
-by a factory (never module-level), and every using test drops its local reference before any
-assertion that may fail today, so a failing assertion's own traceback cannot keep the class registered
-for the rest of the run (#845). Once Green's merge lands, the same children stop being universal.
+"""Pins the FeatureGroup PROPERTY_MAPPING merge: a subclass's declared options are the MRO-merged
+view, most-derived winning, not a plain-attribute replacement. Some children below would be
+accidental universal matchers if declared at module level, so they are built fresh per test via
+function-local factories, with the local reference dropped before any assertion that may fail.
 """
 
 from __future__ import annotations
@@ -29,7 +20,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.user import Options
 
-# --- Items 2-4: MRO merge, most-derived wins; materialization and config-path matching follow it. ---
+# --- MRO merge, most-derived wins; materialization and config-path matching follow it. ---
 
 PMFG_A_KEY = "pmfg_merge_a"
 PMFG_B_KEY = "pmfg_merge_b"
@@ -83,7 +74,7 @@ class PmfgUndeclared(FeatureChainParserMixin, FeatureGroup):
 
 
 class TestFeatureGroupDeclaresTheFeatureGroupSurface:
-    """Item 1: FeatureGroup carries the FEATURE_GROUP surface and an empty-dict, not None, default."""
+    """FeatureGroup carries the FEATURE_GROUP surface and an empty-dict, not None, default."""
 
     def test_feature_group_surface_is_feature_group(self) -> None:
         assert FeatureGroup.PROPERTY_MAPPING_SURFACE is DeclarationSurface.FEATURE_GROUP
@@ -94,7 +85,7 @@ class TestFeatureGroupDeclaresTheFeatureGroupSurface:
 
 
 class TestDeclaredOptionMerge:
-    """Item 2: MRO merge, most-derived winning; a child's declaration never leaks into its parent."""
+    """MRO merge, most-derived winning; a child's declaration never leaks into its parent."""
 
     def test_child_declared_option_keys_includes_every_inherited_key(self) -> None:
         child = _make_merge_child()
@@ -107,7 +98,7 @@ class TestDeclaredOptionMerge:
         child = _make_merge_child()
         try:
             # hasattr, not a direct call: an AttributeError on the class itself would pin it via the
-            # exception's own `.obj` attribute, which outlives this test's teardown gc.collect() (#845).
+            # exception's own `.obj` attribute, which outlives this test's teardown gc.collect().
             has_method = hasattr(child, "declared_option_specs")
             specs = child.declared_option_specs() if has_method else {}
         finally:
@@ -158,7 +149,7 @@ class TestDeclaredOptionMerge:
 
 
 class TestMaterializationFollowsTheMerge:
-    """Item 3: options_with_defaults and GlobalFilter._intake_fill read the merged view."""
+    """options_with_defaults and GlobalFilter._intake_fill read the merged view."""
 
     def test_options_with_defaults_fills_the_inherited_default(self) -> None:
         child = _make_merge_child()
@@ -176,7 +167,7 @@ class TestMaterializationFollowsTheMerge:
 
 
 class TestConfigPathFollowsTheMergeAndDeclaredBeyondBase:
-    """Item 4: config-path matching consults the merged view and the "declared beyond base" rule."""
+    """Config-path matching consults the merged view and the "declared beyond base" rule."""
 
     def test_undeclared_class_with_prefix_pattern_does_not_match_an_unrelated_config_path_name(self) -> None:
         """Unchanged from today: an undeclared class stays out of scope on the config path."""
@@ -200,7 +191,7 @@ class TestConfigPathFollowsTheMergeAndDeclaredBeyondBase:
         assert result is True
 
 
-# --- Item 5: guards read the merged view at call time. ---
+# --- Guards read the merged view at call time. ---
 
 PMFG_RW_TRIGGER_KEY = "pmfg_rw_trigger"
 PMFG_RW_TARGET_KEY = "pmfg_rw_target"
@@ -236,7 +227,7 @@ def _make_required_when_child() -> type[FeatureGroup]:
 
 
 class TestGuardsReadTheMergedViewAtCallTime:
-    """Item 5: the required_when guard, and the name-path presence guard, see inherited keys."""
+    """The required_when guard, and the name-path presence guard, see inherited keys."""
 
     def test_required_when_guard_non_match_when_the_conditionally_required_key_is_absent(self) -> None:
         child = _make_required_when_child()
@@ -272,11 +263,11 @@ class TestGuardsReadTheMergedViewAtCallTime:
         assert any(PMFG_B_KEY in message for message in messages)
 
 
-# --- Items 6-7: author-time rejections on the FeatureGroup surface. ---
+# --- Author-time rejections on the FeatureGroup surface. ---
 
 
 class TestExplicitNoneOrNonDictPropertyMappingRaisesAtClassDefinition:
-    """Item 6: PROPERTY_MAPPING = None or a non-dict raises ValueError at class-definition time."""
+    """PROPERTY_MAPPING = None or a non-dict raises ValueError at class-definition time."""
 
     def test_property_mapping_none_raises_naming_the_class_with_none_and_merge(self) -> None:
         with pytest.raises(ValueError) as exc_info:
@@ -306,7 +297,7 @@ class TestExplicitNoneOrNonDictPropertyMappingRaisesAtClassDefinition:
 
 
 class TestMergeCacheAssignmentRaises:
-    """Item 7: the merge cache is framework-written; declaring it in a class body is rejected."""
+    """The merge cache is framework-written; declaring it in a class body is rejected."""
 
     def test_property_mapping_cache_assignment_raises(self) -> None:
         with pytest.raises(ValueError):
@@ -315,7 +306,7 @@ class TestMergeCacheAssignmentRaises:
                 _property_mapping_cache: ClassVar[dict[str, Any]] = {}
 
 
-# --- Item 8: plain-mixin declarations. ---
+# --- Plain-mixin declarations. ---
 
 PMFG_MIX_KEY = "pmfg_mix_key"
 
@@ -337,7 +328,7 @@ class PmfgMixed(PmfgMix, FeatureGroup):
 
 
 class TestPlainMixinDeclarations:
-    """Item 8: a plain mixin's declaration merges in; a reader-only field on it still raises."""
+    """A plain mixin's declaration merges in; a reader-only field on it still raises."""
 
     def test_declared_option_keys_includes_a_plain_mixin_key(self) -> None:
         assert PMFG_MIX_KEY in PmfgMixed.declared_option_keys()
@@ -360,7 +351,7 @@ class TestPlainMixinDeclarations:
         assert "reached defining PmfgFrameworkSetMixed" in message
 
 
-# --- Item 9: mixin-only classes (no FeatureGroup base) keep working. ---
+# --- Mixin-only classes (no FeatureGroup base) keep working. ---
 
 PMFG_ONLY_MIXIN_KEY = "pmfg_only_mixin_key"
 
@@ -382,7 +373,7 @@ class PmfgNoDeclMixin(FeatureChainParserMixin):
 
 
 class TestMixinOnlyClassesKeepWorking:
-    """Item 9: a bare FeatureChainParserMixin subclass, with or without a declaration."""
+    """A bare FeatureChainParserMixin subclass, with or without a declaration."""
 
     def test_mixin_only_class_returns_its_own_mapping(self) -> None:
         mapping = PmfgOnlyMixin._get_property_mapping()

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_property_mapping_merge.py
@@ -1,0 +1,399 @@
+"""Pins Phase 2 of issue #949's follow-up: FeatureGroup.PROPERTY_MAPPING moves onto the shared
+declaration-surface module (``mloda/core/abstract_plugins/components/property_mapping.py``), so a
+subclass's declared options are the MRO-merged view, most-derived winning, not a plain-attribute
+replacement. Covers the FEATURE_GROUP surface identity, the merge accessors, materialization
+(``options_with_defaults`` / ``GlobalFilter._intake_fill``), config-path matching, guards reading
+the merged view, author-time rejections, and plain-mixin declarations.
+
+Today's bug (a child's own, incomplete PROPERTY_MAPPING masks its parent's) makes several of these
+children an accidental "universal matcher" (issue #771): they'd match any unrelated feature name
+resolved elsewhere in the same test session. Those helpers are therefore built fresh, function-local,
+by a factory (never module-level), and every using test drops its local reference before any
+assertion that may fail today, so a failing assertion's own traceback cannot keep the class registered
+for the rest of the run (#845). Once Green's merge lands, the same children stop being universal.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.property_mapping import DeclarationSurface
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.filter.global_filter import GlobalFilter
+from mloda.user import Options
+
+# --- Items 2-4: MRO merge, most-derived wins; materialization and config-path matching follow it. ---
+
+PMFG_A_KEY = "pmfg_merge_a"
+PMFG_B_KEY = "pmfg_merge_b"
+PMFG_C_KEY = "pmfg_merge_c"
+
+
+class PmfgMergeParent(FeatureChainParserMixin, FeatureGroup):
+    """Declares 'a' (concrete default) and 'b' (NO_DEFAULT, required); a pattern names-captures 'a'.
+
+    Safe at module level: 'b' is unconditionally required, so this class never becomes a universal
+    matcher on the config path (unlike the children built by the factories below).
+    """
+
+    PREFIX_PATTERN = r".*__(?P<pmfg_merge_a>\w+)_pmfg_merge_op$"
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+        PMFG_A_KEY: PropertySpec("a, optional.", default="parent_a_default"),
+        PMFG_B_KEY: PropertySpec("b, required."),
+    }
+
+
+def _make_merge_child() -> type[PmfgMergeParent]:
+    """A fresh subclass declaring only 'c'; function-local (see module docstring)."""
+
+    class PmfgMergeChildLocal(PmfgMergeParent):
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+            PMFG_C_KEY: PropertySpec("c, optional.", default="child_c_default"),
+        }
+
+    return PmfgMergeChildLocal
+
+
+def _make_merge_child2() -> type[PmfgMergeParent]:
+    """A fresh subclass re-declaring 'a' with a different default; function-local, same reason."""
+
+    class PmfgMergeChild2Local(PmfgMergeParent):
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+            PMFG_A_KEY: PropertySpec("a, redeclared.", default="child2_a_default"),
+        }
+
+    return PmfgMergeChild2Local
+
+
+class PmfgUndeclared(FeatureChainParserMixin, FeatureGroup):
+    """Carries a PREFIX_PATTERN but declares no PROPERTY_MAPPING of its own.
+
+    Safe at module level: with no property mapping the config path never activates, so this never
+    matches an unrelated name (verified by the test below, which pins exactly that).
+    """
+
+    PREFIX_PATTERN = r".*__(?P<pmfg_undeclared_key>\w+)_pmfg_undeclared_op$"
+
+
+class TestFeatureGroupDeclaresTheFeatureGroupSurface:
+    """Item 1: FeatureGroup carries the FEATURE_GROUP surface and an empty-dict, not None, default."""
+
+    def test_feature_group_surface_is_feature_group(self) -> None:
+        assert FeatureGroup.PROPERTY_MAPPING_SURFACE is DeclarationSurface.FEATURE_GROUP
+
+    def test_feature_group_property_mapping_default_is_an_empty_dict(self) -> None:
+        assert isinstance(FeatureGroup.PROPERTY_MAPPING, dict)
+        assert FeatureGroup.PROPERTY_MAPPING == {}
+
+
+class TestDeclaredOptionMerge:
+    """Item 2: MRO merge, most-derived winning; a child's declaration never leaks into its parent."""
+
+    def test_child_declared_option_keys_includes_every_inherited_key(self) -> None:
+        child = _make_merge_child()
+        result = child.declared_option_keys()
+        del child
+
+        assert result == {PMFG_A_KEY, PMFG_B_KEY, PMFG_C_KEY}
+
+    def test_child_declared_option_specs_returns_every_inherited_spec(self) -> None:
+        child = _make_merge_child()
+        try:
+            # hasattr, not a direct call: an AttributeError on the class itself would pin it via the
+            # exception's own `.obj` attribute, which outlives this test's teardown gc.collect() (#845).
+            has_method = hasattr(child, "declared_option_specs")
+            specs = child.declared_option_specs() if has_method else {}
+        finally:
+            del child
+
+        assert has_method, "declared_option_specs is not implemented yet"
+        assert set(specs) == {PMFG_A_KEY, PMFG_B_KEY, PMFG_C_KEY}
+        assert specs[PMFG_A_KEY].default == "parent_a_default"
+        assert specs[PMFG_C_KEY].default == "child_c_default"
+
+    def test_declared_option_specs_returns_a_fresh_copy_each_call(self) -> None:
+        child = _make_merge_child()
+        try:
+            has_method = hasattr(child, "declared_option_specs")
+            if has_method:
+                first = child.declared_option_specs()
+                first["pmfg_injected"] = PropertySpec("injected", default=None)
+                second = child.declared_option_specs()
+            else:
+                second = {}
+        finally:
+            del child
+
+        assert has_method, "declared_option_specs is not implemented yet"
+        assert "pmfg_injected" not in second
+
+    def test_parent_declared_option_keys_excludes_the_child_only_key(self) -> None:
+        assert PmfgMergeParent.declared_option_keys() == {PMFG_A_KEY, PMFG_B_KEY}
+
+    def test_a_second_child_redeclaring_a_key_sees_its_own_spec(self) -> None:
+        child2 = _make_merge_child2()
+        try:
+            has_method = hasattr(child2, "declared_option_specs")
+            specs = child2.declared_option_specs() if has_method else {}
+        finally:
+            del child2
+
+        assert has_method, "declared_option_specs is not implemented yet"
+        assert specs[PMFG_A_KEY].default == "child2_a_default"
+
+    def test_child_own_property_mapping_attribute_is_only_its_own_declaration(self) -> None:
+        """The merge lives in the accessors; PROPERTY_MAPPING itself stays the plain declaration."""
+        child = _make_merge_child()
+        own_keys = set(child.__dict__["PROPERTY_MAPPING"])
+        del child
+
+        assert own_keys == {PMFG_C_KEY}
+
+
+class TestMaterializationFollowsTheMerge:
+    """Item 3: options_with_defaults and GlobalFilter._intake_fill read the merged view."""
+
+    def test_options_with_defaults_fills_the_inherited_default(self) -> None:
+        child = _make_merge_child()
+        materialized = child.options_with_defaults(Options())
+        del child
+
+        assert materialized.get(PMFG_A_KEY) == "parent_a_default"
+
+    def test_global_filter_intake_fill_reads_the_inherited_default(self) -> None:
+        child = _make_merge_child()
+        result = GlobalFilter._intake_fill(child, PMFG_A_KEY, Options())
+        del child
+
+        assert result == "parent_a_default"
+
+
+class TestConfigPathFollowsTheMergeAndDeclaredBeyondBase:
+    """Item 4: config-path matching consults the merged view and the "declared beyond base" rule."""
+
+    def test_undeclared_class_with_prefix_pattern_does_not_match_an_unrelated_config_path_name(self) -> None:
+        """Unchanged from today: an undeclared class stays out of scope on the config path."""
+        result = PmfgUndeclared.match_feature_group_criteria("pmfg_undeclared_unrelated_probe", Options())
+
+        assert result is False
+
+    def test_child_config_path_non_match_when_the_inherited_required_key_is_absent(self) -> None:
+        child = _make_merge_child()
+        result = child.match_feature_group_criteria("pmfg_merge_child_probe", Options())
+        del child
+
+        assert result is False
+
+    def test_child_config_path_matches_when_the_inherited_required_key_is_supplied(self) -> None:
+        child = _make_merge_child()
+        options = Options({PMFG_B_KEY: "present_value"})
+        result = child.match_feature_group_criteria("pmfg_merge_child_probe", options)
+        del child
+
+        assert result is True
+
+
+# --- Item 5: guards read the merged view at call time. ---
+
+PMFG_RW_TRIGGER_KEY = "pmfg_rw_trigger"
+PMFG_RW_TARGET_KEY = "pmfg_rw_target"
+PMFG_RW_CHILD_KEY = "pmfg_rw_child_only"
+
+
+def _pmfg_rw_trigger_present(options: Options) -> bool:
+    """required_when predicate: the target key is required whenever the trigger key is present."""
+    return options.get(PMFG_RW_TRIGGER_KEY) is not None
+
+
+def _make_required_when_child() -> type[FeatureGroup]:
+    """A fresh Parent+Child pair, function-local: with empty options BOTH are universal matchers
+    today (the target's declared ``default=None`` makes it config-path skippable regardless of the
+    predicate), so neither may live at module level (see module docstring)."""
+
+    class PmfgRequiredWhenParentLocal(FeatureChainParserMixin, FeatureGroup):
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+            PMFG_RW_TRIGGER_KEY: PropertySpec("trigger", default=None),
+            PMFG_RW_TARGET_KEY: PropertySpec(
+                "target, required when trigger is present.",
+                default=None,
+                required_when=_pmfg_rw_trigger_present,
+            ),
+        }
+
+    class PmfgRequiredWhenChildLocal(PmfgRequiredWhenParentLocal):
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+            PMFG_RW_CHILD_KEY: PropertySpec("child only.", default=None),
+        }
+
+    return PmfgRequiredWhenChildLocal
+
+
+class TestGuardsReadTheMergedViewAtCallTime:
+    """Item 5: the required_when guard, and the name-path presence guard, see inherited keys."""
+
+    def test_required_when_guard_non_match_when_the_conditionally_required_key_is_absent(self) -> None:
+        child = _make_required_when_child()
+        options = Options({PMFG_RW_TRIGGER_KEY: "on"})
+        result = child.match_feature_group_criteria("pmfg_rw_probe", options)
+        del child
+
+        assert result is False
+
+    def test_required_when_guard_matches_when_the_conditionally_required_key_is_present(self) -> None:
+        child = _make_required_when_child()
+        options = Options({PMFG_RW_TRIGGER_KEY: "on", PMFG_RW_TARGET_KEY: "value"})
+        result = child.match_feature_group_criteria("pmfg_rw_probe", options)
+        del child
+
+        assert result is True
+
+    def test_name_path_presence_guard_flags_the_missing_inherited_no_default_key(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A merge child's name-carried match still owes the inherited, uncaptured 'b' key."""
+        feature_name = "pmfg_source__demo_pmfg_merge_op"
+        options = Options({PMFG_C_KEY: "explicit_c"})
+        child = _make_merge_child()
+        try:
+            with caplog.at_level(logging.WARNING):
+                result = child.match_feature_group_criteria(feature_name, options)
+            messages = [record.getMessage() for record in caplog.records]
+        finally:
+            del child
+
+        assert result is False
+        assert any(PMFG_B_KEY in message for message in messages)
+
+
+# --- Items 6-7: author-time rejections on the FeatureGroup surface. ---
+
+
+class TestExplicitNoneOrNonDictPropertyMappingRaisesAtClassDefinition:
+    """Item 6: PROPERTY_MAPPING = None or a non-dict raises ValueError at class-definition time."""
+
+    def test_property_mapping_none_raises_naming_the_class_with_none_and_merge(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmfgNoneDecl(FeatureGroup):
+                PROPERTY_MAPPING = None  # type: ignore[assignment]
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmfgNoneDecl" in message
+        assert "None" in message
+        assert "merge" in message
+
+    def test_property_mapping_non_dict_raises_naming_the_class(self) -> None:
+        """Widened to (ValueError, AttributeError): today's ``.items()`` call on a list raises
+        AttributeError, not the target ValueError; the type assertion below fails for that reason."""
+        with pytest.raises((ValueError, AttributeError)) as exc_info:
+
+            class PmfgListDecl(FeatureGroup):
+                PROPERTY_MAPPING = ["x"]  # type: ignore[assignment]
+
+        error_type = type(exc_info.value)
+        message = str(exc_info.value)
+        del exc_info
+        assert error_type is ValueError, f"expected ValueError, got {error_type.__name__}: {message}"
+        assert "PmfgListDecl" in message
+
+
+class TestMergeCacheAssignmentRaises:
+    """Item 7: the merge cache is framework-written; declaring it in a class body is rejected."""
+
+    def test_property_mapping_cache_assignment_raises(self) -> None:
+        with pytest.raises(ValueError):
+
+            class PmfgCacheAssign(FeatureGroup):
+                _property_mapping_cache: ClassVar[dict[str, Any]] = {}
+
+
+# --- Item 8: plain-mixin declarations. ---
+
+PMFG_MIX_KEY = "pmfg_mix_key"
+
+
+class PmfgMix:
+    """A plain (non-FeatureGroup) mixin declaring one key."""
+
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+        PMFG_MIX_KEY: PropertySpec("m", default=1),
+    }
+
+
+class PmfgMixed(PmfgMix, FeatureGroup):
+    """Mixes in PmfgMix; declares nothing of its own.
+
+    Safe at module level: no FeatureChainParserMixin, so matching falls back to FeatureGroup's
+    plain class-name check, never the config path.
+    """
+
+
+class TestPlainMixinDeclarations:
+    """Item 8: a plain mixin's declaration merges in; a reader-only field on it still raises."""
+
+    def test_declared_option_keys_includes_a_plain_mixin_key(self) -> None:
+        assert PMFG_MIX_KEY in PmfgMixed.declared_option_keys()
+
+    def test_mixin_framework_set_spec_raises_reaching_the_feature_group_subclass(self) -> None:
+        class PmfgFrameworkSetMixin:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "pmfg_fw_key": PropertySpec("fw", framework_set=True, default=None),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class PmfgFrameworkSetMixed(PmfgFrameworkSetMixin, FeatureGroup):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PmfgFrameworkSetMixin" in message
+        assert "framework_set" in message
+        assert "reached defining PmfgFrameworkSetMixed" in message
+
+
+# --- Item 9: mixin-only classes (no FeatureGroup base) keep working. ---
+
+PMFG_ONLY_MIXIN_KEY = "pmfg_only_mixin_key"
+
+
+class PmfgOnlyMixin(FeatureChainParserMixin):
+    """A FeatureChainParserMixin subclass with no FeatureGroup base.
+
+    Safe at module level: it is not a FeatureGroup subclass at all, so it never appears in a
+    FeatureGroup resolution scan elsewhere.
+    """
+
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+        PMFG_ONLY_MIXIN_KEY: PropertySpec("m", default="only_default"),
+    }
+
+
+class PmfgNoDeclMixin(FeatureChainParserMixin):
+    """A FeatureChainParserMixin subclass declaring nothing at all; same safety as PmfgOnlyMixin."""
+
+
+class TestMixinOnlyClassesKeepWorking:
+    """Item 9: a bare FeatureChainParserMixin subclass, with or without a declaration."""
+
+    def test_mixin_only_class_returns_its_own_mapping(self) -> None:
+        mapping = PmfgOnlyMixin._get_property_mapping()
+
+        assert mapping is not None
+        assert PMFG_ONLY_MIXIN_KEY in mapping
+
+    def test_mixin_only_class_matches_on_the_config_path(self) -> None:
+        result = PmfgOnlyMixin.match_feature_group_criteria("pmfg_only_mixin_probe", Options())
+
+        assert result is True
+
+    def test_mixin_subclass_without_a_declaration_returns_none(self) -> None:
+        assert PmfgNoDeclMixin._get_property_mapping() is None

--- a/tests/test_core/test_filter/test_option_divergence_warning_guards.py
+++ b/tests/test_core/test_filter/test_option_divergence_warning_guards.py
@@ -53,9 +53,10 @@ def _emit(mapping: Optional[dict[str, PropertySpec]], feat_options: Options, fil
     """
     feature_group: Optional[type[FeatureGroup]] = None
     if mapping is not None:
+        declared: dict[str, PropertySpec] = mapping
 
         class DwgProbeFeatureGroup(FeatureGroup):
-            PROPERTY_MAPPING = mapping
+            PROPERTY_MAPPING = declared
 
         feature_group = DwgProbeFeatureGroup
 

--- a/tests/test_core/test_prepare/test_match_abort_escalation.py
+++ b/tests/test_core/test_prepare/test_match_abort_escalation.py
@@ -257,7 +257,7 @@ class BothCategoriesMixin845f(FeatureChainParserMixin):
 
     PREFIX_PATTERN = BINDING_PATTERN
     # Annotated exactly as FeatureGroup declares it, so the FeatureGroup subclass below stays consistent.
-    PROPERTY_MAPPING: ClassVar[Optional[dict[str, PropertySpec]]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
         BINDING_KEY: property_spec("the key the feature name carries")
     }
 

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -94,6 +94,11 @@ _MERGED_PROPERTY_MAPPING_RAISES = (
     "already validates every class in the MRO at definition time, so this walk cannot raise for a class "
     "that reached match time"
 )
+_VALIDATE_PROPERTY_SPEC_RAISES = (
+    "real edge: validate_property_spec's ValueError for a malformed or reader-only spec on the FEATURE_GROUP "
+    "surface, reached via _require_spec's public entry point for a caller-supplied mapping that never passed "
+    "the class-definition check; that candidate's own defect, so the seam reads it as a non-match"
+)
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
@@ -111,6 +116,12 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
     ("mloda/core/abstract_plugins/components/property_mapping.py", "merged_property_mapping"): (
         _MERGED_PROPERTY_MAPPING_RAISES
+    ),
+    ("mloda/core/abstract_plugins/components/property_mapping.py", "configuration_property_mapping"): (
+        _MERGED_PROPERTY_MAPPING_RAISES
+    ),
+    ("mloda/core/abstract_plugins/components/property_mapping.py", "validate_property_spec"): (
+        _VALIDATE_PROPERTY_SPEC_RAISES
     ),
 }
 
@@ -143,6 +154,9 @@ SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
     ("mloda/core/abstract_plugins/components/property_mapping.py", "merged_property_mapping"): (
         "name collision: dict.update inside merged_property_mapping, not a real swallow"
+    ),
+    ("mloda/core/abstract_plugins/components/property_mapping.py", "configuration_property_mapping"): (
+        "name collision: dict.update inside merged_property_mapping, reached transitively, not a real swallow"
     ),
 }
 

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -89,6 +89,11 @@ _DECIDED_ABOVE_BY_READER_SELECTION = (
 _MATCHES_COLLISION = "name collision: the match path calls the input-data hooks named matches, not Link.matches"
 _UPDATE_COLLISION = "name collision: dict.update, not the link resolver's"
 _JOIN_COLLISION = "name collision: str.join, not the runner's join"
+_MERGED_PROPERTY_MAPPING_RAISES = (
+    "real edge: own_property_mapping's ValueError for a malformed PROPERTY_MAPPING; __init_subclass__ "
+    "already validates every class in the MRO at definition time, so this walk cannot raise for a class "
+    "that reached match time"
+)
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
@@ -104,6 +109,9 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ),
     ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
+    ("mloda/core/abstract_plugins/components/property_mapping.py", "merged_property_mapping"): (
+        _MERGED_PROPERTY_MAPPING_RAISES
+    ),
 }
 
 # Swallowing functions OUTSIDE the declared modules that the match path calls; the containment there is decided
@@ -133,6 +141,9 @@ SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/link.py", "matches"): _MATCHES_COLLISION,
     ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
+    ("mloda/core/abstract_plugins/components/property_mapping.py", "merged_property_mapping"): (
+        "name collision: dict.update inside merged_property_mapping, not a real swallow"
+    ),
 }
 
 _ESCALATION = "escalate_match_abort"

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -124,12 +124,9 @@ def _source_tuple_values(instance: ConcatenatedFileContent, options: Options) ->
 
 
 def _make_no_spread_file_type_subclass() -> type[ConcatenatedFileContent]:
-    """A throwaway subclass that declares ONLY its own key; the merge, not a manual spread, must
-    supply every other inherited key."""
+    """Declares ONLY its own key; the merge, not a manual spread, must supply the rest."""
 
     class RcfdNoSpreadFileTypeProbeFeatureGroup(ConcatenatedFileContent):
-        """Declares only file_type; the other four keys must come from the MRO merge, not a spread."""
-
         PROPERTY_MAPPING = {
             "file_type": PropertySpec("Markdown files by declaration, no manual spread.", default="md", context=False),
         }

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -125,7 +125,7 @@ def _source_tuple_values(instance: ConcatenatedFileContent, options: Options) ->
 
 def _make_no_spread_file_type_subclass() -> type[ConcatenatedFileContent]:
     """A throwaway subclass that declares ONLY its own key; the merge, not a manual spread, must
-    supply every other inherited key (issue #949 Phase 2)."""
+    supply every other inherited key."""
 
     class RcfdNoSpreadFileTypeProbeFeatureGroup(ConcatenatedFileContent):
         """Declares only file_type; the other four keys must come from the MRO merge, not a spread."""
@@ -172,7 +172,7 @@ class TestDeclarationInventory:
 
 
 class TestDeclarationMergeAcrossSubclassing:
-    """A subclass declaring only its own key still exposes every inherited key (#949 Phase 2)."""
+    """A subclass declaring only its own key still exposes every inherited key."""
 
     def test_declared_option_keys_includes_every_parent_key_without_a_manual_spread(
         self, no_feature_group_registry_pollution: None
@@ -193,7 +193,7 @@ class TestDeclarationMergeAcrossSubclassing:
         subclass = _make_no_spread_file_type_subclass()
         try:
             # hasattr, not a direct call: an AttributeError raised on the class itself would pin it via
-            # the exception's own `.obj` attribute, which outlives this test's gc.collect() (#845).
+            # the exception's own `.obj` attribute, which outlives this test's gc.collect().
             has_method = hasattr(subclass, "declared_option_specs")
             default = subclass.declared_option_specs()["file_type"].default if has_method else None
         finally:

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -123,6 +123,20 @@ def _source_tuple_values(instance: ConcatenatedFileContent, options: Options) ->
     return {source_tuple.source_value for source_tuple in source_tuples}
 
 
+def _make_no_spread_file_type_subclass() -> type[ConcatenatedFileContent]:
+    """A throwaway subclass that declares ONLY its own key; the merge, not a manual spread, must
+    supply every other inherited key (issue #949 Phase 2)."""
+
+    class RcfdNoSpreadFileTypeProbeFeatureGroup(ConcatenatedFileContent):
+        """Declares only file_type; the other four keys must come from the MRO merge, not a spread."""
+
+        PROPERTY_MAPPING = {
+            "file_type": PropertySpec("Markdown files by declaration, no manual spread.", default="md", context=False),
+        }
+
+    return RcfdNoSpreadFileTypeProbeFeatureGroup
+
+
 def _make_markdown_default_subclass() -> type[ConcatenatedFileContent]:
     """A throwaway subclass whose only change is a declared ``file_type`` default of ``"md"``.
 
@@ -155,6 +169,38 @@ class TestDeclarationInventory:
         assert mapping is not None, "ConcatenatedFileContent declares no PROPERTY_MAPPING"
         non_specs = {key: type(value).__name__ for key, value in mapping.items() if not isinstance(value, PropertySpec)}
         assert non_specs == {}
+
+
+class TestDeclarationMergeAcrossSubclassing:
+    """A subclass declaring only its own key still exposes every inherited key (#949 Phase 2)."""
+
+    def test_declared_option_keys_includes_every_parent_key_without_a_manual_spread(
+        self, no_feature_group_registry_pollution: None
+    ) -> None:
+        subclass = _make_no_spread_file_type_subclass()
+        try:
+            result = subclass.declared_option_keys()
+        finally:
+            # Dropped before the assertion (which may fail today): a failing test's own frame would
+            # otherwise pin the throwaway subclass in a traceback that outlives this test's gc.collect().
+            del subclass
+
+        assert result == DECLARED_KEYS
+
+    def test_declared_option_specs_carries_the_subclass_own_file_type_spec(
+        self, no_feature_group_registry_pollution: None
+    ) -> None:
+        subclass = _make_no_spread_file_type_subclass()
+        try:
+            # hasattr, not a direct call: an AttributeError raised on the class itself would pin it via
+            # the exception's own `.obj` attribute, which outlives this test's gc.collect() (#845).
+            has_method = hasattr(subclass, "declared_option_specs")
+            default = subclass.declared_option_specs()["file_type"].default if has_method else None
+        finally:
+            del subclass
+
+        assert has_method, "declared_option_specs is not implemented yet"
+        assert default == "md"
 
 
 class TestDeclaredDefaults:

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -192,14 +192,10 @@ class TestDeclarationMergeAcrossSubclassing:
     ) -> None:
         subclass = _make_no_spread_file_type_subclass()
         try:
-            # hasattr, not a direct call: an AttributeError raised on the class itself would pin it via
-            # the exception's own `.obj` attribute, which outlives this test's gc.collect().
-            has_method = hasattr(subclass, "declared_option_specs")
-            default = subclass.declared_option_specs()["file_type"].default if has_method else None
+            default = subclass.declared_option_specs()["file_type"].default
         finally:
             del subclass
 
-        assert has_method, "declared_option_specs is not implemented yet"
         assert default == "md"
 
 

--- a/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
@@ -1,4 +1,4 @@
-"""Pins the per-reader ``PROPERTY_MAPPING`` declarations (issue #949: ``PropertySpec`` values) and
+"""Pins the per-reader ``PROPERTY_MAPPING`` declarations (``PropertySpec`` values) and
 makes the declared ``document_suffixes`` default load-bearing in ReadFile/ReadDocument matching.
 Leak policy: the leaked readers here are never final; matching is called directly, never via mlodaAPI.
 """

--- a/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
@@ -1,4 +1,4 @@
-"""Pins the per-reader ``READER_OPTIONS`` declarations (issue #949: ``PropertySpec`` values) and
+"""Pins the per-reader ``PROPERTY_MAPPING`` declarations (issue #949: ``PropertySpec`` values) and
 makes the declared ``document_suffixes`` default load-bearing in ReadFile/ReadDocument matching.
 Leak policy: the leaked readers here are never final; matching is called directly, never via mlodaAPI.
 """
@@ -65,7 +65,7 @@ def _json_excluding_read_file() -> type[ReadFile]:
     """ReadFile declaring ``.json`` as a document suffix; lazy so a broken guard fails its users, not collection."""
 
     class RodJsonExcludingReadFile(ReadFile):
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             "document_suffixes": PropertySpec(
                 "Suffixes handed to document readers; declared non-empty so ReadFile auto-excludes them.",
                 default=frozenset({".json"}),
@@ -84,7 +84,7 @@ def _json_claiming_read_document() -> type[ReadDocument]:
     """ReadDocument reader declaring ``.json`` as a document suffix, so it must claim ``.json`` files."""
 
     class RodJsonClaimingReadDocument(ReadDocument):
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             "document_suffixes": PropertySpec(
                 "Structured suffixes this document reader owns; declared non-empty to claim .json.",
                 default=frozenset({".json"}),
@@ -131,7 +131,7 @@ class TestReadFileDeclarations:
         assert ReadFile.reader_option_default("data_access_handle") is None
 
     def test_csv_reader_inherits_without_redeclaring(self) -> None:
-        assert "READER_OPTIONS" not in CsvReader.__dict__
+        assert "PROPERTY_MAPPING" not in CsvReader.__dict__
         assert CsvReader.declared_reader_option_keys() == ReadFile.declared_reader_option_keys()
         assert CsvReader.reader_option_default("document_suffixes") == frozenset()
         assert CsvReader.reader_option_default("data_access_handle") is None
@@ -154,7 +154,7 @@ class TestReadDocumentDeclarations:
         assert ReadDocument.reader_option_default("data_access_handle") is None
 
     def test_markdown_reader_inherits_without_redeclaring(self) -> None:
-        assert "READER_OPTIONS" not in MarkdownDocumentReader.__dict__
+        assert "PROPERTY_MAPPING" not in MarkdownDocumentReader.__dict__
         assert MarkdownDocumentReader.declared_reader_option_keys() == ReadDocument.declared_reader_option_keys()
         assert MarkdownDocumentReader.reader_option_default("document_suffixes") == frozenset()
 
@@ -177,7 +177,7 @@ class TestReadDBDeclarations:
             ReadDB.reader_option_default("document_suffixes")
 
     def test_sqlite_reader_inherits_without_redeclaring(self) -> None:
-        assert "READER_OPTIONS" not in SQLITEReader.__dict__
+        assert "PROPERTY_MAPPING" not in SQLITEReader.__dict__
         assert SQLITEReader.declared_reader_option_keys() == ReadDB.declared_reader_option_keys()
         assert SQLITEReader.reader_option_default("data_access_handle") is None
 

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -7,11 +7,10 @@ unvalidated. This sweep resolves each read to its key and flags any key that no 
 declares, accepting only a narrow allowlist of genuinely engine-internal and genuinely dynamic reads.
 
 The check spans TWO declaration surfaces and is deliberately GLOBAL across both: a key passes when
-SOME shipped FeatureGroup declares it in its ``PROPERTY_MAPPING`` or SOME shipped reader
-(``BaseInputData`` subclass) declares it in its own ``PROPERTY_MAPPING``. Both surfaces share the
-same attribute name; readers still need their own surface because their keys are consumed at
-reader-selection time, before the framework materializes any FeatureGroup ``PROPERTY_MAPPING``
-default. Per-group owning-surface attribution is out of scope for this sweep.
+SOME shipped FeatureGroup or SOME shipped reader (``BaseInputData`` subclass) declares it in its own
+``PROPERTY_MAPPING``. Both surfaces share the same attribute name; readers still need their own
+surface because their keys are consumed at reader-selection time, before the framework materializes
+any FeatureGroup default. Per-group owning-surface attribution is out of scope for this sweep.
 
 Scope notes:
 
@@ -109,9 +108,8 @@ ALLOWED_DYNAMIC_READS: dict[tuple[str, str], tuple[str, str]] = {
 }
 
 # Keys that ONLY the reader surface declares: nothing about them is in any FeatureGroup PROPERTY_MAPPING,
-# so they are the probe for whether the union really reaches the reader (BaseInputData) surface's own
-# PROPERTY_MAPPING. "BaseInputData" is the reserved key the framework itself writes; the other two are
-# read inside reader matching.
+# so they probe whether the union really reaches the reader's own PROPERTY_MAPPING. "BaseInputData" is
+# the reserved key the framework itself writes; the other two are read inside reader matching.
 READER_ONLY_KEYS: frozenset[str] = frozenset({"BaseInputData", "data_access_handle", "document_suffixes"})
 
 # Individual source files whose reads are asserted key-by-key below, so a scanner blind spot cannot
@@ -410,9 +408,9 @@ def property_mapping_declared_union() -> frozenset[str]:
 def reader_declared_union() -> frozenset[str]:
     """Every PROPERTY_MAPPING key declared by ``BaseInputData`` or a shipped reader subclass.
 
-    Filtered by module prefix for the same reason as the FeatureGroup PROPERTY_MAPPING side, with one extra prefix:
-    ``BaseInputData`` itself lives under ``mloda.core`` and is what declares the reserved
-    ``"BaseInputData"`` key, so the filter admits ``mloda.core`` while still excluding ``tests.*``.
+    Filtered by module prefix for the same reason as the FeatureGroup side, with one extra prefix:
+    ``BaseInputData`` itself lives under ``mloda.core`` and declares the reserved ``"BaseInputData"``
+    key, so the filter admits ``mloda.core`` while still excluding ``tests.*``.
     """
     readers: list[type[BaseInputData]] = [BaseInputData, *get_all_subclasses(BaseInputData)]
     keys: set[str] = set()
@@ -441,10 +439,7 @@ def test_no_undeclared_static_option_reads() -> None:
         ALLOWED_LITERAL_KEYS,
         ALLOWED_DYNAMIC_READS,
     )
-    assert violations == [], (
-        "Undeclared option reads (declare the key in the plugin's PROPERTY_MAPPING, "
-        "FeatureGroup or reader surface):\n" + "\n".join(violations)
-    )
+    assert violations == [], "Undeclared option reads (declare the key in PROPERTY_MAPPING):\n" + "\n".join(violations)
 
 
 def test_reference_time_declared_by_time_groups() -> None:
@@ -477,15 +472,14 @@ def test_literal_allowlist_is_load_bearing() -> None:
 
 @pytest.mark.parametrize("key", sorted(READER_ONLY_KEYS))
 def test_declared_union_recognizes_reader_declarations(key: str) -> None:
-    """The union covers the reader (BaseInputData) surface's own PROPERTY_MAPPING, not just the FeatureGroup one."""
+    """The union covers the reader surface's own PROPERTY_MAPPING, not just the FeatureGroup one."""
     assert key in reader_declared_union()
     assert key in declared_union()
 
 
 @pytest.mark.parametrize("key", sorted(READER_ONLY_KEYS))
 def test_reader_keys_are_attributable_to_the_reader_surface_alone(key: str) -> None:
-    """No FeatureGroup PROPERTY_MAPPING and no framework-reserved key covers these, so only the reader
-    surface's own PROPERTY_MAPPING carries them."""
+    """No FeatureGroup PROPERTY_MAPPING and no framework-reserved key covers these; only the reader carries them."""
     assert key not in property_mapping_declared_union()
     assert key not in FRAMEWORK_KEYS
 

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -7,10 +7,11 @@ unvalidated. This sweep resolves each read to its key and flags any key that no 
 declares, accepting only a narrow allowlist of genuinely engine-internal and genuinely dynamic reads.
 
 The check spans TWO declaration surfaces and is deliberately GLOBAL across both: a key passes when
-SOME shipped FeatureGroup declares it in ``PROPERTY_MAPPING`` or SOME shipped reader declares it in
-``READER_OPTIONS``. Readers need their own surface because their keys are consumed at reader-selection
-time, before the framework materializes any ``PROPERTY_MAPPING`` default. Per-group owning-surface
-attribution is out of scope for this sweep.
+SOME shipped FeatureGroup declares it in its ``PROPERTY_MAPPING`` or SOME shipped reader
+(``BaseInputData`` subclass) declares it in its own ``PROPERTY_MAPPING``. Both surfaces share the
+same attribute name; readers still need their own surface because their keys are consumed at
+reader-selection time, before the framework materializes any FeatureGroup ``PROPERTY_MAPPING``
+default. Per-group owning-surface attribution is out of scope for this sweep.
 
 Scope notes:
 
@@ -107,9 +108,10 @@ ALLOWED_DYNAMIC_READS: dict[tuple[str, str], tuple[str, str]] = {
     ),
 }
 
-# Keys that ONLY the reader surface declares: nothing about them is in any PROPERTY_MAPPING, so they are
-# the probe for whether the union really reaches READER_OPTIONS. "BaseInputData" is the reserved key the
-# framework itself writes; the other two are read inside reader matching.
+# Keys that ONLY the reader surface declares: nothing about them is in any FeatureGroup PROPERTY_MAPPING,
+# so they are the probe for whether the union really reaches the reader (BaseInputData) surface's own
+# PROPERTY_MAPPING. "BaseInputData" is the reserved key the framework itself writes; the other two are
+# read inside reader matching.
 READER_ONLY_KEYS: frozenset[str] = frozenset({"BaseInputData", "data_access_handle", "document_suffixes"})
 
 # Individual source files whose reads are asserted key-by-key below, so a scanner blind spot cannot
@@ -154,7 +156,7 @@ def _make_leaked_reader_probe() -> type[BaseInputData]:
     """
 
     class UorLeakedTestTreeReaderProbe(BaseInputData):
-        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
             _PROBE_READER_KEY: PropertySpec("Test-tree only; must never reach the declared union.", default=None),
         }
 
@@ -406,9 +408,9 @@ def property_mapping_declared_union() -> frozenset[str]:
 
 
 def reader_declared_union() -> frozenset[str]:
-    """Every READER_OPTIONS key declared by ``BaseInputData`` or a shipped reader subclass.
+    """Every PROPERTY_MAPPING key declared by ``BaseInputData`` or a shipped reader subclass.
 
-    Filtered by module prefix for the same reason as the PROPERTY_MAPPING side, with one extra prefix:
+    Filtered by module prefix for the same reason as the FeatureGroup PROPERTY_MAPPING side, with one extra prefix:
     ``BaseInputData`` itself lives under ``mloda.core`` and is what declares the reserved
     ``"BaseInputData"`` key, so the filter admits ``mloda.core`` while still excluding ``tests.*``.
     """
@@ -440,8 +442,8 @@ def test_no_undeclared_static_option_reads() -> None:
         ALLOWED_DYNAMIC_READS,
     )
     assert violations == [], (
-        "Undeclared option reads (declare the key in the plugin's PROPERTY_MAPPING or READER_OPTIONS):\n"
-        + "\n".join(violations)
+        "Undeclared option reads (declare the key in the plugin's PROPERTY_MAPPING, "
+        "FeatureGroup or reader surface):\n" + "\n".join(violations)
     )
 
 
@@ -475,14 +477,15 @@ def test_literal_allowlist_is_load_bearing() -> None:
 
 @pytest.mark.parametrize("key", sorted(READER_ONLY_KEYS))
 def test_declared_union_recognizes_reader_declarations(key: str) -> None:
-    """The union covers the READER_OPTIONS surface, not just PROPERTY_MAPPING."""
+    """The union covers the reader (BaseInputData) surface's own PROPERTY_MAPPING, not just the FeatureGroup one."""
     assert key in reader_declared_union()
     assert key in declared_union()
 
 
 @pytest.mark.parametrize("key", sorted(READER_ONLY_KEYS))
 def test_reader_keys_are_attributable_to_the_reader_surface_alone(key: str) -> None:
-    """No PROPERTY_MAPPING and no framework-reserved key covers these, so only READER_OPTIONS carries them."""
+    """No FeatureGroup PROPERTY_MAPPING and no framework-reserved key covers these, so only the reader
+    surface's own PROPERTY_MAPPING carries them."""
     assert key not in property_mapping_declared_union()
     assert key not in FRAMEWORK_KEYS
 


### PR DESCRIPTION
## Summary

`FeatureGroup.PROPERTY_MAPPING` and `BaseInputData.READER_OPTIONS` held the same `PropertySpec` type but behaved differently: readers merged declarations across the MRO, feature groups replaced the parent's mapping on plain attribute lookup, each side had its own author-time rules, and the empty shape was `None` on one side and a pre-seeded dict on the other. This unifies both under one attribute, one merge, and one validator (`mloda/core/abstract_plugins/components/property_mapping.py`).

- Readers now declare `PROPERTY_MAPPING`; a leftover `READER_OPTIONS` raises at class definition naming the rename. `reader_option()` and friends keep their names.
- Declarations merge across the class hierarchy on both surfaces, most-derived winning, cached per class. `FeatureGroup.declared_option_specs()` returns the merged view; every core read site uses it.
- `FeatureGroup.PROPERTY_MAPPING` defaults to `{}`, not `None`. Whether any class beyond `FeatureGroup` declared a mapping decides if the configuration matcher is on, so an undeclared group still never matches on the configuration path. `PROPERTY_MAPPING = None` and non-dicts raise at class definition.
- One validator enforces the per-surface rules (a feature group rejects `framework_set`/`scalar_only`; a reader rejects `match_guard`, `deferred_binding`, `context=False`, and enforcement fields on a `framework_set` key), including through plain mixins. The surface marker and merge cache are framework-owned and guarded against author assignment.

## Behavior change

A feature-group subclass that declared its own mapping while omitting parent keys now inherits them (parent defaults materialize, a default-less parent key becomes required). No shipped hierarchy has both a parent and a child declaring, so nothing in-repo changes. Migration notes in `docs/docs/in_depth/property-mapping.md`.

## Test plan

- [x] New tests pin the merge, the per-surface validation, the marker/cache guards, and config-path matching on both surfaces
- [x] Reader test suites renamed to the new attribute; `READER_OPTIONS` pinned as a hard break
- [x] Docs and `tox` green
