### PR TITLE
fix: keep InstalledPackagesFeatureGroup's output shape on the error path

### DIFF
--- a/mloda_plugins/feature_group/experimental/environment/installed_packages_feature_group.py
+++ b/mloda_plugins/feature_group/experimental/environment/installed_packages_feature_group.py
@@ -91,7 +91,8 @@ class InstalledPackagesFeatureGroup(FeatureGroup):
     - Uses `subprocess.run()` to execute `pip freeze`
     - Captures stdout as text
     - Returns packages as a single string in a list (DataFrame-compatible)
-    - On error, returns error message dictionary
+    - On error, returns the error message in that same column, so the output shape
+      does not change between the success and failure paths
 
     ## Security Considerations
 
@@ -108,7 +109,7 @@ class InstalledPackagesFeatureGroup(FeatureGroup):
             return {cls.get_class_name(): [packages]}
         except subprocess.CalledProcessError as e:
             error_message = f"Command '{e.cmd}' failed with return code {e.returncode}. Error output: {e.stderr}"
-            return {"error": error_message}
+            return {cls.get_class_name(): [error_message]}
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:

--- a/tests/test_plugins/feature_group/experimental/environment/test_installed_packages_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/environment/test_installed_packages_feature_group.py
@@ -1,3 +1,6 @@
+import subprocess
+from unittest.mock import patch
+
 from mloda.user import Feature
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.experimental.environment.installed_packages_feature_group import (
@@ -19,3 +22,24 @@ def test_installed_packages_feature_group_mlodaAPI() -> None:
     result = mloda.run_all(features, compute_frameworks={PandasDataFrame})
     assert len(result) == 1
     assert InstalledPackagesFeatureGroup.get_class_name() in result[0]
+
+
+def test_installed_packages_feature_group_error_path_keeps_the_output_shape() -> None:
+    """A pip freeze failure must land in the documented column, not a separate "error" key.
+
+    The success path returns {ClassName: [...]}, and the class docstring's Output
+    Format section promises that single column. A different key on failure gives a
+    caller a KeyError instead of a readable message, exactly when it is debugging.
+    """
+    feature_set = FeatureSet()
+    failure = subprocess.CalledProcessError(returncode=1, cmd=["pip", "freeze"], stderr="boom")
+
+    with patch("subprocess.run", side_effect=failure):
+        result = InstalledPackagesFeatureGroup.calculate_feature(None, feature_set)
+
+    column = InstalledPackagesFeatureGroup.get_class_name()
+    assert set(result) == {column}, "the failure path must not introduce another key"
+    assert isinstance(result[column], list)
+    assert len(result[column]) == 1
+    assert "boom" in result[column][0]
+    assert "return code 1" in result[column][0]


### PR DESCRIPTION
Closes #1206

`calculate_feature` returned `{cls.get_class_name(): [packages]}` on success but `{"error": error_message}` on `CalledProcessError` — a different key, and a bare string where the success path returns a list. The class's own **Output Format** docstring promises a single column named `InstalledPackagesFeatureGroup`.

The consequence is the wrong way round: a caller gets a `KeyError` or a malformed frame *precisely when `pip freeze` has failed and it needs to read the error message*. The failure path was the one making failures hard to diagnose.

Now `{cls.get_class_name(): [error_message]}` — same key, same list-of-one shape, on both paths.

I also corrected the docstring's **Implementation Details** bullet, which said *"On error, returns error message dictionary"*. That line described the old behaviour and would have contradicted the code after this change.

### Test

The failure branch had no coverage at all. The new test patches `subprocess.run` to raise `CalledProcessError` and asserts:

```python
assert set(result) == {column}, "the failure path must not introduce another key"
```

`set(result) == {column}` rather than `column in result` on purpose — an `in` check would still pass if a stray `"error"` key came back alongside the right one, which is exactly the regression worth catching.

Verified it fails against the old code:

```
FAILED ...::test_installed_packages_feature_group_error_path_keeps_the_output_shape
1 failed, 2 deselected
```

With the fix: **3 passed**. `ruff format` / `ruff check` clean.

`mypy --strict` on the changed file reports 6 errors in 4 *other* files (missing pandas stubs in my local env) — byte-identical output on `upstream/main` with my changes stashed, so nothing new from this PR.
