### PR TITLE
fix: match directory-pattern and wildcard ignore patterns on path boundaries

### DIFF
--- a/mloda_plugins/feature_group/experimental/environment/list_directory_feature_group.py
+++ b/mloda_plugins/feature_group/experimental/environment/list_directory_feature_group.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 from typing import Any
 import logging
@@ -103,10 +104,11 @@ class ListDirectoryFeatureGroup(FeatureGroup):
         """Checks if a file/directory should be ignored based on .gitignore patterns."""
         for pattern in ignore_patterns:
             if pattern.endswith("/"):  # Directory exclusion
-                if file_path.startswith(pattern.rstrip("/")):
+                base = pattern.rstrip("/")
+                if file_path == base or file_path.startswith(base + "/"):
                     return True
-            elif "*" in pattern:  # Basic wildcard support (e.g., *.log)
-                if file_path.endswith(pattern.lstrip("*")):
+            elif "*" in pattern:  # Wildcard support (e.g., *.log, temp*, logs/*)
+                if fnmatch.fnmatch(file_path, pattern):
                     return True
             elif file_path == pattern:  # Exact file/directory match
                 return True

--- a/tests/test_plugins/feature_group/experimental/environment/test_list_directory_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/environment/test_list_directory_feature_group.py
@@ -33,3 +33,18 @@ def test_list_directory_feature_group_mlodaAPI() -> None:
         assert "__init__.py" not in res[ListDirectoryFeatureGroup.get_class_name()].values[0]
     assert len(result) == 1
     assert ListDirectoryFeatureGroup.get_class_name() in result[0]
+
+
+def test_is_ignored_directory_pattern_respects_path_boundary() -> None:
+    # A directory pattern "build/" must not match an unrelated directory that merely
+    # shares the same string prefix, e.g. "build_tools".
+    assert ListDirectoryFeatureGroup._is_ignored("build_tools/x.py", {"build/"}) is False
+    assert ListDirectoryFeatureGroup._is_ignored("build/x.py", {"build/"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("build", {"build/"}) is True
+
+
+def test_is_ignored_wildcard_patterns() -> None:
+    assert ListDirectoryFeatureGroup._is_ignored("debug.log", {"*.log"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("temp_file.txt", {"temp*"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("logs/output.txt", {"logs/*"}) is True
+    assert ListDirectoryFeatureGroup._is_ignored("keep.txt", {"*.log"}) is False


### PR DESCRIPTION
## Summary

- `ListDirectoryFeatureGroup._is_ignored` matched `.gitignore`-style directory patterns with a raw string prefix check, so a pattern like `build/` incorrectly matched unrelated paths such as `build_tools/x.py`.
- Wildcard matching only handled a leading `*` via `lstrip("*")` + `str.endswith`, so patterns like `temp*` or `logs/*` never matched as expected.
- Directory patterns now compare on a path-segment boundary (`file_path == base or file_path.startswith(base + "/")`), and wildcard patterns are matched with `fnmatch.fnmatch`.

Fixes #1207

## Test plan

- [x] `_is_ignored("build_tools/x.py", {"build/"})` returns `False`
- [x] `_is_ignored("build/x.py", {"build/"})` returns `True`
- [x] Additional wildcard patterns (`temp*`, `logs/*`) match correctly, in addition to the existing `*.log` case
- [x] New unit tests added in `test_list_directory_feature_group.py`
- [x] `ruff format --check`, `ruff check`, and `mypy --strict --ignore-missing-imports` pass on the changed files
- [x] Full `pytest` suite run locally (9613 passed, 161 skipped, 2 xfailed); the only failures seen were pre-existing Windows-sandbox issues unrelated to this change (console-encoding in notebook tests, worker crashes in unrelated files) and do not touch `list_directory_feature_group.py`