### PR TITLE
refactor: share the PropertySpec declaration mechanics between READER_OPTIONS and PROPERTY_MAPPING

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -128,6 +128,9 @@ differently because they consume values at different moments.
 | `PROPERTY_MAPPING` | a `FeatureGroup` | Enforces it and applies it: value validation (`allowed_values`, `element_validator`), presence and `required_when`, and materialization of declared defaults into `Options`. |
 | `READER_OPTIONS` | a `BaseInputData` reader | Enforces it at reader selection: presence, `required_when` and strict values are checked before a candidate probes, and a failure vetoes that reader, recording per the ownership rule above. Defaults are never materialized; only the reader's own code applies them. |
 
+Both surfaces run the same per-key validator, and the reader's MRO merge goes through the shared
+helper module (`mloda/core/abstract_plugins/components/declaration_surface.py`).
+
 A reader consumes its option keys during reader **selection** (`match_subclass_data_access`, reached
 through `BaseInputData.matches` from the matcher), before the framework materializes anything. Two
 consequences keep the shared type honest on this surface:
@@ -638,6 +641,7 @@ if it really is a whole-value check.
 | Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
 | Declared defaults materialized at intake, canonicalizing default-equivalent twins | `tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py` |
 | Filter criteria matching observes effective options | `tests/test_core/test_filter/test_filter_criteria_effective_options.py` |
+| The shared declaration mechanics: the per-key validator on both surfaces, the reader merge and its per-class cache, the plain-mixin walk | `tests/.../test_components/test_declaration_surface.py` |
 | The reader surface: the single spec type and its surface guards, the reserved framework key, the MRO merge, the loud undeclared key, the presence rule of `reader_option()` | `tests/.../test_components/test_reader_option_declarations.py` |
 | Reader selection enforcement: strict values, requiredness, the `framework_set` exemption, the attributable `input_data` rejection | `tests/.../test_components/test_reader_option_enforcement.py` |
 | Per-reader declarations, the declared `default` that is load-bearing at selection, and the bare-path branch it does not reach | `tests/.../input_data/test_reader_option_declarations.py` |

--- a/mloda/core/abstract_plugins/components/declaration_surface.py
+++ b/mloda/core/abstract_plugins/components/declaration_surface.py
@@ -1,0 +1,183 @@
+"""Shared mechanics behind ``FeatureGroup.PROPERTY_MAPPING`` and ``BaseInputData.READER_OPTIONS``:
+one per-key validator and one merge helper (the reader merges, the feature group reads its
+attribute); two names, one spec type.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+
+
+class DeclarationSurface(Enum):
+    """The two class-body attributes that share the merge mechanics: which name, which cache."""
+
+    FEATURE_GROUP = ("PROPERTY_MAPPING", "_property_mapping_cache")
+    READER = ("READER_OPTIONS", "_reader_option_specs_cache")
+
+    def __init__(self, attr: str, cache_attr: str) -> None:
+        self._surface_attr = attr
+        self._surface_cache_attr = cache_attr
+
+    @property
+    def attr(self) -> str:
+        return self._surface_attr
+
+    @property
+    def cache_attr(self) -> str:
+        return self._surface_cache_attr
+
+
+def own_declaration(klass: type, surface: DeclarationSurface) -> dict[str, Any]:
+    """The class's own declaration on this surface, rejected loudly when it is None or not a dict."""
+    declared = klass.__dict__.get(surface.attr, {})
+    if declared is None:
+        raise ValueError(
+            f"{klass.__name__}.{surface.attr} is None. Declarations merge across the class "
+            f"hierarchy, so None cannot clear inherited keys. Remove the assignment or declare a dict."
+        )
+    if not isinstance(declared, dict):
+        raise ValueError(
+            f"{klass.__name__}.{surface.attr} is a {type(declared).__name__}, not a dict. "
+            f"Declare a dict mapping option keys to PropertySpec instances."
+        )
+    return declared
+
+
+class _MergedDeclaration(dict[str, PropertySpec]):
+    """The merge cache; a private type so reject_merge_cache_assignment can tell a framework-written
+    cache from an authored one."""
+
+
+def merged_declaration(cls: type, surface: DeclarationSurface) -> dict[str, PropertySpec]:
+    """The MRO-merged declaration of cls on this surface, cached in cls's OWN __dict__; hands
+    back the same object, not a copy. A cache present but not framework-written is poisoned and
+    raises the same way reject_merge_cache_assignment would."""
+    cached = cls.__dict__.get(surface.cache_attr)
+    if isinstance(cached, _MergedDeclaration):
+        return cached
+    if cached is not None:
+        reject_merge_cache_assignment(cls, surface)
+
+    merged = _MergedDeclaration()
+    for klass in reversed(cls.__mro__):
+        merged.update(own_declaration(klass, surface))
+    setattr(cls, surface.cache_attr, merged)
+    return merged
+
+
+def reject_merge_cache_assignment(cls: type, surface: DeclarationSurface) -> None:
+    """The merge cache is framework-written; assigning it in a class body is rejected. A cache warmed
+    by a cooperative __init_subclass__ hook before super() is a _MergedDeclaration and is not blamed."""
+    if surface.cache_attr not in cls.__dict__:
+        return
+    if isinstance(cls.__dict__[surface.cache_attr], _MergedDeclaration):
+        return
+    raise ValueError(
+        f"{cls.__name__} assigns {surface.cache_attr} in its class body; the merge cache is "
+        f"framework-written and must never be declared."
+    )
+
+
+def _reader_inert_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
+    """Fields inert on a reader spec regardless of framework_set."""
+    return (
+        (
+            spec.match_guard is not None,
+            "declares a match_guard, which is name-matching machinery and silently inert on a reader.",
+        ),
+        (
+            spec.deferred_binding,
+            "declares deferred_binding=True, which is the name-capture exemption; a reader key has no name path.",
+        ),
+        (spec.context is False, "declares context=False, which places a materialized value; readers place none."),
+    )
+
+
+def _reader_framework_set_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
+    """Combinations that are inert once a reader spec declares framework_set=True."""
+    return (
+        (
+            spec.strict_validation,
+            "combines framework_set=True with strict_validation=True; the framework-written key is "
+            "exempt from user-value validation, so strictness would be silently inert.",
+        ),
+        (
+            spec.required_when is not None,
+            "combines framework_set=True with a required_when predicate; the framework-written key is "
+            "exempt from user-value validation, so the predicate would be silently inert.",
+        ),
+        (
+            spec.allow_explicit_none,
+            "combines framework_set=True with allow_explicit_none=True; the admit path skips the "
+            "framework-written key, so the flag cannot affect reader selection.",
+        ),
+        (
+            is_no_default(spec.default),
+            "declares framework_set=True without a declared default; the framework-written key must "
+            "declare its absent-state default explicitly, None included.",
+        ),
+    )
+
+
+def _feature_group_checks(spec: PropertySpec) -> tuple[tuple[bool, str], ...]:
+    """Fields that are reader-only and therefore inert on a FeatureGroup spec."""
+    return (
+        (
+            spec.framework_set,
+            "declares framework_set=True, which marks a reader-only field; PROPERTY_MAPPING keys on a "
+            "FeatureGroup are user-set.",
+        ),
+        (
+            spec.scalar_only,
+            "declares scalar_only=True, which marks a reader-only field; PROPERTY_MAPPING keys on a "
+            "FeatureGroup always unpack element-wise.",
+        ),
+    )
+
+
+def validate_property_spec(
+    owner: str, key: str, spec: Any, surface: DeclarationSurface, via: str | None = None
+) -> PropertySpec:
+    """The per-key rules for one surface; via appends the reached-through suffix to any raised message."""
+    suffix = "" if via is None else f" (reached defining {via})"
+    prefix = f"{owner}.{surface.attr}['{key}']"
+    if not isinstance(spec, PropertySpec):
+        raise ValueError(
+            f"{prefix} is a {type(spec).__name__}, not a PropertySpec. "
+            f"Construct PropertySpec(...) or use the property_spec(...) helper.{suffix}"
+        )
+
+    if surface is DeclarationSurface.FEATURE_GROUP:
+        checks = _feature_group_checks(spec)
+    elif surface is DeclarationSurface.READER:
+        checks = _reader_inert_checks(spec)
+    else:
+        raise ValueError(f"Unknown DeclarationSurface {surface!r}.")
+    for triggered, message in checks:
+        if triggered:
+            raise ValueError(f"{prefix} {message}{suffix}")
+
+    if surface is DeclarationSurface.READER and spec.framework_set:
+        for triggered, message in _reader_framework_set_checks(spec):
+            if triggered:
+                raise ValueError(f"{prefix} {message}{suffix}")
+
+    return spec
+
+
+def validate_declaration(cls: type, surface: DeclarationSurface, root: type | None) -> None:
+    """Validate cls's own declaration on this surface, plus every plain mixin's reached through the
+    MRO. A class whose own MRO already contains root is skipped; root=None walks every ancestor."""
+    for key, spec in own_declaration(cls, surface).items():
+        validate_property_spec(cls.__name__, key, spec, surface)
+
+    for klass in cls.__mro__[1:]:
+        # Real inheritance only: a class whose own MRO already contains root validated itself
+        # at its own definition; an ABC.register virtual subclass never ran __init_subclass__ either way.
+        if root is not None and root in klass.__mro__:
+            continue
+        for key, spec in own_declaration(klass, surface).items():
+            validate_property_spec(klass.__name__, key, spec, surface, via=cls.__name__)

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+from mloda.core.abstract_plugins.components.declaration_surface import DeclarationSurface, validate_property_spec
 from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
     contained_raise_reason,
