### PR TITLE
fix: normalize FilterParameter set/frozenset values by equality, not repr

### DIFF
--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -25,10 +25,9 @@ class FilterParameter(Protocol):
 def _normalize_collections(value: Any) -> Any:
     """Normalize collection values so the frozen dataclass stays hashable.
 
-    Lists become tuples, order preserved. Sets/frozensets become frozensets: frozenset equality and
-    hashing are already order- and representation-independent, so cross-type-equal elements (1 and
-    True) normalize the same regardless of which concrete type built either side, unlike a repr-sorted
-    tuple. str/bytes stay scalar and are never exploded.
+    Sets/frozensets normalize to frozenset rather than a repr-sorted tuple: frozenset equality is
+    already order- and representation-independent, so cross-type-equal elements (1 and True)
+    normalize the same regardless of which concrete type built either side.
     """
     if isinstance(value, (str, bytes)):
         return value

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -56,12 +56,6 @@ class FilterParameterImpl:
                     f"Filter parameter '{key}' holds an unhashable {culprit}; "
                     "filter values must be hashable: scalars, or lists, sets or tuples of hashables."
                 )
-        # "values" is the categorical_inclusion membership set (filter engines build `isin(values)`
-        # from it), so its container type and order carry no meaning: fold the now-hashable tuple in
-        # too, so list/tuple/set/frozenset inputs with the same elements are one filter. Other keys
-        # (e.g. a tuple under "value" used as a composite scalar) keep their given shape.
-        if isinstance(normalized.get("values"), tuple):
-            normalized["values"] = frozenset(normalized["values"])
         return cls(_raw=tuple(sorted(normalized.items())))
 
     @property
@@ -70,11 +64,13 @@ class FilterParameterImpl:
 
     @property
     def values(self) -> Optional[list[Any]]:
-        # Collection input always normalizes to a frozenset; hand out the declared list type. A
+        # Stored as a tuple or frozenset for hashability; hand out the declared list type. A
         # frozenset iterates in hash-seed order, so it's re-sorted here to stay deterministic.
         stored = self._get("values")
         if isinstance(stored, frozenset):
             return sorted(stored, key=repr)
+        if isinstance(stored, tuple):
+            return list(stored)
         return cast(Optional[list[Any]], stored)
 
     @property

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -25,9 +25,8 @@ class FilterParameter(Protocol):
 def _normalize_collections(value: Any) -> Any:
     """Normalize collection values so the frozen dataclass stays hashable.
 
-    Sets/frozensets normalize to frozenset rather than a repr-sorted tuple: frozenset equality is
-    already order- and representation-independent, so cross-type-equal elements (1 and True)
-    normalize the same regardless of which concrete type built either side.
+    Sets/frozensets become frozenset, not a repr-sorted tuple: repr isn't cross-type-equality-safe
+    (1 == True), frozenset already is.
     """
     if isinstance(value, (str, bytes)):
         return value
@@ -66,9 +65,7 @@ class FilterParameterImpl:
     @property
     def values(self) -> Optional[list[Any]]:
         # Stored as a tuple or frozenset for hashability; hand out the declared list type. A
-        # frozenset's own iteration order is hash-seed dependent, so a set/frozenset input is
-        # re-sorted here (matching the prior deterministic order) for SQL filter engines that build
-        # a params list from this, and because PySpark's Column.isin only unwraps list/set.
+        # frozenset iterates in hash-seed order, so it's re-sorted here to stay deterministic.
         stored = self._get("values")
         if isinstance(stored, frozenset):
             return sorted(stored, key=repr)

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -65,11 +65,14 @@ class FilterParameterImpl:
 
     @property
     def values(self) -> Optional[list[Any]]:
