### PR TITLE
fix: keep InstalledPackagesFeatureGroup error-path output shape consistent

### DIFF
--- a/mloda_plugins/feature_group/experimental/environment/installed_packages_feature_group.py
+++ b/mloda_plugins/feature_group/experimental/environment/installed_packages_feature_group.py
@@ -108,7 +108,7 @@ class InstalledPackagesFeatureGroup(FeatureGroup):
             return {cls.get_class_name(): [packages]}
         except subprocess.CalledProcessError as e:
             error_message = f"Command '{e.cmd}' failed with return code {e.returncode}. Error output: {e.stderr}"
-            return {"error": error_message}
+            return {cls.get_class_name(): [error_message]}
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:

--- a/tests/test_plugins/feature_group/experimental/environment/test_installed_packages_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/environment/test_installed_packages_feature_group.py
@@ -1,3 +1,6 @@
+import subprocess  # nosec
+
+import pytest
 from mloda.user import Feature
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.experimental.environment.installed_packages_feature_group import (
@@ -19,3 +22,17 @@ def test_installed_packages_feature_group_mlodaAPI() -> None:
     result = mloda.run_all(features, compute_frameworks={PandasDataFrame})
     assert len(result) == 1
     assert InstalledPackagesFeatureGroup.get_class_name() in result[0]
+
+
+def test_installed_packages_feature_group_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_called_process_error(*args: object, **kwargs: object) -> object:
+        raise subprocess.CalledProcessError(1, "pip freeze")
+
+    monkeypatch.setattr(subprocess, "run", raise_called_process_error)
+    feature_set = FeatureSet()
+    result = InstalledPackagesFeatureGroup.calculate_feature(None, feature_set)
+    assert result == {
+        InstalledPackagesFeatureGroup.get_class_name(): [
+            "Command 'pip freeze' failed with return code 1. Error output: None"
+        ]
+    }


### PR DESCRIPTION
- [x] Bug fix (`fix:`)

## Problem

The class docstring's "## Output Format" contract for `InstalledPackagesFeatureGroup.calculate_feature` promises a single column named `InstalledPackagesFeatureGroup` holding a list. The success path honors this:

```python
return {cls.get_class_name(): [packages]}
```

but the `except subprocess.CalledProcessError` branch returned a different shape entirely — key `"error"` with a plain string instead of a list:

```python
return {"error": error_message}
```

Downstream consumers expecting the documented column would hit a `KeyError` or receive a malformed frame whenever `pip freeze` failed.

## Change

One line in the error branch, so both paths share the same shape:

```python
return {cls.get_class_name(): [error_message]}
```

Plus one new test covering the failure branch (monkeypatches `subprocess.run` to raise `subprocess.CalledProcessError(1, "pip freeze")` and asserts the returned dict uses the documented column key with the message in a list), as requested on the issue checklist.

## Why

Fixes #1206.

## How verified

- `.venv/bin/python -m pytest tests/test_plugins/feature_group/experimental/environment/test_installed_packages_feature_group.py` — 3 passed
- `ruff format --check` and `ruff check` on both changed files — clean
- `mypy --strict --ignore-missing-imports` on both changed files — no issues