@@ -257,30 +258,9 @@ class FeatureChainParser:
 
     @classmethod
     def _require_spec(cls, owner_name: str, key: str, spec: Any) -> PropertySpec:
-        """Reject anything that is not a reader-free ``PropertySpec``; the parser entry point is
-        public and takes caller mappings, so neither rule can live at class-definition time alone."""
-        if not isinstance(spec, PropertySpec):
-            # Contained: a raw dict spec is that candidate's own defect, so the seam reads it as a non-match.
-            raise ValueError(
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
-                f"Raw dict specs are no longer accepted; construct PropertySpec(...) or use the "
-                f"property_spec(...) helper."
-            )
-        if spec.framework_set:
-            # Contained: a framework_set spec is that candidate's own defect, so the seam reads it as a non-match.
-            raise ValueError(
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares framework_set=True, which marks a "
-                f"reader-surface (READER_OPTIONS) key written by the framework; PROPERTY_MAPPING keys "
-                f"are user-set."
-            )
-        if spec.scalar_only:
-            # Contained: a scalar_only spec is that candidate's own defect, so the seam reads it as a non-match.
-            raise ValueError(
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares scalar_only=True, which marks a "
-                f"reader-surface (READER_OPTIONS) key rejected outright as a collection; PROPERTY_MAPPING "
-                f"keys always unpack element-wise."
-            )
-        return spec
+        """Thin seam onto the shared FEATURE_GROUP surface rules; the parser entry point is public
+        and takes caller mappings."""
+        return validate_property_spec(owner_name, key, spec, DeclarationSurface.FEATURE_GROUP)
 
     @classmethod
     def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -13,6 +13,12 @@ from mloda.core.abstract_plugins.components.match_rejection import (
     restamp_match_rejections_since,
 )
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.declaration_surface import (
+    DeclarationSurface,
+    merged_declaration,
+    reject_merge_cache_assignment,
+    validate_declaration,
+)
 
 
 from mloda.core.abstract_plugins.components.utils import (
@@ -37,9 +43,6 @@ class BaseInputData(ABC):
         ),
     }
 
-    _reader_option_specs_cache: ClassVar[Optional[dict[str, PropertySpec]]] = None
-    """Merged declarations of ONE class, written into that class's own __dict__ by _merged_reader_option_specs."""
-
     def __init__(self) -> None:
         pass
 
