### PR TITLE
docs: fix spelling in example walkthroughs

### DIFF
--- a/docs/docs/examples/mloda_basics/1_ml_mloda_intro.py
+++ b/docs/docs/examples/mloda_basics/1_ml_mloda_intro.py
@@ -226,7 +226,7 @@ def _(mo):
 
     1. mloda unifies the interfaces for data for various sources, formats and technologies for the definition of the processes and applying the processes on the data. We used the FeatureGroup, the ComputeFramework and mlodaAPI as interfaces.
 
-    2. It integrates with any techologies, e.g. PyArrow and Pandas, enabling flexible tool choices for data processing.
+    2. It integrates with any technologies, e.g. PyArrow and Pandas, enabling flexible tool choices for data processing.
 
     3. mloda combines data access and computation, reducing complexity and providing a reusable approach to ML workflows. Data Access can be controlled centrally for different sources of data. Here, we showed folders and a database access.
 

--- a/docs/docs/examples/mloda_basics/2_ml_advantage_process_focus.py
+++ b/docs/docs/examples/mloda_basics/2_ml_advantage_process_focus.py
@@ -38,7 +38,7 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## Data should be reuseable
+    ## Data should be reusable
 
     In most organizations, data pipelines are often built with a single-purpose focus. This tight coupling of data and data transformation within the same process limits reusability. For example:
 

--- a/docs/docs/examples/mloda_basics/3_ml_data_feature_feature_groups.py
+++ b/docs/docs/examples/mloda_basics/3_ml_data_feature_feature_groups.py
@@ -199,7 +199,7 @@ def _(mo):
      - Testing migrations: Feature(A, Polars), Feature(B, Pandas)
      - Sliding time windows: Feature(A, 10 days), Feature(B, 20 days)
 
-    This means inbetween Data to Feature, we have another abstraction, the FeatureSet.
+    This means in between Data to Feature, we have another abstraction, the FeatureSet.
     """)
     return
 
@@ -219,7 +219,7 @@ def _(mo):
         ...
     ```
 
-    In that sense, the FeatureSet has informations of
+    In that sense, the FeatureSet has information of
 
     - the Features itself
     - filters

--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
@@ -354,7 +354,7 @@ def _(mo):
 
     - POC notebooks
     - Production code scenarios (model training or realtime prediction)
-    - Micro service endpont
+    - Micro service endpoint
     - KPI or QA test data ingestion
 
     With this, the whole ml lifecycle is represented and plugins can be reused in a testable and repeatable way along this cycle.

--- a/docs/docs/examples/mloda_basics/create_synthetic_data.py
+++ b/docs/docs/examples/mloda_basics/create_synthetic_data.py
@@ -55,7 +55,7 @@ class PaymentSyntheticDataSet(OrderSyntheticDataSet):
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         num_samples = features.get_options_key("num_samples")
 
-        # Shuffle valid datetime informations
+        # Shuffle valid datetime information
         valid_datetime_dates = pd.date_range(start="2024-01-01", end="2024-02-01", periods=num_samples, tz="UTC")
         valid_datetime_dates = valid_datetime_dates.to_numpy(copy=True)
         np.random.shuffle(valid_datetime_dates)

--- a/docs/docs/examples/sklearn_integration_basic.py
+++ b/docs/docs/examples/sklearn_integration_basic.py
@@ -143,7 +143,7 @@ def _(data_dict, pd):
     # In mloda, we have the concept of feature groups.
     # A feature group is an abstraction between a data framework and processes of a data transformation.
     # In this example, the data framework is clearly pandas.
-    # The processes are typically meta information like names, but lifecyle definition, or dependencies or relations to other data.
+    # The processes are typically meta information like names, but lifecycle definition, or dependencies or relations to other data.
     class SklearnDataCreator(FeatureGroup):
         # On the basis on the given data_dict earlier defined and its names, we use a DataCreator to inject the data_dict into the feature group abstraction.
         # Very simply spoken: we load the data.


### PR DESCRIPTION
## Summary

Correct seven spelling errors in the rendered ML basics and sklearn examples. This is a documentation-only change and does not alter example behavior.

## Type of change

- [x] Documentation (`docs:`)

## Validation

- `uvx codespell docs/docs/examples`
- `ruff 0.15.13 check` on all six affected files
- `ruff 0.15.13 format --check` on all six affected files

## Checklist

- [x] Documentation updated where relevant
- [x] PR title follows Conventional Commits
- [x] No test changes required for this documentation-only correction