-        # Stored as a tuple or frozenset for hashability; hand out the declared list type. Filter
-        # engines rely on this: PySpark's Column.isin only unwraps list/set, so either would silently
-        # break it if handed out raw.
+        # Stored as a tuple or frozenset for hashability; hand out the declared list type. A
+        # frozenset's own iteration order is hash-seed dependent, so a set/frozenset input is
+        # re-sorted here (matching the prior deterministic order) for SQL filter engines that build
+        # a params list from this, and because PySpark's Column.isin only unwraps list/set.
         stored = self._get("values")
-        if isinstance(stored, (tuple, frozenset)):
+        if isinstance(stored, frozenset):
+            return sorted(stored, key=repr)
+        if isinstance(stored, tuple):
             return list(stored)
         return cast(Optional[list[Any]], stored)
 

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -56,6 +56,12 @@ class FilterParameterImpl:
                     f"Filter parameter '{key}' holds an unhashable {culprit}; "
                     "filter values must be hashable: scalars, or lists, sets or tuples of hashables."
                 )
+        # "values" is the categorical_inclusion membership set (filter engines build `isin(values)`
+        # from it), so its container type and order carry no meaning: fold the now-hashable tuple in
+        # too, so list/tuple/set/frozenset inputs with the same elements are one filter. Other keys
+        # (e.g. a tuple under "value" used as a composite scalar) keep their given shape.
+        if isinstance(normalized.get("values"), tuple):
+            normalized["values"] = frozenset(normalized["values"])
         return cls(_raw=tuple(sorted(normalized.items())))
 
     @property
@@ -64,13 +70,11 @@ class FilterParameterImpl:
 
     @property
     def values(self) -> Optional[list[Any]]:
-        # Stored as a tuple or frozenset for hashability; hand out the declared list type. A
+        # Collection input always normalizes to a frozenset; hand out the declared list type. A
         # frozenset iterates in hash-seed order, so it's re-sorted here to stay deterministic.
         stored = self._get("values")
         if isinstance(stored, frozenset):
             return sorted(stored, key=repr)
-        if isinstance(stored, tuple):
-            return list(stored)
         return cast(Optional[list[Any]], stored)
 
     @property

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -23,14 +23,17 @@ class FilterParameter(Protocol):
 
 
 def _normalize_collections(value: Any) -> Any:
-    """Normalize collection values to tuples so the frozen dataclass stays hashable.
+    """Normalize collection values so the frozen dataclass stays hashable.
 