@@ -48,13 +51,14 @@ class BaseInputData(ABC):
         __init_subclass__ without calling super() defeats them."""
         # Checked before super(): a cooperative later-in-MRO hook may warm the cache during the
         # super() chain; here cls.__dict__ still holds only what the class body wrote.
-        if "_reader_option_specs_cache" in cls.__dict__:
-            raise ValueError(
-                f"{cls.__name__} assigns _reader_option_specs_cache in its class body; the merge cache "
-                f"is framework-written and must never be declared by a reader."
-            )
+        reject_merge_cache_assignment(cls, DeclarationSurface.READER)
         super().__init_subclass__(**kwargs)
         cls._validate_reader_options()
+
+    @classmethod
+    def _validate_reader_options(cls) -> None:
+        cls._validate_reserved_reader_option_key()
+        validate_declaration(cls, DeclarationSurface.READER, BaseInputData)
 
     @classmethod
     def _validate_reserved_reader_option_key(cls) -> None:
@@ -62,7 +66,8 @@ class BaseInputData(ABC):
         validated itself, yet its declaration outranks the base's and is what selection reads."""
         for klass in cls.__mro__:
             declared = klass.__dict__.get("READER_OPTIONS", {})
-            if RESERVED_READER_OPTION_KEY not in declared:
+            # Shape is not this check's concern; own_declaration rejects it once validate_declaration reaches it.
+            if not isinstance(declared, dict) or RESERVED_READER_OPTION_KEY not in declared:
                 continue
             spec = declared[RESERVED_READER_OPTION_KEY]
             if not isinstance(spec, PropertySpec) or not spec.framework_set:
@@ -74,118 +79,19 @@ class BaseInputData(ABC):
             return
 
     @classmethod
-    def _validate_reader_options(cls) -> None:
-        """Reject a reader-invalid declaration where it is written, not later deep in reader matching;
-        checks this class's own declaration plus any plain-mixin declaration reaching its merge."""
-        cls._validate_reserved_reader_option_key()
-        for key, spec in cls._reader_options_declaration(cls).items():
-            cls._validate_reader_option_spec(cls.__name__, key, spec)
-        for klass in cls.__mro__[1:]:
-            # Real inheritance only: an ABC.register virtual subclass answers issubclass True
-            # without ever running __init_subclass__, so it never validated itself.
-            if BaseInputData in klass.__mro__:
-                continue
-            for key, spec in cls._reader_options_declaration(klass).items():
-                cls._validate_reader_option_spec(klass.__name__, key, spec, via=cls.__name__)
-
-    @staticmethod
-    def _reader_options_declaration(klass: type) -> dict[str, Any]:
-        """The class's own READER_OPTIONS, rejected loudly when it is not a dict."""
-        declared = klass.__dict__.get("READER_OPTIONS", {})
-        if not isinstance(declared, dict):
-            raise ValueError(
-                f"{klass.__name__}.READER_OPTIONS is a {type(declared).__name__}, not a dict. "
-                f"Declare a dict mapping option keys to PropertySpec instances."
-            )
-        return declared
-
-    @staticmethod
-    def _validate_reader_option_spec(owner: str, key: str, spec: Any, via: Optional[str] = None) -> None:
-        """The per-key reader rules; owner names the class the declaration is written on,
-        via names the class definition that reached it through the merge."""
-        suffix = "" if via is None else f" (reached defining {via})"
-        if not isinstance(spec, PropertySpec):
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
-                f"Construct PropertySpec(...) instead.{suffix}"
-            )
-        if spec.match_guard is not None:
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] declares a match_guard, which is name-matching "
-                f"machinery and silently inert on a reader.{suffix}"
-            )
-        if spec.deferred_binding:
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] declares deferred_binding=True, which is the "
-                f"name-capture exemption; a reader key has no name path.{suffix}"
-            )
-        if spec.context is False:
-            raise ValueError(
-                f"{owner}.READER_OPTIONS['{key}'] declares context=False, which places a "
-                f"materialized value; readers place none.{suffix}"
-            )
-        if spec.framework_set:
-            if spec.strict_validation:
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with "
-                    f"strict_validation=True; the framework-written key is exempt from user-value "
-                    f"validation, so strictness would be silently inert.{suffix}"
-                )
-            if spec.required_when is not None:
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with a "
-                    f"required_when predicate; the framework-written key is exempt from user-value "
-                    f"validation, so the predicate would be silently inert.{suffix}"
-                )
-            if spec.allow_explicit_none:
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with "
-                    f"allow_explicit_none=True; the admit path skips the framework-written key, "
-                    f"so the flag cannot affect reader selection.{suffix}"
-                )
-            if is_no_default(spec.default):
-                raise ValueError(
-                    f"{owner}.READER_OPTIONS['{key}'] declares framework_set=True without a "
-                    f"declared default; the framework-written key must declare its absent-state "
-                    f"default explicitly, None included.{suffix}"
-                )
-
-    @classmethod
-    def _merged_reader_option_specs(cls) -> dict[str, PropertySpec]:
-        """The merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out.
-
-        Reader selection is a hot path, so the MRO walk runs once per class. The cache is read back
-        with cls.__dict__.get so a subclass never answers from a warm parent cache, and it lives on
-        the class itself rather than in a class-keyed registry so it holds no reference to any class.
-        """
-        cached: Optional[dict[str, PropertySpec]] = cls.__dict__.get("_reader_option_specs_cache")
-        if cached is not None:
-            return cached
-
-        merged: dict[str, PropertySpec] = {}
-        for klass in reversed(cls.__mro__):
-            merged.update(klass.__dict__.get("READER_OPTIONS", {}))
-        cls._reader_option_specs_cache = merged
-        return merged
-
-    @classmethod
     def reader_option_specs(cls) -> dict[str, PropertySpec]:
-        """The declarations of this reader family, most-derived winning; a fresh dict per call.
-
-        Merged across cls.__mro__ from each class's own __dict__ so an inherited attribute is not
-        merged twice, walking the MRO in reverse so a derived declaration wins on a key collision.
-        """
-        return dict(cls._merged_reader_option_specs())
+        """The declarations of this reader family, most-derived winning; a fresh dict per call."""
+        return dict(merged_declaration(cls, DeclarationSurface.READER))
 
     @classmethod
     def declared_reader_option_keys(cls) -> frozenset[str]:
         """Every option key this reader family declares."""
