### PR TITLE
fix: harden JoinStep guard follow-ups (empty uuids, tfs_ids ambiguity, join-served bridging)

### DIFF
--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 from uuid import UUID
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 
@@ -98,6 +99,25 @@ class CfwManager:
             if cf_class_name == cls_name and feature_uuid in children_if_root:
                 cfw_uuid = self.find_leftmost(cfw_uuid, cls_name)
                 return cfw_uuid
+        return None
+
+    def get_unique_cfw_uuid(self, cf_class_name: str, tfs_ids: set[UUID]) -> Optional[UUID]:
+        """
+        Resolves a set of tfs_ids to at most one distinct Compute Framework UUID.
+
+        Raises if the tfs_ids resolve to more than one distinct cfw (ambiguous).
+        Returns None if none of the tfs_ids resolve.
+        """
+        resolved_uuids = {resolved for tfs_id in tfs_ids if (resolved := self.get_cfw_uuid(cf_class_name, tfs_id))}
+        if len(resolved_uuids) > 1:
+            raise ValueError(
+                internal_invariant_error(
+                    "step.tfs_ids resolved to more than one distinct compute framework: ambiguous.",
+                    f"cf_class_name={cf_class_name}, resolved cfw_uuids={resolved_uuids}, tfs_ids={tfs_ids}",
+                )
+            )
+        if len(resolved_uuids) == 1:
+            return next(iter(resolved_uuids))
         return None
 
     def add_to_merge_relation(self, left_uuid: UUID, right_uuid: UUID, cls_name: str) -> None:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -720,6 +720,23 @@ Available join types:
                 parent_parents.update(parent_parent)
         return parent_parents
 
+    @staticmethod
+    def _validate_join_step_uuids(
+        link: Link,
+        destination_framework_uuids: set[UUID],
+        source_framework_uuids: set[UUID],
+    ) -> None:
+        """Both JoinStep sides must name at least one parent; the runtime later reads
+        them with next(iter(...))."""
+        if not destination_framework_uuids or not source_framework_uuids:
+            raise ValueError(
+                internal_invariant_error(
+                    "run_link resolved an empty destination_framework_uuids or source_framework_uuids.",
+                    f"link={link}, destination_framework_uuids={destination_framework_uuids}, "
+                    f"source_framework_uuids={source_framework_uuids}",
+                )
+            )
+
     def run_link(
         self,
         link_fw: LinkFrameworkTrekker,
@@ -897,6 +914,7 @@ Available join types:
         destination_uuids, source_uuids = (
             (join_uuids_right, join_uuids_left) if side is JoinSide.RIGHT else (join_uuids_left, join_uuids_right)
         )
+        self._validate_join_step_uuids(link, set(destination_uuids), set(source_uuids))
 
         record = ResolvedJoin(
             link_uuid=link.uuid,

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -509,8 +509,8 @@ Available join types:
                 # Explicit hops and join-served parents (delivered pre-merged by a JoinStep, no hop built)
                 # both compete for this step's one binding, so both get grouped by the same linkage test
                 # below. Order-independent: collected here, grouped once after the loop.
-                bound_entries: list[tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]]] = []
-                join_served_entries: list[tuple[type[FeatureGroup], UUID, list[JoinStep]]] = []
+                bound_entries: list[tuple[TransformFrameworkStep | _JoinServedParent, UUID]] = []
+                join_served_entries: list[tuple[type[FeatureGroup], UUID]] = []
                 seen_hop_uuids: set[UUID] = set()
 
                 for parent in parents:
@@ -521,11 +521,8 @@ Available join types:
                         if js.matched(ep.compute_framework, parent_node_property.feature.uuid)
                     ]
                     if matching_join_steps:
-                        # Served by a join, no explicit hop needed; keep every matching join, not just
-                        # the first, so the later linkage check doesn't depend on set iteration order.
-                        join_served_entries.append(
-                            (parent_node_property.feature_group_class, parent, matching_join_steps)
-                        )
+                        # Served by a join, no explicit hop needed.
+                        join_served_entries.append((parent_node_property.feature_group_class, parent))
                         continue
 
                     if ep.compute_framework != parent_node_property.feature.get_compute_framework():
@@ -545,7 +542,7 @@ Available join types:
 
                         if canonical_tfs.uuid not in seen_hop_uuids:
                             seen_hop_uuids.add(canonical_tfs.uuid)
