### PR TITLE
fix: key JoinStep.matched on genuine join sides, not the broad required_uuids

### DIFF
--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -97,7 +97,7 @@ class JoinStep(Step):
         If matched, return the uuid of the join step.
         """
 
-        if uuid not in self.required_uuids:
+        if uuid not in self.destination_framework_uuids and uuid not in self.source_framework_uuids:
             return None
 
         if other_framework == self.destination_framework:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -83,6 +83,13 @@ class AppendOrUnionSides(NamedTuple):
     right_uuid: UUID
 
 
+class _JoinServedParent(NamedTuple):
+    """Stand-in for a parent delivered by a JoinStep (no TransformFrameworkStep is built for it), so it
+    can still be named in the missing-Links conflict error."""
+
+    from_feature_group: type[FeatureGroup]
+
+
 class ExecutionPlan:
     def __init__(
         self,
@@ -248,25 +255,35 @@ class ExecutionPlan:
 
     @staticmethod
     def _parents_linked_by_join(uuid_a: UUID, uuid_b: UUID, join_steps: set[JoinStep]) -> bool:
-        """Whether some planned JoinStep ties these two parents together on genuine opposite sides.
+        """Whether two parents are linked, directly or transitively, via JoinSteps' genuine sides
+        (not ``required_uuids``, which unions all of a join's consumers' parents, not just its own two)."""
+        if uuid_a == uuid_b:
+            return True
 