-        return frozenset(cls._merged_reader_option_specs())
+        return frozenset(merged_declaration(cls, DeclarationSurface.READER))
 
     @classmethod
     def _declared_reader_option_spec(cls, key: str) -> PropertySpec:
         """The declaration of key; an undeclared key is a typo, not a silent None."""
-        specs = cls._merged_reader_option_specs()
+        specs = merged_declaration(cls, DeclarationSurface.READER)
         if key not in specs:
             raise ValueError(f"Reader option '{key}' is not declared in READER_OPTIONS of {cls.__name__}.")
         return specs[key]
@@ -216,7 +122,7 @@ class BaseInputData(ABC):
     def _reader_options_admit(cls, options: Optional[Options], record_absence: bool) -> bool:
         """Check this candidate's merged declarations BEFORE its probe runs; a veto is its own non-match.
         record_absence doubles as the ownership signal: it gates absence recordings and stages present-value ones."""
-        for key, spec in cls._merged_reader_option_specs().items():
+        for key, spec in merged_declaration(cls, DeclarationSurface.READER).items():
             if spec.framework_set:
                 continue
             if options is None:

--- a/tests/test_core/test_abstract_plugins/test_components/test_declaration_surface.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_declaration_surface.py
@@ -1,0 +1,734 @@
+"""The shared mechanics behind ``FeatureGroup.PROPERTY_MAPPING`` and ``BaseInputData.READER_OPTIONS``:
+one spec type, one per-key validator, and one MRO-merge helper used by the reader (``FeatureGroup``
+keeps plain-attribute lookup on ``main``). Two attribute names; ``DeclarationSurface`` says which
+fields are inert on which.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.declaration_surface import (
+    DeclarationSurface,
+    merged_declaration,
+    own_declaration,
+    reject_merge_cache_assignment,
+    validate_declaration,
+    validate_property_spec,
+)
+
+
+def _dsurf_match_guard(value: Any) -> bool:
+    return True
+
+
+def _dsurf_required_when(options: Any) -> bool:
+    return False
+
+
+class TestDeclarationSurfaceEnum:
+    def test_feature_group_attr(self) -> None:
+        assert DeclarationSurface.FEATURE_GROUP.attr == "PROPERTY_MAPPING"
+
+    def test_feature_group_cache_attr(self) -> None:
+        assert DeclarationSurface.FEATURE_GROUP.cache_attr == "_property_mapping_cache"
+
+    def test_reader_attr(self) -> None:
+        assert DeclarationSurface.READER.attr == "READER_OPTIONS"
+
+    def test_reader_cache_attr(self) -> None:
+        assert DeclarationSurface.READER.cache_attr == "_reader_option_specs_cache"
+
+    def test_exactly_two_members(self) -> None:
+        assert {member.name for member in DeclarationSurface} == {"FEATURE_GROUP", "READER"}
+
+
+class TestOwnDeclaration:
+    """``own_declaration`` reads exactly ``klass.__dict__[surface.attr]``, never the merge."""
+
+    def test_no_own_declaration_returns_empty_dict_on_feature_group_surface(self) -> None:
+        class DsurfNoOwnFg:
+            pass
+
+        assert own_declaration(DsurfNoOwnFg, DeclarationSurface.FEATURE_GROUP) == {}
+
+    def test_no_own_declaration_returns_empty_dict_on_reader_surface(self) -> None:
+        class DsurfNoOwnReader:
+            pass
+
+        assert own_declaration(DsurfNoOwnReader, DeclarationSurface.READER) == {}
+
+    def test_own_property_mapping_declaration_is_returned(self) -> None:
+        spec = PropertySpec("x", default=None)
+
+        class DsurfOwnFgDecl:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_a": spec}
+
+        assert own_declaration(DsurfOwnFgDecl, DeclarationSurface.FEATURE_GROUP) == {"dsurf_a": spec}
+
+    def test_own_reader_options_declaration_is_returned(self) -> None:
+        spec = PropertySpec("x", default=None)
+
+        class DsurfOwnReaderDecl:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"dsurf_a": spec}
+
+        assert own_declaration(DsurfOwnReaderDecl, DeclarationSurface.READER) == {"dsurf_a": spec}
+
+    def test_none_own_declaration_on_feature_group_surface_names_property_mapping(self) -> None:
+        class DsurfNoneOwnFg:
+            PROPERTY_MAPPING = None
+
+        with pytest.raises(ValueError) as exc_info:
+            own_declaration(DsurfNoneOwnFg, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfNoneOwnFg" in message
+        assert "PROPERTY_MAPPING" in message
+        assert "hierarchy" in message
+        assert "inherited" in message
+        assert "None" in message
+
+    def test_none_own_declaration_on_reader_surface_names_reader_options(self) -> None:
+        class DsurfNoneOwnReader:
+            READER_OPTIONS = None
+
+        with pytest.raises(ValueError) as exc_info:
+            own_declaration(DsurfNoneOwnReader, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfNoneOwnReader" in message
+        assert "READER_OPTIONS" in message
+        assert "PROPERTY_MAPPING" not in message
+
+    def test_non_dict_own_declaration_on_feature_group_surface_names_the_type(self) -> None:
+        class DsurfListOwnFg:
+            PROPERTY_MAPPING = ["not", "a", "dict"]
+
+        with pytest.raises(ValueError) as exc_info:
+            own_declaration(DsurfListOwnFg, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfListOwnFg.PROPERTY_MAPPING is a list, not a dict." in message
+
+    def test_non_dict_own_declaration_on_reader_surface_names_the_type(self) -> None:
+        class DsurfIntOwnReader:
+            READER_OPTIONS = 42
+
+        with pytest.raises(ValueError) as exc_info:
+            own_declaration(DsurfIntOwnReader, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfIntOwnReader.READER_OPTIONS is a int, not a dict." in message
+
+
+class TestMergedDeclaration:
+    """Reversed-MRO merge, most-derived winning, cached per class under ``surface.cache_attr``."""
+
+    def test_parent_only_declaration_merges_alone_on_feature_group_surface(self) -> None:
+        a_spec = PropertySpec("a", default="parent_a")
+
+        class DsurfMergeFgParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_a": a_spec}
+
+        assert merged_declaration(DsurfMergeFgParent, DeclarationSurface.FEATURE_GROUP) == {"dsurf_a": a_spec}
+
+    def test_parent_only_declaration_merges_alone_on_reader_surface(self) -> None:
+        a_spec = PropertySpec("a", default="parent_a")
+
+        class DsurfMergeReaderParent:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"dsurf_a": a_spec}
+
+        assert merged_declaration(DsurfMergeReaderParent, DeclarationSurface.READER) == {"dsurf_a": a_spec}
+
+    def test_child_merges_parent_and_own_keys_on_feature_group_surface(self) -> None:
+        a_spec = PropertySpec("a", default="parent_a")
+        b_spec = PropertySpec("b", default="child_b")
+
+        class DsurfMergeFgParent2:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_a": a_spec}
+
+        class DsurfMergeFgChild2(DsurfMergeFgParent2):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_b": b_spec}
+
+        assert merged_declaration(DsurfMergeFgChild2, DeclarationSurface.FEATURE_GROUP) == {
+            "dsurf_a": a_spec,
+            "dsurf_b": b_spec,
+        }
+
+    def test_child_merges_parent_and_own_keys_on_reader_surface(self) -> None:
+        a_spec = PropertySpec("a", default="parent_a")
+        b_spec = PropertySpec("b", default="child_b")
+
+        class DsurfMergeReaderParent2:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"dsurf_a": a_spec}
+
+        class DsurfMergeReaderChild2(DsurfMergeReaderParent2):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"dsurf_b": b_spec}
+
+        assert merged_declaration(DsurfMergeReaderChild2, DeclarationSurface.READER) == {
+            "dsurf_a": a_spec,
+            "dsurf_b": b_spec,
+        }
+
+    def test_most_derived_declaration_wins_on_a_key_collision(self) -> None:
+        parent_spec = PropertySpec("a", default="parent")
+        child_spec = PropertySpec("a", default="child")
+
+        class DsurfCollideParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_key": parent_spec}
+
+        class DsurfCollideChild(DsurfCollideParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_key": child_spec}
+
+        assert merged_declaration(DsurfCollideChild, DeclarationSurface.FEATURE_GROUP)["dsurf_key"] is child_spec
+        assert merged_declaration(DsurfCollideParent, DeclarationSurface.FEATURE_GROUP)["dsurf_key"] is parent_spec
+
+    def test_child_declaration_does_not_leak_into_the_parent(self) -> None:
+        class DsurfLeakParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {}
+
+        class DsurfLeakChild(DsurfLeakParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_only_child": PropertySpec("x", default=None),
+            }
+
+        assert "dsurf_only_child" not in merged_declaration(DsurfLeakParent, DeclarationSurface.FEATURE_GROUP)
+
+    def test_cache_lives_in_the_class_own_dict_under_the_surface_cache_attr(self) -> None:
+        class DsurfCacheClass:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_k": PropertySpec("x", default=None)}
+
+        merged_declaration(DsurfCacheClass, DeclarationSurface.FEATURE_GROUP)
+
+        assert DeclarationSurface.FEATURE_GROUP.cache_attr in DsurfCacheClass.__dict__
+
+    def test_a_subclass_defined_after_a_warm_parent_cache_sees_its_own_declaration(self) -> None:
+        class DsurfColdParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_cache_key": PropertySpec("p", default="parent"),
+            }
+
+        assert merged_declaration(DsurfColdParent, DeclarationSurface.FEATURE_GROUP)["dsurf_cache_key"].default == (
+            "parent"
+        )
+
+        class DsurfLateChild(DsurfColdParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_cache_key": PropertySpec("c", default="child"),
+            }
+
+        assert merged_declaration(DsurfLateChild, DeclarationSurface.FEATURE_GROUP)["dsurf_cache_key"].default == (
+            "child"
+        )
+        assert merged_declaration(DsurfColdParent, DeclarationSurface.FEATURE_GROUP)["dsurf_cache_key"].default == (
+            "parent"
+        )
+
+    def test_a_key_added_by_a_late_subclass_is_visible_after_a_warm_parent_cache(self) -> None:
+        class DsurfKeysParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_parent_key": PropertySpec("Parent only.", default=None),
+            }
+
+        assert set(merged_declaration(DsurfKeysParent, DeclarationSurface.FEATURE_GROUP)) == {"dsurf_parent_key"}
+
+        class DsurfKeysChild(DsurfKeysParent):
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_child_key": PropertySpec("Child only.", default=None),
+            }
+
+        assert set(merged_declaration(DsurfKeysChild, DeclarationSurface.FEATURE_GROUP)) == {
+            "dsurf_parent_key",
+            "dsurf_child_key",
+        }
+        assert "dsurf_child_key" not in merged_declaration(DsurfKeysParent, DeclarationSurface.FEATURE_GROUP)
+
+    def test_a_subclass_never_answers_from_a_parents_warm_cache(self) -> None:
+        class DsurfNeverParent:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_never_p": PropertySpec("p", default=None),
+            }
+
+        merged_declaration(DsurfNeverParent, DeclarationSurface.FEATURE_GROUP)
+
+        class DsurfNeverChild(DsurfNeverParent):
+            pass
+
+        merged_declaration(DsurfNeverChild, DeclarationSurface.FEATURE_GROUP)
+
+        assert DeclarationSurface.FEATURE_GROUP.cache_attr in DsurfNeverChild.__dict__
+
+    def test_repeated_reads_return_the_same_cached_object(self) -> None:
+        class DsurfRepeat:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {"dsurf_k": PropertySpec("x", default=None)}
+
+        first = merged_declaration(DsurfRepeat, DeclarationSurface.FEATURE_GROUP)
+        second = merged_declaration(DsurfRepeat, DeclarationSurface.FEATURE_GROUP)
+
+        assert first is second
+
+    def test_base_input_data_subclass_merges_the_reserved_key_with_its_own(self) -> None:
+        class DsurfReaderMergeSub(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_reader_merge_key": PropertySpec("x", default=None),
+            }
+
+        merged = merged_declaration(DsurfReaderMergeSub, DeclarationSurface.READER)
+
+        assert "dsurf_reader_merge_key" in merged
+        assert "BaseInputData" in merged
+
+    def test_base_input_data_subclass_most_derived_declaration_wins(self) -> None:
+        class DsurfReaderMergeParent(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_reader_merge_key": PropertySpec("parent", default="parent_v"),
+            }
+
+        class DsurfReaderMergeChild(DsurfReaderMergeParent):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_reader_merge_key": PropertySpec("child", default="child_v"),
+            }
+
+        child_merged = merged_declaration(DsurfReaderMergeChild, DeclarationSurface.READER)
+        parent_merged = merged_declaration(DsurfReaderMergeParent, DeclarationSurface.READER)
+
+        assert child_merged["dsurf_reader_merge_key"].default == "child_v"
+        assert parent_merged["dsurf_reader_merge_key"].default == "parent_v"
+
+
+class TestAPlainClassDeclaringBothSurfacesMergesSeparately:
+    """One class declaring both ``PROPERTY_MAPPING`` and ``READER_OPTIONS`` merges each independently."""
+
+    def test_two_distinct_cache_attributes_after_reading_both_surfaces(self) -> None:
+        class DsurfBothDecl:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_fg_key": PropertySpec("fg", default=None),
+            }
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_reader_key": PropertySpec("reader", default=None),
+            }
+
+        fg_merged = merged_declaration(DsurfBothDecl, DeclarationSurface.FEATURE_GROUP)
+        reader_merged = merged_declaration(DsurfBothDecl, DeclarationSurface.READER)
+
+        assert fg_merged == {"dsurf_fg_key": DsurfBothDecl.PROPERTY_MAPPING["dsurf_fg_key"]}
+        assert reader_merged == {"dsurf_reader_key": DsurfBothDecl.READER_OPTIONS["dsurf_reader_key"]}
+        assert DeclarationSurface.FEATURE_GROUP.cache_attr in DsurfBothDecl.__dict__
+        assert DeclarationSurface.READER.cache_attr in DsurfBothDecl.__dict__
+        assert (
+            DsurfBothDecl.__dict__[DeclarationSurface.FEATURE_GROUP.cache_attr]
+            is not DsurfBothDecl.__dict__[DeclarationSurface.READER.cache_attr]
+        )
+
+
+class TestRejectMergeCacheAssignment:
+    """The merge cache is framework-written per surface; a class body assigning it is rejected."""
+
+    def test_raises_naming_the_feature_group_cache_attr(self) -> None:
+        class DsurfCacheAssignFg:
+            _property_mapping_cache: ClassVar[Any] = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            reject_merge_cache_assignment(DsurfCacheAssignFg, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfCacheAssignFg" in message
+        assert "_property_mapping_cache" in message
+        assert "framework" in message
+
+    def test_raises_naming_the_reader_cache_attr(self) -> None:
+        class DsurfCacheAssignReader:
+            _reader_option_specs_cache: ClassVar[Any] = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            reject_merge_cache_assignment(DsurfCacheAssignReader, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfCacheAssignReader" in message
+        assert "_reader_option_specs_cache" in message
+        assert "framework" in message
+
+    def test_no_raise_when_cache_attr_absent(self) -> None:
+        class DsurfNoCacheAssign:
+            pass
+
+        reject_merge_cache_assignment(DsurfNoCacheAssign, DeclarationSurface.FEATURE_GROUP)
+        reject_merge_cache_assignment(DsurfNoCacheAssign, DeclarationSurface.READER)
+
+    def test_a_cache_warmed_by_merged_declaration_is_not_blamed(self) -> None:
+        """The cache reject guard runs on the class body only; a value the framework itself wrote
+        via ``merged_declaration`` before the guard fires must never be mistaken for an authored one."""
+
+        class DsurfWarmedCache:
+            PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_warmed_k": PropertySpec("x", default=None),
+            }
+
+        merged_declaration(DsurfWarmedCache, DeclarationSurface.FEATURE_GROUP)
+
+        reject_merge_cache_assignment(DsurfWarmedCache, DeclarationSurface.FEATURE_GROUP)
+
+
+class TestPoisonedCacheWithoutABaseHook:
+    """A plain class (no ``FeatureGroup``/``BaseInputData`` base, so no ``__init_subclass__`` hook
+    ever ran ``reject_merge_cache_assignment``) can plant a bogus cache value directly in its body.
+    ``merged_declaration`` must refuse to trust it too, not silently hand it back or blow up on a
+    missing attribute of the merge-cache-internal type."""
+
+    def test_merged_declaration_raises_on_a_poisoned_feature_group_cache(self) -> None:
+        class DsurfPoisonedFgCache:
+            _property_mapping_cache: ClassVar[Any] = {"k": PropertySpec("x", default=None)}
+
+        with pytest.raises(ValueError) as merged_exc:
+            merged_declaration(DsurfPoisonedFgCache, DeclarationSurface.FEATURE_GROUP)
+        merged_message = str(merged_exc.value)
+        del merged_exc
+
+        with pytest.raises(ValueError) as guard_exc:
+            reject_merge_cache_assignment(DsurfPoisonedFgCache, DeclarationSurface.FEATURE_GROUP)
+        guard_message = str(guard_exc.value)
+        del guard_exc
+
+        assert "DsurfPoisonedFgCache" in merged_message
+        assert "_property_mapping_cache" in merged_message
+        assert merged_message == guard_message
+
+    def test_merged_declaration_raises_on_a_poisoned_reader_cache(self) -> None:
+        class DsurfPoisonedReaderCache:
+            _reader_option_specs_cache: ClassVar[Any] = {"k": PropertySpec("x", default=None)}
+
+        with pytest.raises(ValueError) as merged_exc:
+            merged_declaration(DsurfPoisonedReaderCache, DeclarationSurface.READER)
+        merged_message = str(merged_exc.value)
+        del merged_exc
+
+        with pytest.raises(ValueError) as guard_exc:
+            reject_merge_cache_assignment(DsurfPoisonedReaderCache, DeclarationSurface.READER)
+        guard_message = str(guard_exc.value)
+        del guard_exc
+
+        assert "DsurfPoisonedReaderCache" in merged_message
+        assert "_reader_option_specs_cache" in merged_message
+        assert merged_message == guard_message
+
+
+class TestValidatePropertySpec:
+    """The per-key rules, parametrized by surface; ``via`` appends the reached-through suffix."""
+
+    def test_non_property_spec_value_rejected_on_reader_surface(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", "not a spec", DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert message == (
+            "DsurfOwner.READER_OPTIONS['dsurf_key'] is a str, not a PropertySpec. "
+            "Construct PropertySpec(...) or use the property_spec(...) helper."
+        )
+
+    def test_non_property_spec_value_rejected_on_feature_group_surface(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", 42, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfOwner.PROPERTY_MAPPING['dsurf_key'] is a int, not a PropertySpec." in message
+
+    def test_via_suffix_is_appended(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfMixin", "dsurf_key", 42, DeclarationSurface.READER, via="DsurfReader")
+
+        message = str(exc_info.value)
+        del exc_info
+        assert message.endswith(" (reached defining DsurfReader)")
+
+    def test_no_via_suffix_when_via_is_none(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", 42, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "(reached defining" not in message
+
+    def test_feature_group_rejects_framework_set(self) -> None:
+        spec = PropertySpec("x", default=None, framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "reader-only" in message
+
+    def test_feature_group_rejects_scalar_only(self) -> None:
+        spec = PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, scalar_only=True, default="a")
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "scalar_only" in message
+        assert "reader-only" in message
+
+    def test_reader_rejects_match_guard(self) -> None:
+        spec = PropertySpec("x", match_guard=_dsurf_match_guard, default=None)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "match_guard" in message
+
+    def test_reader_rejects_deferred_binding(self) -> None:
+        spec = PropertySpec("x", deferred_binding=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "deferred_binding" in message
+
+    def test_reader_rejects_context_false(self) -> None:
+        spec = PropertySpec("x", context=False, default=None)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "context" in message
+
+    def test_reader_rejects_framework_set_with_strict_validation(self) -> None:
+        spec = PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, default="a", framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "strict_validation" in message
+
+    def test_reader_rejects_framework_set_with_required_when(self) -> None:
+        spec = PropertySpec("x", required_when=_dsurf_required_when, default=None, framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "required_when" in message
+
+    def test_reader_rejects_framework_set_with_allow_explicit_none(self) -> None:
+        spec = PropertySpec("x", allow_explicit_none=True, default=None, framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "allow_explicit_none" in message
+
+    def test_reader_rejects_framework_set_with_no_declared_default(self) -> None:
+        spec = PropertySpec("x", framework_set=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "framework_set" in message
+        assert "default" in message
+
+    def test_reader_accepts_framework_set_with_none_default(self) -> None:
+        spec = PropertySpec("x", default=None, framework_set=True)
+
+        result = validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        assert result is spec
+
+    def test_feature_group_accepts_match_guard(self) -> None:
+        spec = PropertySpec("x", match_guard=_dsurf_match_guard, default=None)
+
+        result = validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        assert result is spec
+
+    def test_feature_group_accepts_context_false(self) -> None:
+        spec = PropertySpec("x", context=False, default=None)
+
+        result = validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.FEATURE_GROUP)
+
+        assert result is spec
+
+    def test_reader_accepts_scalar_only_strict_with_allowed_values(self) -> None:
+        spec = PropertySpec("x", scalar_only=True, strict_validation=True, allowed_values=("a", "b"), default="a")
+
+        result = validate_property_spec("DsurfOwner", "dsurf_key", spec, DeclarationSurface.READER)
+
+        assert result is spec
+
+    def test_reader_surface_message_contains_reader_options_not_property_mapping(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", "bad", DeclarationSurface.READER)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "READER_OPTIONS" in message
+        assert "PROPERTY_MAPPING" not in message
+
+    def test_feature_group_surface_message_contains_property_mapping_not_reader_options(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", 42, DeclarationSurface.FEATURE_GROUP)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "PROPERTY_MAPPING" in message
+        assert "READER_OPTIONS" not in message
+
+    def test_no_message_ever_mentions_the_retired_surface_marker_constant(self) -> None:
+        messages = []
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec("DsurfOwner", "dsurf_key", "bad", DeclarationSurface.READER)
+        messages.append(str(exc_info.value))
+        del exc_info
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_property_spec(
+                "DsurfOwner",
+                "dsurf_key",
+                PropertySpec("x", framework_set=True, default=None),
+                DeclarationSurface.FEATURE_GROUP,
+            )
+        messages.append(str(exc_info.value))
+        del exc_info
+
+        for message in messages:
+            assert "PROPERTY_MAPPING_SURFACE" not in message
+
+
+class TestValidateDeclaration:
+    """Class-definition validation for a class whose MRO contains ``root``; a direct call passes
+    ``root`` explicitly (here: ``BaseInputData``)."""
+
+    def test_a_mixin_reader_invalid_spec_is_rejected_with_via_naming_the_subclass(self) -> None:
+        class DsurfBadMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_bad_key": PropertySpec("Guarded.", match_guard=_dsurf_match_guard, default=None),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class DsurfBadMixinReader(DsurfBadMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfBadMixin" in message
+        assert "dsurf_bad_key" in message
+        assert "match_guard" in message
+        assert "(reached defining DsurfBadMixinReader)" in message
+
+    def test_a_valid_mixin_declaration_defines_fine_and_merges(self) -> None:
+        spec = PropertySpec("Valid, declared on the mixin.", default="dsurf_mixin_default")
+
+        class DsurfGoodMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"dsurf_good_key": spec}
+
+        class DsurfGoodMixinReader(DsurfGoodMixin, BaseInputData):
+            pass
+
+        assert merged_declaration(DsurfGoodMixinReader, DeclarationSurface.READER)["dsurf_good_key"] is spec
+
+    def test_own_none_declaration_on_cls_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class DsurfNoneOwnReader(BaseInputData):
+                READER_OPTIONS = None  # type: ignore[assignment]  # invalid shape is the point
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfNoneOwnReader" in message
+
+    def test_direct_call_on_a_clean_subclass_does_not_raise(self) -> None:
+        class DsurfCleanReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_clean_key": PropertySpec("Valid.", default=None),
+            }
+
+        validate_declaration(DsurfCleanReader, DeclarationSurface.READER, BaseInputData)
+
+    def test_a_class_below_the_root_is_not_re_walked_as_a_plain_mixin(self) -> None:
+        """A class whose own MRO already contains ``root`` validated itself at its own definition;
+        ``validate_declaration`` on a grandchild must not re-raise for it a second time under a
+        fresh ``via`` and must not choke walking it as though it had no root."""
+
+        class DsurfRealInheritanceParent(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_parent_key": PropertySpec("Valid.", default=None),
+            }
+
+        class DsurfRealInheritanceChild(DsurfRealInheritanceParent):
+            pass
+
+        validate_declaration(DsurfRealInheritanceChild, DeclarationSurface.READER, BaseInputData)
+
+
+class TestValidateDeclarationWalksEveryAncestorWhenThereIsNoRoot:
+    """With ``root=None``, EVERY ancestor is walked as a plain mixin, not just the immediate one;
+    a defect declared two classes up the plain hierarchy is still caught."""
+
+    def test_a_defect_declared_two_classes_up_is_caught_naming_the_declaring_ancestor_via_the_leaf(self) -> None:
+        class DsurfNoRootA:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_bad_key": PropertySpec("Guarded.", match_guard=_dsurf_match_guard, default=None),
+            }
+
+        class DsurfNoRootB(DsurfNoRootA):
+            pass
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_declaration(DsurfNoRootB, DeclarationSurface.READER, None)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "DsurfNoRootA" in message
+        assert "(reached defining DsurfNoRootB)" in message
+
+
+class TestCooperativeHookReadingBeforeSuperIsNotBlamed:
+    """A mixin's warm read before ``super()`` must not be mistaken for the class body assigning the cache."""
+
+    def test_reader_side_mixin_reading_before_super_defines_fine(self) -> None:
+        class DsurfReaderEarlyReadMixin:
+            def __init_subclass__(cls, **kwargs: Any) -> None:
+                cls.declared_reader_option_keys()  # type: ignore[attr-defined]
+                super().__init_subclass__(**kwargs)
+
+        class DsurfReaderEarlyReadSub(DsurfReaderEarlyReadMixin, BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "dsurf_early_reader_key": PropertySpec("x", default=None),
+            }
+
+        result = DsurfReaderEarlyReadSub.declared_reader_option_keys()
+        del DsurfReaderEarlyReadSub
+        del DsurfReaderEarlyReadMixin
+
+        assert "dsurf_early_reader_key" in result

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -89,6 +89,17 @@ _DECIDED_ABOVE_BY_READER_SELECTION = (
 _MATCHES_COLLISION = "name collision: the match path calls the input-data hooks named matches, not Link.matches"
 _UPDATE_COLLISION = "name collision: dict.update, not the link resolver's"
 _JOIN_COLLISION = "name collision: str.join, not the runner's join"
+_MERGED_DECLARATION_RAISES = (
+    "real edge: own_declaration's ValueError for a malformed declaration; __init_subclass__ already "
+    "validates every class in the MRO at definition time, so this walk cannot raise for a class that "
+    "reached match time"
+)
+_VALIDATE_PROPERTY_SPEC_RAISES = (
+    "real edge: validate_property_spec's ValueError for a malformed or reader-only spec on the FEATURE_GROUP "
+    "surface, reached via _require_spec's public entry point for a caller-supplied mapping that never passed "
+    "the class-definition check; that candidate's own defect, so the seam reads it as a non-match"
+)
+_MERGED_DECLARATION_SWALLOWS_DIRECT = "name collision: dict.update inside merged_declaration, not a real swallow"
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
@@ -104,6 +115,12 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ),
     ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