-                            bound_entries.append((canonical_tfs, parent, []))
+                            bound_entries.append((canonical_tfs, parent))
 
                         # Records every parent the hop covers; they all share one owning step, so
                         # this doesn't change the scheduling gate.
@@ -557,35 +554,28 @@ Available join types:
 
                         need_to_upload_collector.add(parent)
 
-                # Group entries by transitive linkage: same feature-group class, declared-side sharing via
-                # either entry's matching JoinSteps (catches a case-override hop whose parent lost the
-                # JoinStep's own uuid to a same-role sibling, see `_case_override_beats_nearer_wrong_framework_left`),
-                # or `_parents_linked_by_join`.
+                # Group entries by transitive linkage: same feature-group class, one entry's own class a
+                # subclass (or superclass) of the other's (catches a case-override hop whose parent lost the
+                # JoinStep's own uuid to a same-role sibling, see `_case_override_beats_nearer_wrong_framework_left`,
+                # without also bridging two entries that merely share an unrelated common ancestor via some
+                # third join's declared side), or `_parents_linked_by_join`.
                 def _entries_linked(
-                    entry_a: tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]],
-                    entry_b: tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]],
+                    entry_a: tuple[TransformFrameworkStep | _JoinServedParent, UUID],
+                    entry_b: tuple[TransformFrameworkStep | _JoinServedParent, UUID],
                 ) -> bool:
-                    hop_a, parent_a, matching_a = entry_a
-                    hop_b, parent_b, matching_b = entry_b
+                    hop_a, parent_a = entry_a
+                    hop_b, parent_b = entry_b
                     if hop_a.from_feature_group is hop_b.from_feature_group:
                         return True
