### PR TITLE
test: fold test_documentation's markdown-file helpers into docs_corpus

### DIFF
--- a/tests/docs_corpus.py
+++ b/tests/docs_corpus.py
@@ -17,12 +17,17 @@ PYTHON_LOOKING = re.compile(r"i?py(thon)?[0-9]*(-repl)?|pycon", re.IGNORECASE)
 PYTHON_BLOCK_PATTERN = re.compile(rf"```(?:{RUNNABLE_TAG}|{ILLUSTRATIVE_TAG})\n(.*?)```", re.DOTALL)
 
 
-def doc_files() -> list[Path]:
-    """Every markdown file under DOCS_ROOT; never an empty list, so a bad path fails loudly at import time."""
-    files = sorted(DOCS_ROOT.rglob("*.md"))
+def doc_files(root: Path = DOCS_ROOT) -> list[Path]:
+    """Every markdown file under root; never an empty list, so a bad path fails loudly at import time."""
+    files = sorted(root.rglob("*.md"))
     if not files:
-        raise RuntimeError(f"no markdown files found under {DOCS_ROOT}, doc guard tests would check nothing")
+        raise RuntimeError(f"no markdown files found under {root}, doc guard tests would check nothing")
     return files
+
+
+def doc_id(fpath: Path) -> str:
+    """Repo-relative posix path used as a pytest parametrize id."""
+    return fpath.relative_to(REPO_ROOT).as_posix()
 
 
 def is_python_fence(info: str) -> bool:

--- a/tests/test_docs_corpus.py
+++ b/tests/test_docs_corpus.py
@@ -2,7 +2,15 @@
 
 import pytest
 