-        ``required_uuids`` is excluded: it is the union of ALL parents of everything that consumes
-        the join (see ``run_link``'s ``join_step_required_uuids``), not just the join's own two
-        sides, so two unrelated parents can coincidentally both appear there.
-        """
+        adjacency: dict[UUID, set[UUID]] = defaultdict(set)
         for js in join_steps:
-            a_dest, a_src = uuid_a in js.destination_framework_uuids, uuid_a in js.source_framework_uuids
-            b_dest, b_src = uuid_b in js.destination_framework_uuids, uuid_b in js.source_framework_uuids
-            if (a_dest and b_src) or (a_src and b_dest):
+            for dest_uuid in js.destination_framework_uuids:
+                adjacency[dest_uuid].update(js.source_framework_uuids)
+            for src_uuid in js.source_framework_uuids:
+                adjacency[src_uuid].update(js.destination_framework_uuids)
+
+        visited = {uuid_a}
+        frontier = {uuid_a}
+        while frontier:
+            frontier = set().union(*(adjacency[node] for node in frontier)) - visited
+            if uuid_b in frontier:
                 return True
+            visited |= frontier
         return False
 
     @staticmethod
     def _conflicting_transform_hops_error(
-        ep: FeatureGroupStep, first_hop: TransformFrameworkStep, second_hop: TransformFrameworkStep
+        ep: FeatureGroupStep,
+        first_hop: TransformFrameworkStep | _JoinServedParent,
+        second_hop: TransformFrameworkStep | _JoinServedParent,
     ) -> str:
-        """A FeatureGroupStep can only bind one incoming framework hop; two distinct, unlinked
-        upstream instances is a missing-Link configuration problem, not a bug."""
+        """A FeatureGroupStep can only bind one incoming source; two distinct, unlinked ones is a
+        missing-Link configuration problem, not a bug."""
         feature_name = format_feature_group_class(ep.feature_group)
         first_name = format_feature_group_class(first_hop.from_feature_group)
         second_name = format_feature_group_class(second_hop.from_feature_group)
@@ -489,23 +506,26 @@ Available join types:
                     member_parents = graph.parent_to_children_mapping.get(member_uuid, set())
                     parents |= member_parents - self.get_parent_parents(member_parents, graph)
 
-                # Every distinct hop this step binds, collected before any conflict is decided: whether
-                # a later hop links to an earlier one must not depend on the arbitrary (set-derived)
-                # order the parents are visited in, only on the final, complete set of hops this step
-                # actually binds. The conflict check itself runs once, after this loop.
-                bound_hops: list[tuple[TransformFrameworkStep, UUID]] = []
+                # Explicit hops and join-served parents (delivered pre-merged by a JoinStep, no hop built)
+                # both compete for this step's one binding, so both get grouped by the same linkage test
+                # below. Order-independent: collected here, grouped once after the loop.
+                bound_entries: list[tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]]] = []
+                join_served_entries: list[tuple[type[FeatureGroup], UUID, list[JoinStep]]] = []
+                seen_hop_uuids: set[UUID] = set()
 
                 for parent in parents:
-                    match = set()
                     parent_node_property = graph.get_nodes()[parent]
-
-                    for js in left_join_frameworks:
-                        found = js.matched(ep.compute_framework, parent_node_property.feature.uuid)
-                        if found:
-                            match.add(found)
-                            break
-                    if match:
-                        # parent is served by a join step; the expanded link token already orders the consumer
+                    matching_join_steps = [
+                        js
+                        for js in left_join_frameworks
+                        if js.matched(ep.compute_framework, parent_node_property.feature.uuid)
+                    ]
+                    if matching_join_steps:
+                        # Served by a join, no explicit hop needed; keep every matching join, not just
+                        # the first, so the later linkage check doesn't depend on set iteration order.
+                        join_served_entries.append(
+                            (parent_node_property.feature_group_class, parent, matching_join_steps)
+                        )
                         continue
 
                     if ep.compute_framework != parent_node_property.feature.get_compute_framework():
@@ -523,8 +543,9 @@ Available join types:
                             new_execution_plan.append(new_tfs)
                             canonical_tfs = new_tfs
 
-                        if not any(hop.uuid == canonical_tfs.uuid for hop, _ in bound_hops):
-                            bound_hops.append((canonical_tfs, parent))
+                        if canonical_tfs.uuid not in seen_hop_uuids:
+                            seen_hop_uuids.add(canonical_tfs.uuid)
+                            bound_entries.append((canonical_tfs, parent, []))
 
                         # Records every parent the hop covers; they all share one owning step, so
                         # this doesn't change the scheduling gate.
@@ -536,33 +557,62 @@ Available join types:
 
                         need_to_upload_collector.add(parent)
 
-                # Group the distinct hops by transitive linkage (same source feature-group class, or
-                # tied together by a declared Link): a hop conflicts only with a group it links to
-                # neither by class nor by Link, not with every other hop individually. This also settles
-                # a hop whose own parent uuid never itself became a JoinStep's destination/source uuid
-                # (e.g. an off-framework sibling of the declared side the join actually used) as long as
-                # some other member of its group did; grouping every hop up front, rather than deciding
-                # per pair as each parent is visited, keeps the result independent of the (arbitrary,
-                # set-derived) order the parents were visited in.
-                hop_groups: list[list[tuple[TransformFrameworkStep, UUID]]] = []
-                for hop, hop_parent in bound_hops:
+                # Group entries by transitive linkage: same feature-group class, declared-side sharing via
+                # either entry's matching JoinSteps (catches a case-override hop whose parent lost the
+                # JoinStep's own uuid to a same-role sibling, see `_case_override_beats_nearer_wrong_framework_left`),
+                # or `_parents_linked_by_join`.
+                def _entries_linked(
+                    entry_a: tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]],
+                    entry_b: tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]],
+                ) -> bool:
+                    hop_a, parent_a, matching_a = entry_a
+                    hop_b, parent_b, matching_b = entry_b
+                    if hop_a.from_feature_group is hop_b.from_feature_group:
+                        return True
+                    if any(
+                        issubclass(hop_b.from_feature_group, declared_side)
+                        for js in matching_a
+                        for declared_side in (js.link.left_feature_group, js.link.right_feature_group)
+                    ):
+                        return True
+                    if any(
+                        issubclass(hop_a.from_feature_group, declared_side)
+                        for js in matching_b
+                        for declared_side in (js.link.left_feature_group, js.link.right_feature_group)
+                    ):
+                        return True
+                    return self._parents_linked_by_join(parent_a, parent_b, left_join_frameworks)
+
+                def _add_to_groups(
+                    groups: list[list[tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]]]],
+                    entry: tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]],
+                ) -> None:
                     linked_groups = [
-                        group
-                        for group in hop_groups
-                        if any(
-                            member_hop.from_feature_group is hop.from_feature_group
-                            or self._parents_linked_by_join(member_parent, hop_parent, left_join_frameworks)
-                            for member_hop, member_parent in group
-                        )
+                        group for group in groups if any(_entries_linked(entry, member) for member in group)
                     ]
                     if linked_groups:
                         target_group = linked_groups[0]
-                        target_group.append((hop, hop_parent))
+                        target_group.append(entry)
                         for other_group in linked_groups[1:]:
                             target_group.extend(other_group)
-                            hop_groups.remove(other_group)
+                            groups.remove(other_group)
                     else:
-                        hop_groups.append([(hop, hop_parent)])
+                        groups.append([entry])
+
+                hop_groups: list[list[tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]]]] = []
+                for entry in bound_entries:
+                    _add_to_groups(hop_groups, entry)
+
+                if len(hop_groups) > 1:
+                    raise ValueError(
+                        self._conflicting_transform_hops_error(ep, hop_groups[0][0][0], hop_groups[1][0][0])
+                    )
+
+                # Join-served parents compete for the same binding, so merge them into the same groups too.
+                for served_feature_group, served_parent, matching_join_steps in join_served_entries:
+                    _add_to_groups(
+                        hop_groups, (_JoinServedParent(served_feature_group), served_parent, matching_join_steps)
+                    )
 
                 if len(hop_groups) > 1:
                     raise ValueError(
@@ -809,6 +859,7 @@ Available join types:
             right_uuids = frozenset({sides.right_uuid})
             # Append/union gates only on its own two feature uuids, not on the general required_uuids.
             join_step_required_uuids = {sides.left_uuid, sides.right_uuid}
+            join_uuids_left, join_uuids_right = left_uuids, right_uuids
         else:
             side = JoinSide.RIGHT if swap_sides else JoinSide.LEFT
             destination = frozenset(destination_framework_uuids)
@@ -831,12 +882,21 @@ Available join types:
                 # step/framework hop and is dropped by design.
                 left_uuids, right_uuids = left_from_split, right_from_split
             else:
-                # The step's own sets, so a record never names parents outside its destination/source
-                # claim. A same-framework self link lands here too, since its declared sides are then
-                # identical; a cross-framework self link (parents split across two frameworks) instead
-                # takes the branch above, like any other multi-framework declared side.
+                # The step's own sets; a same-framework self link lands here too. Framework-broad, so
+                # join_uuids_left/right below narrow independently rather than reusing these.
                 left_uuids, right_uuids = resolved_left, resolved_right
             join_step_required_uuids = required_uuids
+
+            # destination_uuids/source_uuids must only ever name genuine declared-side members, regardless
+            # of which branch above ran; any-distance widening keeps a nearer wrong-framework sibling from
+            # hiding a farther, correct one.
+            declared_side_uuids = split.left_uuids_any_distance | split.right_uuids_any_distance
+            join_uuids_left = resolved_left & declared_side_uuids
+            join_uuids_right = resolved_right & declared_side_uuids
+
+        destination_uuids, source_uuids = (
+            (join_uuids_right, join_uuids_left) if side is JoinSide.RIGHT else (join_uuids_left, join_uuids_right)
+        )
 
         record = ResolvedJoin(
             link_uuid=link.uuid,
@@ -848,8 +908,8 @@ Available join types:
                 link.right_feature_group, link.right_index, right_uuids, self.declared_frameworks
             ),
             destination_side=side,
-            destination_uuids=frozenset(destination_framework_uuids),
-            source_uuids=frozenset(source_framework_uuids),
+            destination_uuids=frozenset(destination_uuids),
+            source_uuids=frozenset(source_uuids),
             destination_framework=destination_framework,
             source_framework=source_framework,
             consumers=frozenset(children_uuids),

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -6,6 +6,8 @@ same-shaped hops from genuinely different parents must not dedup into one (Scena
 from typing import NamedTuple
 from uuid import UUID, uuid4
 
+import pytest
+
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
@@ -23,6 +25,9 @@ from mloda.user import Link
 from mloda.user import Options
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
 
 
 class DedupBaseFG(FeatureGroup):
@@ -275,3 +280,81 @@ def test_parents_linked_by_join_requires_genuine_opposite_sides() -> None:
 
     assert ExecutionPlan._parents_linked_by_join(a, b, {join_step}) is False
     assert ExecutionPlan._parents_linked_by_join(dest, src, {join_step}) is True
+
+
+# ---------------------------------------------------------------------------
+# A parent matching more than one JoinStep must not depend on set iteration order
+# ---------------------------------------------------------------------------
+
+
+class MatchedJsHubFG(DedupBaseFG):
+    """A hub genuinely joined to two different sides, so its uuid is a real side of two JoinSteps."""
+
+
+class MatchedJsAFG(DedupBaseFG):
+    pass
+
+
+class MatchedJsYFG(DedupBaseFG):
+    pass
+
+
+class MatchedJsConsumerFG(DedupBaseFG):
+    pass
+
+
+def _hub_matches_two_joins_scenario(
+    hub_link_token: UUID, other_link_token: UUID
+) -> tuple[list[JoinStep | FeatureGroupStep], Graph]:
+    """Hub parent P genuinely matches both JoinSteps; only the token order differs between calls."""
+    graph = Graph()
+
+    p = _feature("matched_js_hub_p", PandasDataFrame)
+    q = _feature("matched_js_a_q", PyArrowTable)
+    graph.add_node(p.uuid, NodeProperties(p, MatchedJsHubFG))
+    graph.add_node(q.uuid, NodeProperties(q, MatchedJsAFG))
+    graph.parent_to_children_mapping[p.uuid] = set()
+    graph.parent_to_children_mapping[q.uuid] = set()
+
+    hub_link = Link.inner(JoinSpec(MatchedJsAFG, "id"), JoinSpec(MatchedJsHubFG, "id"))
+    other_link = Link.inner(JoinSpec(MatchedJsHubFG, "id2"), JoinSpec(MatchedJsYFG, "id2"))
+
+    hub_join_step = JoinStep(
+        link=hub_link,
+        destination_framework=PandasDataFrame,
+        source_framework=PyArrowTable,
+        required_uuids=set(),
+        destination_framework_uuids={p.uuid},
+        source_framework_uuids={uuid4()},
+        token=hub_link_token,
+    )
+    other_join_step = JoinStep(
+        link=other_link,
+        destination_framework=PandasDataFrame,
+        source_framework=PythonDictFramework,
+        required_uuids=set(),
+        destination_framework_uuids={p.uuid},
+        source_framework_uuids={uuid4()},
+        token=other_link_token,
+    )
+
+    consumer = _feature("matched_js_consumer", PandasDataFrame)
+    feature_set = FeatureSet()
+    feature_set.add(consumer)
+    graph.parent_to_children_mapping[consumer.uuid] = {p.uuid, q.uuid}
+    consumer_step = FeatureGroupStep(MatchedJsConsumerFG, feature_set, set(), PandasDataFrame)
+
+    return [hub_join_step, other_join_step, consumer_step], graph
+
+
+@pytest.mark.parametrize(
+    "hub_link_token, other_link_token",
+    [(UUID(int=1), UUID(int=2)), (UUID(int=2), UUID(int=1))],
+    ids=["hub_link_lower_token", "other_link_lower_token"],
+)
+def test_parent_matching_two_join_steps_does_not_raise_regardless_of_token_order(
+    hub_link_token: UUID, other_link_token: UUID
+) -> None:
+    execution_plan, graph = _hub_matches_two_joins_scenario(hub_link_token, other_link_token)
+
+    ExecutionPlan().add_tfs(execution_plan, graph)

--- a/tests/test_core/test_prepare/test_joinstep_matched_broad_required_uuids.py
+++ b/tests/test_core/test_prepare/test_joinstep_matched_broad_required_uuids.py
@@ -1,0 +1,298 @@
+"""An unrelated, unlinked parent must not skip the missing-Link conflict check by being wrongly
+treated as "served by" a join it isn't genuinely a side of."""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Index, Link, Options, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+class LinkedRootA(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"linked_root_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        import pandas as pd
+
+        return pd.DataFrame({"linked_root_a": [1, 2, 3], "id": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("id",))]
+
+
+class LinkedRootB(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"linked_root_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        import pyarrow as pa
+
+        return pa.table({"linked_root_b": [10, 20, 30], "id": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("id",))]
+
+
+class OrphanRootC(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"orphan_root_c"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"orphan_root_c": [100, 200, 300]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+
+class OrphanRootD(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"orphan_root_d"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"orphan_root_d": [1000, 2000, 3000]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+
+class FourParentConsumer(FeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("linked_root_a"),
+            Feature("linked_root_b"),
+            Feature("orphan_root_c"),
+            Feature("orphan_root_d"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"four_parent_consumer_result"}
+
+
+class ThreeParentConsumer(FeatureGroup):
+    """A join-served linked pair (zero explicit hops) plus an orphan (one explicit hop)."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("linked_root_a"),
+            Feature("linked_root_b"),
+            Feature("orphan_root_c"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"three_parent_consumer_result"}
+
+
+def test_joinstep_matched_does_not_swallow_unrelated_unlinked_parent() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        mloda.prepare(
+            features=[Feature("four_parent_consumer_result")],
+            links={Link.inner_on(LinkedRootA, LinkedRootB)},
+            compute_frameworks={PandasDataFrame, PyArrowTable, PythonDictFramework},
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {LinkedRootA, LinkedRootB, OrphanRootC, OrphanRootD, FourParentConsumer}
+            ),
+        )
+
+    error_message = str(exc_info.value)
+
+    assert "Link" in error_message, "Error should mention Links as the missing piece of guidance"
+    assert "OrphanRootC" in error_message, "Error should name the first conflicting unlinked upstream feature group"
+    assert "OrphanRootD" in error_message, "Error should name the second conflicting unlinked upstream feature group"
+
+
+def test_joinstep_matched_raises_for_literal_three_parent_scenario() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        mloda.prepare(
+            features=[Feature("three_parent_consumer_result")],
+            links={Link.inner_on(LinkedRootA, LinkedRootB)},
+            compute_frameworks={PandasDataFrame, PyArrowTable, PythonDictFramework},
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {LinkedRootA, LinkedRootB, OrphanRootC, ThreeParentConsumer}
+            ),
+        )
+
+    error_message = str(exc_info.value)
+
+    assert "Link" in error_message, "Error should mention Links as the missing piece of guidance"
+    assert "OrphanRootC" in error_message, "Error should name the unlinked orphan feature group"
+    assert "LinkedRootA" in error_message or "LinkedRootB" in error_message, (
+        "Error should name the linked side it conflicts with"
+    )
+
+
+class IndependentJoinPairOneLeft(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"independent_join_pair_one_left"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        import pandas as pd
+
+        return pd.DataFrame({"independent_join_pair_one_left": [1, 2, 3], "pair_one_id": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("pair_one_id",))]
+
+
+class IndependentJoinPairOneRight(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"independent_join_pair_one_right"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"independent_join_pair_one_right": [10, 20, 30], "pair_one_id": [1, 2, 3]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("pair_one_id",))]
+
+
+class IndependentJoinPairTwoLeft(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"independent_join_pair_two_left"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        import pandas as pd
+
+        return pd.DataFrame({"independent_join_pair_two_left": [4, 5, 6], "pair_two_id": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("pair_two_id",))]
+
+
+class IndependentJoinPairTwoRight(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"independent_join_pair_two_right"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"independent_join_pair_two_right": [40, 50, 60], "pair_two_id": [1, 2, 3]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("pair_two_id",))]
+
+
+class TwoIndependentJoinsConsumer(FeatureGroup):
+    """Both parents are join-served by two separate, unlinked JoinSteps: zero explicit hops at all."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("independent_join_pair_one_left"),
+            Feature("independent_join_pair_one_right"),
+            Feature("independent_join_pair_two_left"),
+            Feature("independent_join_pair_two_right"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"two_independent_joins_consumer_result"}
+
+
+def test_joinstep_matched_raises_when_every_parent_is_join_served() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        mloda.prepare(
+            features=[Feature("two_independent_joins_consumer_result")],
+            links={
+                Link.inner_on(IndependentJoinPairOneLeft, IndependentJoinPairOneRight),
+                Link.inner_on(IndependentJoinPairTwoLeft, IndependentJoinPairTwoRight),
+            },
+            compute_frameworks={PandasDataFrame, PyArrowTable, PythonDictFramework},
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {
+                    IndependentJoinPairOneLeft,
+                    IndependentJoinPairOneRight,
+                    IndependentJoinPairTwoLeft,
+                    IndependentJoinPairTwoRight,
+                    TwoIndependentJoinsConsumer,
+                }
+            ),
+        )
+
+    error_message = str(exc_info.value)
+
+    assert "Link" in error_message, "Error should mention Links as the missing piece of guidance"
+    # Either member of a pair can be the one a group reports first (both are join-served by the same
+    # JoinStep and merge into one group), so accept either side's name for each of the two pairs.
+    assert any(name in error_message for name in ("IndependentJoinPairOneLeft", "IndependentJoinPairOneRight")), (
+        "Error should name a feature group from the first independently join-served pair"
+    )
+    assert any(name in error_message for name in ("IndependentJoinPairTwoLeft", "IndependentJoinPairTwoRight")), (
+        "Error should name a feature group from the second independently join-served pair"
+    )

--- a/tests/test_core/test_prepare/test_resolved_join_record.py
+++ b/tests/test_core/test_prepare/test_resolved_join_record.py
@@ -207,6 +207,14 @@ class FrameworkCollision(NamedTuple):
     unrelated_uuid: UUID
 
 
+class FallbackBranchCollision(NamedTuple):
+    plan: ExecutionPlan
+    link: Link
+    left_uuid: UUID
+    far_right_uuid: UUID
+    unrelated_uuid: UUID
+
+
 class Chain(NamedTuple):
     plan: ExecutionPlan
     producer: Link
@@ -446,6 +454,34 @@ def _link_with_a_declared_left_split_across_frameworks_and_a_colliding_third_par
     }
     planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker, declared_frameworks)
     return FrameworkCollision(planned.plan, link, left_pandas.uuid, left_pyarrow.uuid, right.uuid, unrelated.uuid)
+
+
+def _right_join_farther_right_parent_and_a_colliding_third_parent() -> FallbackBranchCollision:
+    """Lands run_link's final fallback branch; an unrelated third parent shares the source framework."""
+    planned = _planned()
+    link = _pair_link(Link.right)
+
+    left = feature("resolved_join_fallback_collision_left", PyArrowTable, link.left_index)
+    nearest_right = feature("resolved_join_fallback_collision_nearest_right", PythonDictFramework, link.right_index)
+    far_right = feature("resolved_join_fallback_collision_far_right", PandasDataFrame, link.right_index)
+    unrelated = feature("resolved_join_fallback_collision_unrelated", PyArrowTable)
+    child = feature("resolved_join_fallback_collision_child", PandasDataFrame)
+
+    planned.graph.add_node(left.uuid, NodeProperties(left, link.left_feature_group))
+    planned.graph.add_node(nearest_right.uuid, NodeProperties(nearest_right, ResolvedJoinPairRight))
+    planned.graph.add_node(far_right.uuid, NodeProperties(far_right, ResolvedJoinPairRightDescendant))
+    planned.graph.add_node(unrelated.uuid, NodeProperties(unrelated, ResolvedJoinUnlinked))
+    planned.queue.append((link.left_feature_group, {left}))
+    planned.queue.append((ResolvedJoinPairRight, {nearest_right}))
+    planned.queue.append((ResolvedJoinPairRightDescendant, {far_right}))
+    planned.queue.append((ResolvedJoinUnlinked, {unrelated}))
+    planned.queue.append((link, PyArrowTable, PandasDataFrame))
+    _add_child(planned, child, left, nearest_right, far_right, unrelated)
+    # The trekker key matches the queued key directly, so run_link never flips here.
+    trek(planned.link_trekker, link, (PyArrowTable, PandasDataFrame), child.uuid)
+
+    planned.plan.create_execution_plan(planned.queue, planned.graph, planned.link_trekker)
+    return FallbackBranchCollision(planned.plan, link, left.uuid, far_right.uuid, unrelated.uuid)
 
 
 def _ordered_chain() -> Chain:
@@ -945,8 +981,7 @@ def test_a_parent_the_link_never_mentions_stays_out_of_the_declared_sides() -> N
     assert record.destination_side is JoinSide.RIGHT
     assert record.left.uuids == {unlinked.left_uuid}
     assert record.right.uuids == {unlinked.right_uuid}
-    # The join writes into a parent that belongs to neither declared side, which a validation step should reject.
-    assert record.destination_uuids == {unlinked.right_uuid, unlinked.unlinked_uuid}
+    assert record.destination_uuids == {unlinked.right_uuid}
     assert record.source_uuids == {unlinked.left_uuid}
 
 
@@ -960,27 +995,26 @@ def test_a_declared_side_keeps_only_the_frameworks_its_own_parents_declared() ->
     assert PythonDictFramework not in record.left.declared_frameworks | record.right.declared_frameworks
 
 
-def test_a_third_parent_sharing_the_destination_framework_must_not_leak_into_declared_left() -> None:
-    """Issue #1137 finding #1: the declared left split across two frameworks defeats the full (both-sides)
-    containment check, and the fallback must not hand an unrelated, same-framework parent to record.left,
-    nor the declared-left parent that belongs to the other framework's joinstep."""
-    built = _link_with_a_declared_left_split_across_frameworks_and_a_colliding_third_parent()
+def test_a_third_parent_sharing_the_destination_framework_now_raises_a_missing_links_error() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        _link_with_a_declared_left_split_across_frameworks_and_a_colliding_third_parent()
 
-    record = _one_record(built.plan, built.link)
-
-    assert built.unrelated_uuid not in record.left.uuids
-    assert built.left_pyarrow_uuid not in record.left.uuids
-    assert record.left.uuids == {built.left_pandas_uuid}
-    assert record.right.uuids == {built.right_uuid}
+    error_message = str(exc_info.value)
+    assert "Link" in error_message, "Error should mention Links as the missing piece of guidance"
+    # Either declared side can be the one a merged join-served group reports first, so accept either name.
+    assert "ResolvedJoinPairLeft" in error_message or "ResolvedJoinPairRight" in error_message
+    assert "ResolvedJoinUnlinked" in error_message
 
 
-def test_a_third_parent_sharing_the_destination_framework_must_not_leak_its_frameworks_into_declared_left() -> None:
-    built = _link_with_a_declared_left_split_across_frameworks_and_a_colliding_third_parent()
+def test_a_third_parent_colliding_in_run_links_final_fallback_also_raises() -> None:
+    """Same leak as above, in run_link's other (final fallback) branch."""
+    with pytest.raises(ValueError) as exc_info:
+        _right_join_farther_right_parent_and_a_colliding_third_parent()
 
-    record = _one_record(built.plan, built.link)
-
-    assert PandasDataFrame in record.left.declared_frameworks
-    assert PythonDictFramework not in record.left.declared_frameworks
+    error_message = str(exc_info.value)
+    assert "Link" in error_message, "Error should mention Links as the missing piece of guidance"
+    assert "ResolvedJoinPairRight" in error_message
+    assert "ResolvedJoinUnlinked" in error_message
 
 
 def test_a_self_join_gives_each_declared_side_only_its_own_parent() -> None:
@@ -1087,7 +1121,6 @@ def test_a_decline_reached_through_the_inversion_branch_records_the_orientation_
         _case_override_disagrees_with_the_nearest_split,
         _right_join_farther_right_parent_holds_destination_framework,
         _right_join_both_sides_claim_destination_framework,
-        _link_with_a_declared_left_split_across_frameworks_and_a_colliding_third_parent,
         _right_join_both_declared_sides_share_one_framework_child_on_a_third,
         _right_join_declared_left_spans_frameworks_declared_right_is_pyarrow_only,
     ],
@@ -1106,7 +1139,6 @@ def test_a_decline_reached_through_the_inversion_branch_records_the_orientation_
         "case_override_disagrees_with_nearest_split",
         "right_join_farther_right_parent_holds_destination_framework",
         "right_join_both_sides_claim_destination_framework",
-        "declared_left_framework_collision_with_unrelated_third_parent",
         "right_join_both_declared_sides_share_one_framework",
         "right_join_declared_right_is_pyarrow_exclusive",
     ],