-                    if any(
-                        issubclass(hop_b.from_feature_group, declared_side)
-                        for js in matching_a
-                        for declared_side in (js.link.left_feature_group, js.link.right_feature_group)
-                    ):
-                        return True
-                    if any(
-                        issubclass(hop_a.from_feature_group, declared_side)
-                        for js in matching_b
-                        for declared_side in (js.link.left_feature_group, js.link.right_feature_group)
+                    if issubclass(hop_a.from_feature_group, hop_b.from_feature_group) or issubclass(
+                        hop_b.from_feature_group, hop_a.from_feature_group
                     ):
                         return True
                     return self._parents_linked_by_join(parent_a, parent_b, left_join_frameworks)
 
                 def _add_to_groups(
-                    groups: list[list[tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]]]],
-                    entry: tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]],
+                    groups: list[list[tuple[TransformFrameworkStep | _JoinServedParent, UUID]]],
+                    entry: tuple[TransformFrameworkStep | _JoinServedParent, UUID],
                 ) -> None:
                     linked_groups = [
                         group for group in groups if any(_entries_linked(entry, member) for member in group)
@@ -599,20 +589,13 @@ Available join types:
                     else:
                         groups.append([entry])
 
-                hop_groups: list[list[tuple[TransformFrameworkStep | _JoinServedParent, UUID, list[JoinStep]]]] = []
+                hop_groups: list[list[tuple[TransformFrameworkStep | _JoinServedParent, UUID]]] = []
                 for entry in bound_entries:
                     _add_to_groups(hop_groups, entry)
 
-                if len(hop_groups) > 1:
-                    raise ValueError(
-                        self._conflicting_transform_hops_error(ep, hop_groups[0][0][0], hop_groups[1][0][0])
-                    )
-
                 # Join-served parents compete for the same binding, so merge them into the same groups too.
-                for served_feature_group, served_parent, matching_join_steps in join_served_entries:
-                    _add_to_groups(
-                        hop_groups, (_JoinServedParent(served_feature_group), served_parent, matching_join_steps)
-                    )
+                for served_feature_group, served_parent in join_served_entries:
+                    _add_to_groups(hop_groups, (_JoinServedParent(served_feature_group), served_parent))
 
                 if len(hop_groups) > 1:
                     raise ValueError(

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -143,10 +143,9 @@ class ComputeFrameworkExecutor:
         cfw_uuid: Optional[UUID] = None
 
         if isinstance(step, FeatureGroupStep):
-            for tfs_id in step.tfs_ids:
-                cfw_uuid = self.cfw_register.get_cfw_uuid(step.compute_framework.get_class_name(), tfs_id)
-                if cfw_uuid:
-                    return cfw_uuid
+            resolved_uuid = self.cfw_register.get_unique_cfw_uuid(step.compute_framework.get_class_name(), step.tfs_ids)
+            if resolved_uuid is not None:
+                return resolved_uuid
 
             feature_uuid = step.features.any_uuid
 

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -480,10 +480,9 @@ class ExecutionOrchestrator:
 
         class_name = step.compute_framework.get_class_name()
 
-        for tfs_id in step.tfs_ids:
-            cfw_uuid = self.cfw_register.get_cfw_uuid(class_name, tfs_id)
-            if cfw_uuid:
-                return cfw_uuid
+        resolved_uuid = self.cfw_register.get_unique_cfw_uuid(class_name, step.tfs_ids)
+        if resolved_uuid is not None:
+            return resolved_uuid
 
         if step.features.any_uuid is None:
             return None

--- a/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
+++ b/tests/test_core/test_prepare/test_add_tfs_dedup_wiring.py
@@ -306,7 +306,10 @@ class MatchedJsConsumerFG(DedupBaseFG):
 def _hub_matches_two_joins_scenario(
     hub_link_token: UUID, other_link_token: UUID
 ) -> tuple[list[JoinStep | FeatureGroupStep], Graph]:
-    """Hub parent P genuinely matches both JoinSteps; only the token order differs between calls."""
+    """Hub parent P genuinely matches both JoinSteps; only the token order differs between calls. Q is the
+    genuine source-side member of ``hub_join_step`` (what ``run_link`` actually produces: source uuids
+    narrowed to genuine declared-side members), so P and Q are linked via real uuid adjacency, not merely
+    by sharing a declared-side class."""
     graph = Graph()
 
     p = _feature("matched_js_hub_p", PandasDataFrame)
@@ -325,7 +328,7 @@ def _hub_matches_two_joins_scenario(
         source_framework=PyArrowTable,
         required_uuids=set(),
         destination_framework_uuids={p.uuid},
-        source_framework_uuids={uuid4()},
+        source_framework_uuids={q.uuid},
         token=hub_link_token,
     )
     other_join_step = JoinStep(
@@ -358,3 +361,193 @@ def test_parent_matching_two_join_steps_does_not_raise_regardless_of_token_order
     execution_plan, graph = _hub_matches_two_joins_scenario(hub_link_token, other_link_token)
 
     ExecutionPlan().add_tfs(execution_plan, graph)
+
+
+# ---------------------------------------------------------------------------
+# A join-served parent bridging two otherwise-unlinked explicit hops
+# ---------------------------------------------------------------------------
+
+
+class BridgeXFG(DedupBaseFG):
+    pass
+
+
+class BridgeYFG(DedupBaseFG):
+    pass
+
+
+class BridgeUnrelatedFG(DedupBaseFG):
+    pass
+
+
+class BridgeConsumerFG(DedupBaseFG):
+    pass
+
+
+class BridgeScenario(NamedTuple):
+    producer_x: FeatureGroupStep
+    producer_y: FeatureGroupStep
+    join_step: JoinStep
+    dest_step: FeatureGroupStep
+    graph: Graph
+
+
+def _bridge_scenario(bridged: bool) -> BridgeScenario:
+    """Two genuinely unlinked explicit hops (producer_x, class BridgeXFG on PandasDataFrame;
+    producer_y, class BridgeYFG on PyArrowTable) feed one consumer on PythonDictFramework, plus
+    join-served parents whose class is an exact match for a hop's own class, on PythonDictFramework
+    (what ``run_link`` actually produces: destination/source uuids are narrowed to genuine
+    declared-side members). ``bridged=True`` gives BOTH hops a join-served counterpart, and the two
+    counterparts sit on opposite sides of the same JoinStep, so they are themselves genuinely
+    linked; this ties both explicit hops into one group. ``bridged=False`` gives only the left hop
+    a counterpart, and the link's right side names an unrelated class, so the right hop stays
+    genuinely unlinked."""
+    graph = Graph()
+
+    parent_x = _feature("bridge_parent_x", PandasDataFrame)
+    parent_y = _feature("bridge_parent_y", PyArrowTable)
+    bridge_left = _feature("bridge_left_served", PythonDictFramework)
+    _root_node(graph, parent_x, BridgeXFG)
+    _root_node(graph, parent_y, BridgeYFG)
+    _root_node(graph, bridge_left, BridgeXFG)
+
+    producer_x = _producer_step(BridgeXFG, parent_x, PandasDataFrame)
+    producer_y = _producer_step(BridgeYFG, parent_y, PyArrowTable)
+
+    right_side = BridgeYFG if bridged else BridgeUnrelatedFG
+    link = Link.inner(JoinSpec(BridgeXFG, "id"), JoinSpec(right_side, "id"))
+
+    destination_framework_uuids = {bridge_left.uuid}
+    source_framework_uuids: set[UUID] = set()
+    dest_parents = {parent_x.uuid, parent_y.uuid, bridge_left.uuid}
+
+    if bridged:
+        bridge_right = _feature("bridge_right_served", PythonDictFramework)
+        _root_node(graph, bridge_right, BridgeYFG)
+        source_framework_uuids = {bridge_right.uuid}
+        dest_parents.add(bridge_right.uuid)
+
+    join_step = JoinStep(
+        link=link,
+        destination_framework=PythonDictFramework,
+        source_framework=PythonDictFramework,
+        required_uuids=set(),
+        destination_framework_uuids=destination_framework_uuids,
+        source_framework_uuids=source_framework_uuids,
+    )
+
+    dest_feature = _feature("bridge_dest", PythonDictFramework)
+    feature_set = FeatureSet()
+    feature_set.add(dest_feature)
+    graph.parent_to_children_mapping[dest_feature.uuid] = dest_parents
+    dest_step = FeatureGroupStep(BridgeConsumerFG, feature_set, set(), PythonDictFramework)
+
+    return BridgeScenario(producer_x, producer_y, join_step, dest_step, graph)
+
+
+def test_join_served_parent_genuinely_bridging_two_hops_does_not_raise() -> None:
+    """Two join-served parents, each an exact-class match for one explicit hop and genuinely
+    adjacent to each other on the same JoinStep, must merge both hops into one group instead of
+    tripping the missing-Links check on the bound-entries-only grouping pass."""
+    scenario = _bridge_scenario(bridged=True)
+
+    ExecutionPlan().add_tfs(
+        [scenario.producer_x, scenario.producer_y, scenario.join_step, scenario.dest_step], scenario.graph
+    )
+
+
+def test_join_served_parent_linked_to_only_one_hop_still_raises() -> None:
+    """Guard against an overly-broad fix: a join-served parent must genuinely bridge BOTH hops,
+    not merely be present, for the missing-Links check to stand down."""
+    scenario = _bridge_scenario(bridged=False)
+
+    with pytest.raises(ValueError, match="two different, unlinked source feature"):
+        ExecutionPlan().add_tfs(
+            [scenario.producer_x, scenario.producer_y, scenario.join_step, scenario.dest_step], scenario.graph
+        )
+
+
+# ---------------------------------------------------------------------------
+# A join-served parent must not bridge two hops that are merely siblings under a
+# shared declared-side ancestor, with no genuine join between them
+# ---------------------------------------------------------------------------
+
+
+class SiblingBroadFG(DedupBaseFG):
+    """The class a link declares on one side; two unrelated sibling subclasses share it."""
+
+
+class SiblingS1FG(SiblingBroadFG):
+    pass
+
+
+class SiblingS2FG(SiblingBroadFG):
+    pass
+
+
+class SiblingRightFG(DedupBaseFG):
+    pass
+
+
+class SiblingConsumerFG(DedupBaseFG):
+    pass
+
+
+class SiblingBridgeScenario(NamedTuple):
+    producer_s1: FeatureGroupStep
+    producer_s2: FeatureGroupStep
+    join_step: JoinStep
+    consumer_step: FeatureGroupStep
+    graph: Graph
+
+
+def _sibling_bridge_scenario() -> SiblingBridgeScenario:
+    """Consumer (PythonDict) pulls from S1 (Pandas) and S2 (PyArrow), two sibling subclasses of a
+    link's declared left side with no Link between them, plus a genuinely join-served third parent
+    whose class equals S1's exactly (a real declared-side member, as ``run_link`` narrows
+    destination/source uuids to declared-side members only). The join-served parent legitimately
+    binds to the S1 hop; it must not also bridge the unrelated S2 hop just because S2 happens to
+    descend from the same declared-side base class."""
+    graph = Graph()
+
+    p_s1 = _feature("sibling_s1_pandas", PandasDataFrame)
+    p_s2 = _feature("sibling_s2_pyarrow", PyArrowTable)
+    p_served = _feature("sibling_s1_dict_served", PythonDictFramework)
+    _root_node(graph, p_s1, SiblingS1FG)
+    _root_node(graph, p_s2, SiblingS2FG)
+    _root_node(graph, p_served, SiblingS1FG)
+
+    producer_s1 = _producer_step(SiblingS1FG, p_s1, PandasDataFrame)
+    producer_s2 = _producer_step(SiblingS2FG, p_s2, PyArrowTable)
+
+    link = Link.inner(JoinSpec(SiblingBroadFG, "id"), JoinSpec(SiblingRightFG, "id"))
+    right_parent = _feature("sibling_right_dict", PythonDictFramework)
+    _root_node(graph, right_parent, SiblingRightFG)
+    join_step = JoinStep(
+        link=link,
+        destination_framework=PythonDictFramework,
+        source_framework=PythonDictFramework,
+        required_uuids=set(),
+        destination_framework_uuids={p_served.uuid, right_parent.uuid},
+        source_framework_uuids={p_served.uuid, right_parent.uuid},
+    )
+
+    consumer = _feature("sibling_consumer", PythonDictFramework)
+    feature_set = FeatureSet()
+    feature_set.add(consumer)
+    graph.parent_to_children_mapping[consumer.uuid] = {p_s1.uuid, p_s2.uuid, p_served.uuid}
+    consumer_step = FeatureGroupStep(SiblingConsumerFG, feature_set, set(), PythonDictFramework)
+
+    return SiblingBridgeScenario(producer_s1, producer_s2, join_step, consumer_step, graph)
+
+
+def test_join_served_sibling_parent_does_not_bridge_two_unrelated_declared_side_subclasses() -> None:
+    """A join-served parent classed as one declared-side subclass must not silently merge an
+    unrelated sibling subclass's hop into its group; the two hops share no genuine Link."""
+    scenario = _sibling_bridge_scenario()
+
+    with pytest.raises(ValueError, match="two different, unlinked source feature"):
+        ExecutionPlan().add_tfs(
+            [scenario.producer_s1, scenario.producer_s2, scenario.join_step, scenario.consumer_step],
+            scenario.graph,
+        )

--- a/tests/test_core/test_prepare/test_run_link_empty_uuid_guard.py
+++ b/tests/test_core/test_prepare/test_run_link_empty_uuid_guard.py
@@ -1,0 +1,165 @@
+"""Guard against run_link constructing a JoinStep with an empty declared side.
+
+`set() <= anything` is always True, so an empty `split.left_uuids`/`right_uuids` can slip
+through run_link's subset branch and produce an empty destination/source uuid set. Left
+unguarded, that empty set later raises an unguarded StopIteration in compute_framework_executor.
+"""
+
+from typing import Any, Optional
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec
+from mloda.user import Link
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class GuardBaseFG(FeatureGroup):
+    """Unmatchable base so a leaked subclass stays invisible to feature resolution."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class GuardLeftFG(GuardBaseFG):
+    pass
+
+
+class GuardRightFG(GuardBaseFG):
+    pass
+
+
+def _link() -> Link:
+    return Link.inner(JoinSpec(GuardLeftFG, "id"), JoinSpec(GuardRightFG, "id"))
+
+
+def test_validate_join_step_uuids_rejects_empty_destination_side() -> None:
+    """An empty destination side must raise ValueError before JoinStep construction, not later
+    surface as StopIteration in compute_framework_executor."""
+    link = _link()
+    non_empty: set[UUID] = {uuid4()}
+
+    with pytest.raises(ValueError, match="(?i)empty"):
+        ExecutionPlan._validate_join_step_uuids(link, set(), non_empty)
+
+
+def test_validate_join_step_uuids_rejects_empty_source_side() -> None:
+    link = _link()
+    non_empty: set[UUID] = {uuid4()}
+
+    with pytest.raises(ValueError, match="(?i)empty"):
+        ExecutionPlan._validate_join_step_uuids(link, non_empty, set())
+
+
+def test_validate_join_step_uuids_message_mentions_the_link() -> None:
+    """The raised message must be actionable: it must name the offending link, not just 'empty'."""
+    link = _link()
+
+    with pytest.raises(ValueError) as exc_info:
+        ExecutionPlan._validate_join_step_uuids(link, set(), {uuid4()})
+
+    assert str(link) in str(exc_info.value)
+
+
+def test_validate_join_step_uuids_accepts_two_genuine_non_empty_sides() -> None:
+    """Guard against an overly-broad fix: two real, non-empty sides must not raise."""
+    link = _link()
+
+    ExecutionPlan._validate_join_step_uuids(link, {uuid4()}, {uuid4()})
+
+
+class WiringJoinLeftFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"wiring_join_left"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        import pandas as pd
+
+        return pd.DataFrame({"wiring_join_left": [1, 2, 3], "id": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("id",))]
+
+
+class WiringJoinRightFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"wiring_join_right"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        import pyarrow as pa
+
+        return pa.table({"wiring_join_right": [10, 20, 30], "id": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("id",))]
+
+
+class WiringJoinChild(FeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("wiring_join_left"), Feature("wiring_join_right")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"wiring_join_child_result"}
+
+
+def test_run_link_calls_validate_join_step_uuids_with_non_empty_sides() -> None:
+    """Proves the guard is wired into run_link, not just independently correct: an ordinary,
+    successful join must invoke it with the genuine (non-empty) destination and source uuids."""
+    with patch.object(ExecutionPlan, "_validate_join_step_uuids", wraps=ExecutionPlan._validate_join_step_uuids) as spy:
+        mloda.prepare(
+            features=[Feature("wiring_join_child_result")],
+            links={Link.inner_on(WiringJoinLeftFG, WiringJoinRightFG)},
+            compute_frameworks={PandasDataFrame, PyArrowTable},
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {WiringJoinLeftFG, WiringJoinRightFG, WiringJoinChild}
+            ),
+        )
+
+    assert spy.call_count >= 1
+    _, destination_uuids, source_uuids = spy.call_args[0]
+    assert destination_uuids
+    assert source_uuids

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -364,7 +364,7 @@ class TestPrepareExecuteStep:
         step.compute_framework.get_class_name.return_value = "TestCFW"
 
         existing_uuid = uuid4()
-        cfw_register.get_cfw_uuid.return_value = existing_uuid
+        cfw_register.get_unique_cfw_uuid.return_value = existing_uuid
 
         result = executor.prepare_execute_step(step, ParallelizationMode.SYNC)
 
@@ -378,6 +378,7 @@ class TestPrepareExecuteStep:
 
         step = Mock(spec=FeatureGroupStep)
         step.tfs_ids = [uuid4()]
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = None
 
         feature_uuid = uuid4()
@@ -409,6 +410,8 @@ class TestPrepareExecuteStep:
         step.tfs_ids = []
         step.features = Mock()
         step.features.any_uuid = None
+        step.compute_framework = Mock()
+        cfw_register.get_unique_cfw_uuid.return_value = None
 
         with pytest.raises(ValueError, match="from_feature_uuid should not be none"):
             executor.prepare_execute_step(step, ParallelizationMode.SYNC)
@@ -673,6 +676,7 @@ class TestSyncExecuteStep:
         step.compute_framework.get_class_name.return_value = "TestCFW"
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -699,6 +703,7 @@ class TestSyncExecuteStep:
         step.step_is_done = False
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -723,6 +728,7 @@ class TestSyncExecuteStep:
         step.compute_framework.get_class_name.return_value = "TestCFW"
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -757,6 +763,7 @@ class TestThreadExecuteStep:
         step.compute_framework.get_class_name.return_value = "TestCFW"
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -785,6 +792,7 @@ class TestThreadExecuteStep:
         step.compute_framework.get_class_name.return_value = "TestCFW"
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -814,6 +822,7 @@ class TestThreadExecuteStep:
         step.compute_framework.get_class_name.return_value = "TestCFW"
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -848,6 +857,7 @@ class TestMultiExecuteStep:
         step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -879,6 +889,7 @@ class TestMultiExecuteStep:
         step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)
@@ -946,6 +957,7 @@ class TestMultiExecuteStep:
         step.get_uuids.return_value = {uuid4()}
 
         cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
 
         mock_cfw = Mock(spec=ComputeFramework)

--- a/tests/test_core/test_runtime/test_tfs_ids_ambiguous_resolution.py
+++ b/tests/test_core/test_runtime/test_tfs_ids_ambiguous_resolution.py
@@ -1,0 +1,175 @@
+"""Tests for FeatureGroupStep.tfs_ids ambiguity detection.
+
+Guards prepare_execute_step (ComputeFrameworkExecutor) and _cfw_to_occupy
+(ExecutionOrchestrator): if two tfs_ids resolve to two DIFFERENT registered
+compute frameworks, resolution must raise instead of picking one via set order.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+from uuid import UUID, uuid4
+
+import pytest
+
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.core.cfw_manager import CfwManager
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.runtime.compute_framework_executor import ComputeFrameworkExecutor
+from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda.core.runtime.worker_manager import WorkerManager
+
+CLASS_NAME = "TestCFW"
+
+
+def _register_two_distinct_cfws(cfw_register: CfwManager, tfs_id_a: UUID, tfs_id_b: UUID) -> tuple[UUID, UUID]:
+    """Register two cfws under CLASS_NAME, each rooted on a different tfs_id."""
+    cfw_uuid_a, cfw_uuid_b = uuid4(), uuid4()
+    cfw_register.add_cfw_to_compute_frameworks(cfw_uuid_a, CLASS_NAME, {tfs_id_a})
+    cfw_register.add_cfw_to_compute_frameworks(cfw_uuid_b, CLASS_NAME, {tfs_id_b})
+    return cfw_uuid_a, cfw_uuid_b
+
+
+def _register_one_shared_cfw(cfw_register: CfwManager, tfs_id_a: UUID, tfs_id_b: UUID) -> UUID:
+    """Register a single cfw rooted on both tfs_ids (non-ambiguous)."""
+    cfw_uuid = uuid4()
+    cfw_register.add_cfw_to_compute_frameworks(cfw_uuid, CLASS_NAME, {tfs_id_a, tfs_id_b})
+    return cfw_uuid
+
+
+def _feature_group_step(tfs_ids: set[UUID]) -> Mock:
+    step = Mock(spec=FeatureGroupStep)
+    step.tfs_ids = tfs_ids
+    step.compute_framework = Mock()
+    step.compute_framework.get_class_name.return_value = CLASS_NAME
+    step.get_parallelization_mode.return_value = set()
+    return step
+
+
+class TestPrepareExecuteStepTfsIdsAmbiguity:
+    """ComputeFrameworkExecutor.prepare_execute_step, FeatureGroupStep branch."""
+
+    def test_raises_when_two_tfs_ids_resolve_to_different_cfws(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        tfs_id_a, tfs_id_b = uuid4(), uuid4()
+        _register_two_distinct_cfws(cfw_register, tfs_id_a, tfs_id_b)
+
+        step = _feature_group_step({tfs_id_a, tfs_id_b})
+
+        with pytest.raises(ValueError, match="(?i)ambiguous"):
+            executor.prepare_execute_step(step, ParallelizationMode.SYNC)
+
+    def test_returns_cfw_uuid_when_all_tfs_ids_resolve_to_same_cfw(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        tfs_id_a, tfs_id_b = uuid4(), uuid4()
+        cfw_uuid = _register_one_shared_cfw(cfw_register, tfs_id_a, tfs_id_b)
+
+        step = _feature_group_step({tfs_id_a, tfs_id_b})
+
+        result = executor.prepare_execute_step(step, ParallelizationMode.SYNC)
+
+        assert result == cfw_uuid
+
+    def test_returns_cfw_uuid_when_only_one_tfs_id_resolves(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        tfs_id_resolved, tfs_id_unresolved = uuid4(), uuid4()
+        cfw_uuid = uuid4()
+        cfw_register.add_cfw_to_compute_frameworks(cfw_uuid, CLASS_NAME, {tfs_id_resolved})
+
+        step = _feature_group_step({tfs_id_resolved, tfs_id_unresolved})
+
+        result = executor.prepare_execute_step(step, ParallelizationMode.SYNC)
+
+        assert result == cfw_uuid
+
+    def test_falls_through_to_any_uuid_when_no_tfs_id_resolves(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        any_uuid = uuid4()
+        cfw_uuid = uuid4()
+        cfw_register.add_cfw_to_compute_frameworks(cfw_uuid, CLASS_NAME, {any_uuid})
+
+        step = _feature_group_step({uuid4(), uuid4()})
+        step.features = Mock()
+        step.features.any_uuid = any_uuid
+        step.children_if_root = set()
+
+        result = executor.prepare_execute_step(step, ParallelizationMode.SYNC)
+
+        assert result == cfw_uuid
+
+
+class TestCfwToOccupyTfsIdsAmbiguity:
+    """ExecutionOrchestrator._cfw_to_occupy."""
+
+    def _orchestrator(self, cfw_register: CfwManager) -> ExecutionOrchestrator:
+        orchestrator = ExecutionOrchestrator(Mock(spec=ExecutionPlan))
+        orchestrator.cfw_register = cfw_register
+        return orchestrator
+
+    def test_raises_when_two_tfs_ids_resolve_to_different_cfws(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        orchestrator = self._orchestrator(cfw_register)
+
+        tfs_id_a, tfs_id_b = uuid4(), uuid4()
+        _register_two_distinct_cfws(cfw_register, tfs_id_a, tfs_id_b)
+
+        step = _feature_group_step({tfs_id_a, tfs_id_b})
+
+        with pytest.raises(ValueError, match="(?i)ambiguous"):
+            orchestrator._cfw_to_occupy(step)
+
+    def test_returns_cfw_uuid_when_all_tfs_ids_resolve_to_same_cfw(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        orchestrator = self._orchestrator(cfw_register)
+
+        tfs_id_a, tfs_id_b = uuid4(), uuid4()
+        cfw_uuid = _register_one_shared_cfw(cfw_register, tfs_id_a, tfs_id_b)
+
+        step = _feature_group_step({tfs_id_a, tfs_id_b})
+
+        result = orchestrator._cfw_to_occupy(step)
+
+        assert result == cfw_uuid
+
+    def test_returns_cfw_uuid_when_only_one_tfs_id_resolves(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        orchestrator = self._orchestrator(cfw_register)
+
+        tfs_id_resolved, tfs_id_unresolved = uuid4(), uuid4()
+        cfw_uuid = uuid4()
+        cfw_register.add_cfw_to_compute_frameworks(cfw_uuid, CLASS_NAME, {tfs_id_resolved})
+
+        step = _feature_group_step({tfs_id_resolved, tfs_id_unresolved})
+
+        result = orchestrator._cfw_to_occupy(step)
+
+        assert result == cfw_uuid
+
+    def test_falls_through_to_any_uuid_when_no_tfs_id_resolves(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        orchestrator = self._orchestrator(cfw_register)
+
+        any_uuid = uuid4()
+        cfw_uuid = uuid4()
+        cfw_register.add_cfw_to_compute_frameworks(cfw_uuid, CLASS_NAME, {any_uuid})
+
+        step = _feature_group_step({uuid4(), uuid4()})
+        step.features = Mock()
+        step.features.any_uuid = any_uuid
+
+        result = orchestrator._cfw_to_occupy(step)
+
+        assert result == cfw_uuid


### PR DESCRIPTION
## Summary

Three independent hardenings to the join-resolution machinery, follow-ups from a prior JoinStep missing-Links guard:

- `run_link` could, in a theoretical edge case, resolve an empty `destination_framework_uuids` or `source_framework_uuids` set for a constructed `JoinStep`. That previously surfaced later as an unguarded `StopIteration` deep in the runtime. A new `ExecutionPlan._validate_join_step_uuids` guard now raises a clear error at construction time instead, and a wiring test proves it is actually invoked during a real join.

- `FeatureGroupStep.tfs_ids` can hold more than one uuid in some join-served scenarios. The two consumers picked whichever uuid resolved first in set iteration order, silently masking a genuine ambiguity if two uuids ever resolved to different compute frameworks. Both now go through a shared `CfwManager.get_unique_cfw_uuid` helper that raises on real ambiguity and keeps current behavior otherwise.

- `add_tfs` checked explicit transform hops for the missing-Links conflict before join-served parents (parents already delivered pre-merged by a join, no explicit hop needed) were merged into the same grouping, so a join-served parent that genuinely links two otherwise-separate hops could not prevent a false conflict error. The two-stage check is now one check, run after both explicit hops and join-served parents are merged. The linkage test itself was also tightened: it used to treat two entries as linked whenever either was a subclass of any declared side of the other's matching join, which could wrongly bridge two genuinely unrelated hops that merely share a common ancestor class. It now requires the two entries' own classes to be directly related to each other (or connected through actual join uuid adjacency), closing that gap while preserving the original case-override scenario it was built for.

## Test plan

- New regression tests for each of the three fixes, including an adversarial case for the linkage tightening and a wiring test proving the empty-uuid guard is reachable from a real join.
- Full `tox` passes: tests, ruff format/check, mypy --strict, bandit.