-from tests.docs_corpus import ILLUSTRATIVE_TAG, OUTPUT_TAG, RUNNABLE_TAG, is_python_fence
+from tests.docs_corpus import (
+    DOCS_ROOT,
+    ILLUSTRATIVE_TAG,
+    OUTPUT_TAG,
+    REPO_ROOT,
+    RUNNABLE_TAG,
+    doc_files,
+    is_python_fence,
+)
 
 PYTHON_LOOKING_INFO_STRINGS = (
     "python",
@@ -44,3 +52,27 @@ def test_is_python_fence_matches_python_looking_info(info: str) -> None:
 @pytest.mark.parametrize("info", NON_PYTHON_INFO_STRINGS)
 def test_is_python_fence_rejects_non_python_info(info: str) -> None:
     assert not is_python_fence(info), f"{info!r} should not be recognised as a python fence"
+
+
+def test_doc_files_default_returns_docs_root_files() -> None:
+    files = doc_files()
+    assert files
+    assert files == sorted(DOCS_ROOT.rglob("*.md"))
+
+
+def test_doc_files_accepts_explicit_root() -> None:
+    other_root = DOCS_ROOT / "in_depth"
+    files = doc_files(other_root)
+    assert files
+    assert files == sorted(other_root.rglob("*.md"))
+    assert files != doc_files()
+
+
+def test_doc_id_returns_repo_relative_posix_path() -> None:
+    from tests.docs_corpus import doc_id
+
+    fpath = doc_files()[0]
+    result = doc_id(fpath)
+    assert result == fpath.relative_to(REPO_ROOT).as_posix()
+    assert not result.startswith("/")
+    assert "\\" not in result

--- a/tests/test_docs_near_miss_labels.py
+++ b/tests/test_docs_near_miss_labels.py
@@ -24,7 +24,7 @@ from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, render_resolution_failure
 from mloda.core.prepare.resolution_types import Elimination, EliminationStage, EvaluationResult
 
-from tests.docs_corpus import DOCS_ROOT, REPO_ROOT, doc_files
+from tests.docs_corpus import DOCS_ROOT, REPO_ROOT, doc_files, doc_id
 
 FENCE_PATTERN = re.compile(r"^\s*```")
 
@@ -61,7 +61,7 @@ def _near_miss_bullets(text: str) -> Iterator[tuple[int, re.Match[str]]]:
             yield number, match
 
 
-@pytest.mark.parametrize("fpath", doc_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+@pytest.mark.parametrize("fpath", doc_files(), ids=doc_id)
 def test_rendered_near_miss_bullets_carry_a_current_stage_label(fpath: Path) -> None:
     """Every label a page reproduces in a near-miss bullet is still a value of ``_STAGE_LABELS``."""
     stale = [
@@ -159,7 +159,7 @@ def _unmatched_filter_warnings(text: str) -> Iterator[tuple[int, re.Match[str]]]
             yield number, match
 
 
-@pytest.mark.parametrize("fpath", doc_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+@pytest.mark.parametrize("fpath", doc_files(), ids=doc_id)
 def test_rendered_unmatched_filter_warnings_carry_a_current_stage_label(fpath: Path) -> None:
     """Every label a page reproduces in an unmatched-filter warning is still a value of ``_STAGE_LABELS``."""
     stale = [

--- a/tests/test_documentation/test_documentation.py
+++ b/tests/test_documentation/test_documentation.py
@@ -10,7 +10,7 @@ import pytest
 from typing import Any
 import time
 from mloda.steward import ExtenderHook, Extender
-from tests.docs_corpus import PYTHON_BLOCK_PATTERN, RUNNABLE_TAG
+from tests.docs_corpus import PYTHON_BLOCK_PATTERN, RUNNABLE_TAG, doc_files, doc_id
 import logging
 
 logger = logging.getLogger(__name__)
@@ -20,24 +20,6 @@ logger = logging.getLogger(__name__)
 # checking zero files (issue #937).
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCS_DIR = REPO_ROOT / "docs"
-
-
-def _markdown_files(root: Path) -> list[Path]:
-    """Every markdown file under ``root``, never an empty list.
-
-    Two ``parametrize`` calls consume this at import time, where an empty list
-    silently collapses to zero test cases instead of failing. Raising here
-    turns that into a collection error naming the directory we looked in.
-    """
-    files = sorted(root.rglob("*.md"))
-    if not files:
-        raise RuntimeError(f"no markdown files found under {root} - the documentation tests would check nothing")
-    return files
-
-
-def _doc_id(fpath: Path) -> str:
-    """Repo-relative test id, so ids do not carry an absolute machine path."""
-    return fpath.relative_to(REPO_ROOT).as_posix()
 
 
 # We need this to test DokuExtender
@@ -107,13 +89,13 @@ def run_md_file_isolated(fpath: Path) -> None:
 
 @pytest.mark.timeout(120)
 def test_files_good() -> None:
-    run_md_files_isolated(_markdown_files(DOCS_DIR))
+    run_md_files_isolated(doc_files(DOCS_DIR))
 
 
 TEST_IMPORT_PATTERN = re.compile(r"^\s*from\s+tests\..*$", re.MULTILINE)
 
 
-@pytest.mark.parametrize("fpath", _markdown_files(DOCS_DIR / "docs"), ids=_doc_id)
+@pytest.mark.parametrize("fpath", doc_files(DOCS_DIR / "docs"), ids=doc_id)
 def test_no_test_imports_in_docs(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     violations = []
@@ -156,14 +138,14 @@ def _extract_headings(md_path: Path) -> set[str]:
     return {_heading_to_anchor(m.group(1)) for m in HEADING_PATTERN.finditer(text)}
 
 
-@pytest.mark.parametrize("fpath", _markdown_files(DOCS_ROOT), ids=_doc_id)
+@pytest.mark.parametrize("fpath", doc_files(DOCS_ROOT), ids=doc_id)
 def test_no_absolute_site_links(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     matches = ABSOLUTE_LINK_PATTERN.findall(text)
     assert not matches, f"{fpath} contains absolute mloda-ai.github.io links (should be relative): {matches}"
 
 
-@pytest.mark.parametrize("fpath", _markdown_files(DOCS_ROOT), ids=_doc_id)
+@pytest.mark.parametrize("fpath", doc_files(DOCS_ROOT), ids=doc_id)
 def test_internal_link_targets_exist(fpath: Path) -> None:
     text = fpath.read_text(encoding="utf-8")
     errors: list[str] = []


### PR DESCRIPTION
## Summary

tests/docs_corpus.py centralizes the repo-root-anchored markdown file list shared by several doc guard tests. A fourth, similarly-shaped copy lived in tests/test_documentation/test_documentation.py: its private _markdown_files() and _doc_id() did the same anti-vacuous file-list job over a different root, taken as a parameter.

- doc_files() in tests/docs_corpus.py now accepts an optional root parameter (default DOCS_ROOT).
- Added doc_id() to tests/docs_corpus.py, the same repo-relative posix id logic that was duplicated as a private helper in test_documentation.py and as two inline parametrize id lambdas in test_docs_near_miss_labels.py.
- test_documentation.py and test_docs_near_miss_labels.py now import and use the shared helpers instead of their own copies.

No behavior change: same files collected, same test ids.

## Test plan

- [x] tox (full gate: pytest, ruff format/check, license allowlist, mypy --strict, bandit)
- [x] tests/test_documentation/ run directly (excluded from the default tox env, only covered under the python314 matrix leg)