-    Sets are ordered deterministically, str/bytes stay scalar and are never exploded.
+    Lists become tuples, order preserved. Sets/frozensets become frozensets: frozenset equality and
+    hashing are already order- and representation-independent, so cross-type-equal elements (1 and
+    True) normalize the same regardless of which concrete type built either side, unlike a repr-sorted
+    tuple. str/bytes stay scalar and are never exploded.
     """
     if isinstance(value, (str, bytes)):
         return value
     if isinstance(value, (set, frozenset)):
-        return tuple(sorted(value, key=repr))
+        return frozenset(value)
     if isinstance(value, list):
         return tuple(value)
     return value
@@ -63,10 +66,11 @@ class FilterParameterImpl:
 
     @property
     def values(self) -> Optional[list[Any]]:
-        # Stored as a tuple for hashability; hand out the declared list type. Filter engines rely
-        # on this: PySpark's Column.isin only unwraps list/set, so a tuple would silently break it.
+        # Stored as a tuple or frozenset for hashability; hand out the declared list type. Filter
+        # engines rely on this: PySpark's Column.isin only unwraps list/set, so either would silently
+        # break it if handed out raw.
         stored = self._get("values")
-        if isinstance(stored, tuple):
+        if isinstance(stored, (tuple, frozenset)):
             return list(stored)
         return cast(Optional[list[Any]], stored)
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -167,13 +167,17 @@ class TestNormalizeCollectionsStaysShallow:
         assert _normalize_collections([1, 2]) == (1, 2)
 
     def test_set_becomes_a_frozenset(self) -> None:
-        assert _normalize_collections({"b", "a"}) == frozenset({"a", "b"})
+        result = _normalize_collections({"b", "a"})
+        assert isinstance(result, frozenset)
+        assert result == frozenset({"a", "b"})
 
     def test_frozenset_stays_a_frozenset(self) -> None:
-        assert _normalize_collections(frozenset({"b", "a"})) == frozenset({"a", "b"})
+        result = _normalize_collections(frozenset({"b", "a"}))
+        assert isinstance(result, frozenset)
+        assert result == frozenset({"a", "b"})
 
     def test_cross_type_equal_set_elements_normalize_equal(self) -> None:
-        """1 == True: repr-based sorting used to leak the concrete type into the normalized order."""
+        """1 == True: repr-based sorting used to leak the concrete type into the normalized result."""
         assert _normalize_collections({1, 2}) == _normalize_collections({True, 2})
 
     def test_dict_is_left_unchanged_so_the_probe_can_reject_it(self) -> None:

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -166,11 +166,15 @@ class TestNormalizeCollectionsStaysShallow:
     def test_list_becomes_a_tuple(self) -> None:
         assert _normalize_collections([1, 2]) == (1, 2)
 
-    def test_set_becomes_a_tuple_sorted_by_repr(self) -> None:
-        assert _normalize_collections({"b", "a"}) == ("a", "b")
+    def test_set_becomes_a_frozenset(self) -> None:
+        assert _normalize_collections({"b", "a"}) == frozenset({"a", "b"})
 
-    def test_frozenset_becomes_a_tuple_sorted_by_repr(self) -> None:
-        assert _normalize_collections(frozenset({"b", "a"})) == ("a", "b")
+    def test_frozenset_stays_a_frozenset(self) -> None:
+        assert _normalize_collections(frozenset({"b", "a"})) == frozenset({"a", "b"})
+
+    def test_cross_type_equal_set_elements_normalize_equal(self) -> None:
+        """1 == True: repr-based sorting used to leak the concrete type into the normalized order."""
+        assert _normalize_collections({1, 2}) == _normalize_collections({True, 2})
 
     def test_dict_is_left_unchanged_so_the_probe_can_reject_it(self) -> None:
         assert _normalize_collections({"a": 1}) == {"a": 1}

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -264,9 +264,8 @@ def test_parameter_sorting_is_consistent() -> None:
 
 # --- Collection value normalization tests (see issue #664) ---
 #
-# Contract: collection values are stored hashable in `_raw` (list/tuple as tuple, set/frozenset as
-# frozenset), but the public `values` property returns a `list`, matching its declared type. Scalars
-# must never be exploded.
+# Contract: collection values are stored hashable in `_raw` (tuple or frozenset), but the public
+# `values` property returns a `list`, matching its declared type. Scalars must never be exploded.
 
 
 def test_from_dict_with_list_values_normalizes_raw_to_tuple() -> None:
@@ -295,11 +294,7 @@ def test_values_property_returns_list_for_set_input() -> None:
 
 
 def test_values_property_is_deterministically_ordered_for_set_input() -> None:
-    """Test the public list order does not depend on the set's hash-seed iteration order.
-
-    A frozenset's own iteration order varies with PYTHONHASHSEED, so `values` must not hand it
-    out directly; it re-sorts by repr, matching the order the prior tuple-based storage produced.
-    """
+    """Test the public list order does not depend on the set's hash-seed iteration order."""
     params: dict[str, Any] = {"values": {5, 3, 40, 1, 22}}
     filter_param = FilterParameterImpl.from_dict(params)
 