+    ("mloda/core/abstract_plugins/components/declaration_surface.py", "merged_declaration"): (
+        _MERGED_DECLARATION_RAISES
+    ),
+    ("mloda/core/abstract_plugins/components/declaration_surface.py", "validate_property_spec"): (
+        _VALIDATE_PROPERTY_SPEC_RAISES
+    ),
 }
 
 # Swallowing functions OUTSIDE the declared modules that the match path calls; the containment there is decided
@@ -133,6 +150,9 @@ SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/link.py", "matches"): _MATCHES_COLLISION,
     ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
+    ("mloda/core/abstract_plugins/components/declaration_surface.py", "merged_declaration"): (
+        _MERGED_DECLARATION_SWALLOWS_DIRECT
+    ),
 }
 
 _ESCALATION = "escalate_match_abort"


### PR DESCRIPTION
## Summary

`PROPERTY_MAPPING` on a `FeatureGroup` and `READER_OPTIONS` on a `BaseInputData` are two declarations over one spec type. They keep their names and their semantics; what they now share is the mechanics, through `mloda/core/abstract_plugins/components/declaration_surface.py`:

- One per-key validator, parameterized by a `DeclarationSurface` enum that carries the surface's attribute name, so every message names `PROPERTY_MAPPING` or `READER_OPTIONS` as written. The reader hook and `FeatureChainParser._require_spec` both delegate to it; the two rule sets that lived in `base_input_data.py` and `feature_chain_parser.py` are one table.
- One MRO-merge helper with a per-class cache in the class's own `__dict__`, used by the reader surface (`reader_option_specs()`, `declared_reader_option_keys()`, the selection-time admit check). The reader's private merge, declaration and validation helpers go (about 130 lines).
- One walker that validates plain-mixin declarations at the concrete class definition, and one guard for the framework-written merge cache.

No behavior change on either surface: the feature group still reads its attribute (no merge, `None` default unchanged), the reader still merges lazily with the reserved key at its base.

Supersedes #1196.

## Tests

- `tests/test_core/test_abstract_plugins/test_components/test_declaration_surface.py`: the shared module on both surfaces (validator rules and messages, merge and cache, poisoned cache, mixin walk).
- Reader-side and feature-group tests are unchanged.
