### PR TITLE
fix: raise instead of hanging on a compute-framework merge-relation cycle

### DIFF
--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -128,6 +128,9 @@ class CfwManager:
         """
         Adds a merge relation between two Compute Framework UUIDs.
 
+        Calling this a second time for a pair already merged, with either uuid on either
+        side, can create a cycle in cfw_merge_relation, which find_leftmost will detect and raise on.
+
         Args:
             left_uuid: The UUID of the left Compute Framework.
             right_uuid: The UUID of the right Compute Framework.
@@ -148,19 +151,27 @@ class CfwManager:
 
         Returns:
             The leftmost UUID in the chain.
+
+        Raises:
+            ValueError: If cfw_merge_relation contains a cycle.
         """
         if uuid not in self.cfw_merge_relation:
             return uuid
 
+        start_uuid = uuid
         leftmost_uuid = uuid
         visited = {uuid}
 
         while self.cfw_merge_relation[uuid][0] != uuid:
             uuid = self.cfw_merge_relation[uuid][0]
 
-            # A revisited uuid means cfw_merge_relation contains a cycle instead of a chain to a root.
             if uuid in visited:
-                raise ValueError(f"Cycle detected in cfw_merge_relation while resolving leftmost uuid: {uuid}")
+                raise ValueError(
+                    internal_invariant_error(
+                        "cfw_merge_relation contains a cycle while resolving leftmost uuid.",
+                        f"start_uuid={start_uuid}, cls_name={cls_name}, visited={visited}",
+                    )
+                )
             visited.add(uuid)
 
             if self.cfw_merge_relation[uuid][1] == cls_name:

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -153,9 +153,15 @@ class CfwManager:
             return uuid
 
         leftmost_uuid = uuid
+        visited = {uuid}
 
         while self.cfw_merge_relation[uuid][0] != uuid:
             uuid = self.cfw_merge_relation[uuid][0]
+
+            # A revisited uuid means cfw_merge_relation contains a cycle instead of a chain to a root.
+            if uuid in visited:
+                raise ValueError(f"Cycle detected in cfw_merge_relation while resolving leftmost uuid: {uuid}")
+            visited.add(uuid)
 
             if self.cfw_merge_relation[uuid][1] == cls_name:
                 leftmost_uuid = uuid

--- a/tests/test_core/test_core/test_cfw_manager.py
+++ b/tests/test_core/test_core/test_cfw_manager.py
@@ -1,4 +1,8 @@
-"""Tests for CfwManager child_bootstrap get/set round-trip."""
+"""Tests for CfwManager child_bootstrap get/set round-trip and merge-relation cycles."""
+
+from uuid import uuid4
+
+import pytest
 
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.core.cfw_manager import CfwManager
@@ -30,3 +34,20 @@ class TestCfwManagerChildBootstrapRoundTrip:
         cfw_register.set_child_bootstrap(None)
 
         assert cfw_register.get_child_bootstrap() is None
+
+
+class TestCfwManagerFindLeftmostCycleDetection:
+    """A merge-relation cycle must raise, not hang find_leftmost forever."""
+
+    @pytest.mark.timeout(2)
+    def test_find_leftmost_raises_value_error_on_a_two_node_cycle(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        uuid_a = uuid4()
+        uuid_b = uuid4()
+        cls_name = "SomeComputeFramework"
+
+        cfw_register.add_to_merge_relation(uuid_a, uuid_b, cls_name)
+        cfw_register.add_to_merge_relation(uuid_b, uuid_a, cls_name)
+
+        with pytest.raises(ValueError):
+            cfw_register.find_leftmost(uuid_a, cls_name)

--- a/tests/test_core/test_core/test_cfw_manager.py
+++ b/tests/test_core/test_core/test_cfw_manager.py
@@ -51,3 +51,32 @@ class TestCfwManagerFindLeftmostCycleDetection:
 
         with pytest.raises(ValueError):
             cfw_register.find_leftmost(uuid_a, cls_name)
+
+    @pytest.mark.timeout(2)
+    def test_find_leftmost_raises_value_error_on_a_three_node_cycle(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        uuid_a = uuid4()
+        uuid_b = uuid4()
+        uuid_c = uuid4()
+        cls_name = "SomeComputeFramework"
+
+        cfw_register.add_to_merge_relation(uuid_a, uuid_b, cls_name)
+        cfw_register.add_to_merge_relation(uuid_b, uuid_c, cls_name)
+        cfw_register.add_to_merge_relation(uuid_c, uuid_a, cls_name)
+
+        with pytest.raises(ValueError):
+            cfw_register.find_leftmost(uuid_a, cls_name)
+
+    def test_find_leftmost_returns_the_root_uuid_for_a_non_cyclic_multi_hop_chain(self) -> None:
+        cfw_register = CfwManager({ParallelizationMode.SYNC})
+        uuid_a = uuid4()
+        uuid_b = uuid4()
+        uuid_c = uuid4()
+        cls_name = "SomeComputeFramework"
+
+        cfw_register.add_to_merge_relation(uuid_a, uuid_b, cls_name)
+        cfw_register.add_to_merge_relation(uuid_b, uuid_c, cls_name)
+
+        assert cfw_register.find_leftmost(uuid_c, cls_name) == uuid_a
+        assert cfw_register.find_leftmost(uuid_b, cls_name) == uuid_a
+        assert cfw_register.find_leftmost(uuid_a, cls_name) == uuid_a


### PR DESCRIPTION
## Summary

`CfwManager.find_leftmost` walked a merge-relation chain with no cycle detection. If two compute frameworks are merged twice with sides swapped, the relation forms a cycle instead of a chain to a root, and `find_leftmost` loops forever instead of returning or failing.

`find_leftmost` now tracks visited uuids while walking the chain and raises a clear internal-invariant error (matching this file's existing convention for this class of bug) if a uuid is revisited before reaching a root, instead of hanging. Both methods' docstrings now document this behavior and the hazard that causes it.

## Test plan

- Added a test reproducing the exact two-node cycle, guarded with a short timeout so a regression fails fast instead of hanging the suite.
- Added a three-node cycle test to confirm the fix generalizes beyond the minimal case.
- Added a non-cyclic multi-hop chain test to pin the existing happy path.
- Full local test suite, ruff, mypy --strict, and bandit all pass.