### PR TITLE
test: cover bfill in missing value integrations

### DIFF
--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_missing_value_utils.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_missing_value_utils.py
@@ -20,6 +20,7 @@ MISSING_VALUE_FEATURES: list[Feature | str] = [
     "category__mode_imputed",  # Mode imputation
     "category__constant_imputed",  # Constant imputation
     "temperature__ffill_imputed",  # Forward fill imputation
+    "temperature__bfill_imputed",  # Backward fill imputation
 ]
 
 
@@ -72,8 +73,11 @@ def validate_missing_value_features(result: list[pd.DataFrame]) -> None:
     assert imputed_df["category__constant_imputed"].iloc[1] == "Unknown"
     assert imputed_df["category__constant_imputed"].iloc[4] == "Unknown"
 
-    assert not pd.isna(imputed_df["temperature__ffill_imputed"].iloc[2])
-    assert not pd.isna(imputed_df["temperature__ffill_imputed"].iloc[3])
+    assert imputed_df["temperature__ffill_imputed"].iloc[2] == 68.3
+    assert imputed_df["temperature__ffill_imputed"].iloc[3] == 68.3
+
+    assert imputed_df["temperature__bfill_imputed"].iloc[2] == 70.1
+    assert imputed_df["temperature__bfill_imputed"].iloc[3] == 70.1
 
     assert "income__mean_imputed" in imputed_df.columns
     assert abs(imputed_df["income__mean_imputed"].iloc[1] - 61666.67) < 1.0  # Increased tolerance for PyArrow

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pandas_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pandas_missing_value_feature_group.py
@@ -301,6 +301,7 @@ class TestMissingValuePandasIntegration:
             "category__mode_imputed",  # Mode imputation
             "category__constant_imputed",  # Constant imputation
             "temperature__ffill_imputed",  # Forward fill imputation
+            "temperature__bfill_imputed",  # Backward fill imputation
         ]
 
         feature_list: list[Feature | str] = [Feature(name=feature, options=options) for feature in feature_str]

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
@@ -304,6 +304,7 @@ class TestMissingValuePyArrowIntegration:
             "category__mode_imputed",  # Mode imputation
             "category__constant_imputed",  # Constant imputation
             "temperature__ffill_imputed",  # Forward fill imputation
+            "temperature__bfill_imputed",  # Backward fill imputation
         ]
 
         feature_list: list[str | Feature] = [Feature(name=feature, options=options) for feature in feature_str]

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_python_dict_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_python_dict_missing_value_feature_group.py
@@ -364,6 +364,7 @@ class TestMissingValuePythonDictIntegration:
             "category__mode_imputed",  # Mode imputation
             "category__constant_imputed",  # Constant imputation
             "temperature__ffill_imputed",  # Forward fill imputation
+            "temperature__bfill_imputed",  # Backward fill imputation
         ]
 
         feature_list = [Feature(name=feature, options=options) for feature in feature_str]


### PR DESCRIPTION

## Summary

Adds end-to-end `bfill` coverage for the pandas, PyArrow, and Python-dictionary missing-value integrations. Exact assertions verify that `ffill` and `bfill` fill values from the correct directions.

Closes #1208

## Testing

- 9570 passed, 170 skipped, 2 xfailed
- Ruff format and lint checks passed
- Mypy, Bandit, and license checks passed