### PR TITLE
fix: respect path-segment boundaries in ListDirectoryFeatureGroup ignore patterns

### DIFF
--- a/mloda_plugins/feature_group/experimental/environment/list_directory_feature_group.py
+++ b/mloda_plugins/feature_group/experimental/environment/list_directory_feature_group.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 import logging
+from fnmatch import fnmatch
 
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
@@ -103,10 +104,11 @@ class ListDirectoryFeatureGroup(FeatureGroup):
         """Checks if a file/directory should be ignored based on .gitignore patterns."""
         for pattern in ignore_patterns:
             if pattern.endswith("/"):  # Directory exclusion
-                if file_path.startswith(pattern.rstrip("/")):
+                dir_pattern = pattern.rstrip("/")
+                if file_path == dir_pattern or file_path.startswith(dir_pattern + "/"):
                     return True
-            elif "*" in pattern:  # Basic wildcard support (e.g., *.log)
-                if file_path.endswith(pattern.lstrip("*")):
+            elif "*" in pattern:  # Wildcard support (e.g., *.log, temp*, logs/*)
+                if fnmatch(file_path, pattern):
                     return True
             elif file_path == pattern:  # Exact file/directory match
                 return True

--- a/tests/test_plugins/feature_group/experimental/environment/test_list_directory_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/environment/test_list_directory_feature_group.py
@@ -33,3 +33,21 @@ def test_list_directory_feature_group_mlodaAPI() -> None:
         assert "__init__.py" not in res[ListDirectoryFeatureGroup.get_class_name()].values[0]
     assert len(result) == 1
     assert ListDirectoryFeatureGroup.get_class_name() in result[0]
+
+
+def test_is_ignored_directory_pattern_respects_segment_boundary() -> None:
+    # A directory pattern must match the directory itself and its contents,
+    # but not unrelated paths that merely share a prefix.
+    assert ListDirectoryFeatureGroup._is_ignored("build_tools/x.py", {"build/"}) is False
+    assert ListDirectoryFeatureGroup._is_ignored("build", {"build/"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("build/out.txt", {"build/"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("build/sub/out.txt", {"build/"}) is True
+
+
+def test_is_ignored_wildcard_patterns() -> None:
+    assert ListDirectoryFeatureGroup._is_ignored("debug.log", {"*.log"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("debug.txt", {"*.log"}) is False
+    assert ListDirectoryFeatureGroup._is_ignored("temp.txt", {"temp*"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("keep.txt", {"temp*"}) is False
+    assert ListDirectoryFeatureGroup._is_ignored("logs/app.log", {"logs/*"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("other/app.log", {"logs/*"}) is False


### PR DESCRIPTION
- [x] Bug fix (`fix:`)

## Problem

`ListDirectoryFeatureGroup._is_ignored` matched `.gitignore`-style directory patterns with a raw string prefix check:

```python
if file_path.startswith(pattern.rstrip("/")):
```

So a pattern like `build/` also incorrectly ignored unrelated paths such as `build_tools/x.py`, since the string merely starts with `build`.

The wildcard branch had a similar problem: it only did an `endswith` check after stripping leading asterisks, so patterns like `temp*` and `logs/*` never matched anything, and matching was not real glob semantics.

## Change

- Directory patterns (`pattern.endswith("/")`) now match on a path-segment boundary: the pattern equals the path, or the path starts with `pattern + "/"`.
- Wildcard patterns now use `fnmatch.fnmatch(file_path, pattern)`, so `*.log`, `temp*` and `logs/*` all behave as expected.

Fixes #1207

## Verification

- Reproduced the bug before the fix: `_is_ignored("build_tools/x.py", {"build/"})` returned `True`, and `temp*` / `logs/*` never matched.
- Added focused tests for both cases in `tests/test_plugins/feature_group/experimental/environment/test_list_directory_feature_group.py`.
- `uv run pytest tests/test_plugins/feature_group/experimental/environment/test_list_directory_feature_group.py` — 4 passed.
- `uv run ruff format --check`, `uv run ruff check`, and `uv run mypy --strict` on the changed files — all pass.
- Full suite: `uv run pytest tests/` — 9618 passed, 161 skipped, 2 xfailed.