### PR DESCRIPTION
## Summary

A FeatureGroupStep whose parents come from two different, unlinked upstream sources is supposed to raise a "missing Links" error at plan-build time rather than silently binding only one source's data. That guard could be bypassed: `JoinStep.matched()` decided whether a parent was "already served" by a join using that join's full prerequisite superset, not its own two genuine sides, so an unrelated parent could be wrongly absorbed and skip the conflict check entirely.

## Changes

- `JoinStep.matched()` now keys on the join's genuine destination/source side membership instead of the broad prerequisite set.
- `_parents_linked_by_join` now walks the graph of genuine opposite-side edges (handles hub-style join graphs, where two sources are joined separately to a shared hub and are only linked transitively through it) instead of checking a single JoinStep at a time.
- The conflict check unifies explicit transform hops and join-served parents into one grouping mechanism, so a linked pair competing with a lone unrelated parent, or two independently join-served parents with no hop between them, are caught the same way two explicit hops always were.
- A parent matching more than one JoinStep is checked against all of its matching joins, removing a dependency on set iteration order.
- The uuid sets that feed the above (`destination_uuids`/`source_uuids`) are now always narrowed to genuine declared-side membership in every code path that computes them, closing a class of leaks where an unrelated parent sharing a join's compute framework could still be swallowed.

## Test plan

- [x] New regression tests through the public `mloda.prepare`/`mlodaAPI` surface covering: an unrelated orphan parent alongside a linked pair, the literal three-parent scenario, a parent genuinely served by two different joins, and a consumer whose parents are entirely join-served across two independent unlinked joins.
- [x] Existing chained/star join test families and `ResolvedJoin` construction tests pass unchanged (or updated where they had been asserting the previously-leaky behavior).
- [x] Full tox: pytest, ruff format/check, mypy --strict, bandit, license allowlist all pass.