@@ -332,6 +327,14 @@ def test_homogeneous_set_values_still_deduplicate_regardless_of_insertion_order(
     assert first == second
     assert hash(first) == hash(second)
     assert len({first, second}) == 1
+
+
+def test_set_and_list_values_no_longer_alias() -> None:
+    """Set stores as frozenset, list as tuple: same elements, no longer equal (was repr-sort luck)."""
+    from_set = FilterParameterImpl.from_dict({"values": {"EU", "NA"}})
+    from_list = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
+
+    assert from_set != from_list
 
 
 def test_values_property_returns_list_for_tuple_input() -> None:

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -293,6 +293,34 @@ def test_values_property_returns_list_for_set_input() -> None:
     assert sorted(filter_param.values) == ["EU", "NA"]
 
 
+def test_cross_type_equal_set_values_normalize_equal() -> None:
+    """Test set elements normalize by value equality, not repr, so 1 and True land in the same order."""
+    from_int = FilterParameterImpl.from_dict({"values": {1, 2}})
+    from_bool = FilterParameterImpl.from_dict({"values": {True, 2}})
+
+    assert from_int == from_bool
+    assert hash(from_int) == hash(from_bool)
+
+
+def test_cross_type_equal_frozenset_values_normalize_equal() -> None:
+    """Test the same cross-type-equal normalization holds for a frozenset input."""
+    from_int = FilterParameterImpl.from_dict({"values": frozenset({1, 2})})
+    from_bool = FilterParameterImpl.from_dict({"values": frozenset({True, 2})})
+
+    assert from_int == from_bool
+    assert hash(from_int) == hash(from_bool)
+
+
+def test_homogeneous_set_values_still_deduplicate_regardless_of_insertion_order() -> None:
+    """Test the pre-existing homogeneous, natively-orderable behavior (dedup, hashability) survives."""
+    first = FilterParameterImpl.from_dict({"values": {"NA", "EU"}})
+    second = FilterParameterImpl.from_dict({"values": {"EU", "NA"}})
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert len({first, second}) == 1
+
+
 def test_values_property_returns_list_for_tuple_input() -> None:
     """Test a tuple value comes back out of the public accessor as a list."""
     filter_param = FilterParameterImpl.from_dict({"values": ("EU", "NA")})

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -264,8 +264,9 @@ def test_parameter_sorting_is_consistent() -> None:
 
 # --- Collection value normalization tests (see issue #664) ---
 #
-# Contract: collection values are stored hashable (tuple) in `_raw`, but the public `values`
-# property returns a `list`, matching its declared type. Scalars must never be exploded.
+# Contract: collection values are stored hashable in `_raw` (list/tuple as tuple, set/frozenset as
+# frozenset), but the public `values` property returns a `list`, matching its declared type. Scalars
+# must never be exploded.
 
 
 def test_from_dict_with_list_values_normalizes_raw_to_tuple() -> None:
@@ -276,11 +277,11 @@ def test_from_dict_with_list_values_normalizes_raw_to_tuple() -> None:
     assert isinstance(hash(filter_param), int)
 
 
-def test_from_dict_with_set_values_is_hashable() -> None:
-    """Test a set value is accepted and does not break hashing."""
-    params: dict[str, Any] = {"values": {"EU", "NA"}}
-    filter_param = FilterParameterImpl.from_dict(params)
+def test_from_dict_with_set_values_normalizes_raw_to_frozenset() -> None:
+    """Test a set value is stored as a frozenset internally so the frozen dataclass stays hashable."""
+    filter_param = FilterParameterImpl.from_dict({"values": {"EU", "NA"}})
 
+    assert filter_param._raw == (("values", frozenset({"EU", "NA"})),)
     assert isinstance(hash(filter_param), int)
 
 
@@ -293,8 +294,20 @@ def test_values_property_returns_list_for_set_input() -> None:
     assert sorted(filter_param.values) == ["EU", "NA"]
 
 
+def test_values_property_is_deterministically_ordered_for_set_input() -> None:
+    """Test the public list order does not depend on the set's hash-seed iteration order.
+
+    A frozenset's own iteration order varies with PYTHONHASHSEED, so `values` must not hand it
+    out directly; it re-sorts by repr, matching the order the prior tuple-based storage produced.
+    """
+    params: dict[str, Any] = {"values": {5, 3, 40, 1, 22}}
+    filter_param = FilterParameterImpl.from_dict(params)
+
+    assert filter_param.values == sorted({5, 3, 40, 1, 22}, key=repr)
+
+
 def test_cross_type_equal_set_values_normalize_equal() -> None:
-    """Test set elements normalize by value equality, not repr, so 1 and True land in the same order."""
+    """Test set elements normalize by value equality, not repr, so 1 and True are interchangeable."""
     from_int = FilterParameterImpl.from_dict({"values": {1, 2}})
     from_bool = FilterParameterImpl.from_dict({"values": {True, 2}})
 

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -39,14 +39,13 @@ def test_from_dict_with_range_params() -> None:
 def test_from_dict_with_categorical_values() -> None:
     """Test creating FilterParameterImpl with multiple values.
 
-    Internal storage normalizes the list to a frozenset so the frozen dataclass stays hashable and
-    order/container-independent (categorical_inclusion filters build `isin(values)` from it).
+    Internal storage normalizes the list to a tuple so the frozen dataclass stays hashable.
     """
     params = {"values": ["A", "B", "C"]}
     filter_param = FilterParameterImpl.from_dict(params)
 
     assert isinstance(filter_param, FilterParameterImpl)
-    assert filter_param._raw == (("values", frozenset({"A", "B", "C"})),)
+    assert filter_param._raw == (("values", ("A", "B", "C")),)
 
 
 def test_from_dict_with_max_exclusive() -> None:
@@ -265,17 +264,15 @@ def test_parameter_sorting_is_consistent() -> None:
 
 # --- Collection value normalization tests (see issue #664) ---
 #
-# Contract: "values" collection input is stored hashable in `_raw` as a frozenset regardless of
-# whether it arrived as a list, tuple, set or frozenset, since categorical_inclusion filters build
-# an order- and container-independent `isin(values)` from it. The public `values` property returns
-# a `list`, matching its declared type. Scalars must never be exploded.
+# Contract: collection values are stored hashable in `_raw` (tuple or frozenset), but the public
+# `values` property returns a `list`, matching its declared type. Scalars must never be exploded.
 
 
-def test_from_dict_with_list_values_normalizes_raw_to_frozenset() -> None:
-    """Test a list value is stored as a frozenset internally so the frozen dataclass stays hashable."""
+def test_from_dict_with_list_values_normalizes_raw_to_tuple() -> None:
+    """Test a list value is stored as a tuple internally so the frozen dataclass stays hashable."""
     filter_param = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
 
-    assert filter_param._raw == (("values", frozenset({"EU", "NA"})),)
+    assert filter_param._raw == (("values", ("EU", "NA")),)
     assert isinstance(hash(filter_param), int)
 
 
@@ -332,22 +329,12 @@ def test_homogeneous_set_values_still_deduplicate_regardless_of_insertion_order(
     assert len({first, second}) == 1
 
 
-def test_set_and_list_values_alias() -> None:
-    """Set and list inputs with the same elements both normalize to a frozenset: same filter."""
+def test_set_and_list_values_no_longer_alias() -> None:
+    """Set stores as frozenset, list as tuple: same elements, no longer equal (was repr-sort luck)."""
     from_set = FilterParameterImpl.from_dict({"values": {"EU", "NA"}})
     from_list = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
 
-    assert from_set == from_list
-    assert hash(from_set) == hash(from_list)
-
-
-def test_differently_ordered_list_values_alias() -> None:
-    """Test list input order carries no meaning either: it's folded into the same frozenset."""
-    first = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
-    second = FilterParameterImpl.from_dict({"values": ["NA", "EU"]})
-
-    assert first == second
-    assert hash(first) == hash(second)
+    assert from_set != from_list
 
 
 def test_values_property_returns_list_for_tuple_input() -> None:

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -39,13 +39,14 @@ def test_from_dict_with_range_params() -> None:
 def test_from_dict_with_categorical_values() -> None:
     """Test creating FilterParameterImpl with multiple values.
 
-    Internal storage normalizes the list to a tuple so the frozen dataclass stays hashable.
+    Internal storage normalizes the list to a frozenset so the frozen dataclass stays hashable and
+    order/container-independent (categorical_inclusion filters build `isin(values)` from it).
     """
     params = {"values": ["A", "B", "C"]}
     filter_param = FilterParameterImpl.from_dict(params)
 
     assert isinstance(filter_param, FilterParameterImpl)
-    assert filter_param._raw == (("values", ("A", "B", "C")),)
+    assert filter_param._raw == (("values", frozenset({"A", "B", "C"})),)
 
 
 def test_from_dict_with_max_exclusive() -> None:
@@ -264,15 +265,17 @@ def test_parameter_sorting_is_consistent() -> None:
 
 # --- Collection value normalization tests (see issue #664) ---
 #
-# Contract: collection values are stored hashable in `_raw` (tuple or frozenset), but the public
-# `values` property returns a `list`, matching its declared type. Scalars must never be exploded.
+# Contract: "values" collection input is stored hashable in `_raw` as a frozenset regardless of
+# whether it arrived as a list, tuple, set or frozenset, since categorical_inclusion filters build
+# an order- and container-independent `isin(values)` from it. The public `values` property returns
+# a `list`, matching its declared type. Scalars must never be exploded.
 
 
-def test_from_dict_with_list_values_normalizes_raw_to_tuple() -> None:
-    """Test a list value is stored as a tuple internally so the frozen dataclass stays hashable."""
+def test_from_dict_with_list_values_normalizes_raw_to_frozenset() -> None:
+    """Test a list value is stored as a frozenset internally so the frozen dataclass stays hashable."""
     filter_param = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
 
-    assert filter_param._raw == (("values", ("EU", "NA")),)
+    assert filter_param._raw == (("values", frozenset({"EU", "NA"})),)
     assert isinstance(hash(filter_param), int)
 
 
@@ -329,12 +332,22 @@ def test_homogeneous_set_values_still_deduplicate_regardless_of_insertion_order(
     assert len({first, second}) == 1
 
 
-def test_set_and_list_values_no_longer_alias() -> None:
-    """Set stores as frozenset, list as tuple: same elements, no longer equal (was repr-sort luck)."""
+def test_set_and_list_values_alias() -> None:
+    """Set and list inputs with the same elements both normalize to a frozenset: same filter."""
     from_set = FilterParameterImpl.from_dict({"values": {"EU", "NA"}})
     from_list = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
 
-    assert from_set != from_list
+    assert from_set == from_list
+    assert hash(from_set) == hash(from_list)
+
+
+def test_differently_ordered_list_values_alias() -> None:
+    """Test list input order carries no meaning either: it's folded into the same frozenset."""
+    first = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
+    second = FilterParameterImpl.from_dict({"values": ["NA", "EU"]})
+
+    assert first == second
+    assert hash(first) == hash(second)
 
 
 def test_values_property_returns_list_for_tuple_input() -> None:


### PR DESCRIPTION
## Summary

`_normalize_collections` sorted set/frozenset values by `repr()` when converting them to a tuple. `repr()` is not canonical with respect to Python's own value equality, so cross-type-equal elements (e.g. `1` and `True`) could normalize to different orders depending on which concrete type was used, making two otherwise-equal `FilterParameterImpl` instances compare unequal and hash differently.

## Fix

Normalize set/frozenset values to a `frozenset` instead of a sorted tuple. `frozenset` equality and hashing are already order- and representation-independent, so cross-type-equal elements land the same regardless of which side used which type. This mirrors how `_deep_hashable` and `Feature._reduce` already normalize sets elsewhere in the codebase.

The public `values` property still hands out a `list`: since a `frozenset`'s own iteration order depends on the process hash seed, it is re-sorted by `repr` on the way out, matching the deterministic order the previous tuple-based storage produced (SQL filter engines build query parameters from this list).

## Testing

Added tests for cross-type-equal set/frozenset normalization, deterministic public ordering, and the internal storage shape. Full `tox` gate (tests, ruff format/check, mypy --strict, bandit, license check) passes.

Fixes #1195