### PR TITLE
fix: document run_link's trekker lookup and tfs_ids as intentional

### DIFF
--- a/mloda/core/core/step/feature_group_step.py
+++ b/mloda/core/core/step/feature_group_step.py
@@ -35,7 +35,8 @@ class FeatureGroupStep(Step):
 
         self.need_to_upload = False
 
-        # Currently, also used for joinsteps without tfs. This might be a bug.
+        # A uuid already registered on the target compute framework, not necessarily a TransformFrameworkStep's
+        # own uuid: ExecutionPlan.add_tfs's same-framework join path also stores a plain feature uuid here.
         self.tfs_ids: set[UUID] = set()
 
     def get_uuids(self) -> set[UUID]:

--- a/mloda/core/core/step/feature_group_step.py
+++ b/mloda/core/core/step/feature_group_step.py
@@ -35,8 +35,6 @@ class FeatureGroupStep(Step):
 
         self.need_to_upload = False
 
-        # A uuid already registered on the target compute framework, not necessarily a TransformFrameworkStep's
-        # own uuid: ExecutionPlan.add_tfs's same-framework join path also stores a plain feature uuid here.
         self.tfs_ids: set[UUID] = set()
 
     def get_uuids(self) -> set[UUID]:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -743,13 +743,11 @@ Available join types:
         children_uuids: set[UUID] = set()
         attempted_key = link_fw
 
-        for stored_links, uuids in link_trekker.data.items():
-            if link_fw == stored_links:
-                children_uuids.update(uuids)
-            # this part is not working!
+        children_uuids.update(link_trekker.data.get(link_fw, set()))
 
         swap_merge_sides = False
 
+        # link_fw is sourced from link_trekker.data, so this branch is defensive, not expected to trigger.
         if len(children_uuids) == 0:
             # No child needs the declared orientation, so destination and source are the other way around.
             destination_framework = link_fw[2]

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -496,6 +496,8 @@ Available join types:
                                         inner_ep, store_val
                                     )
                                 else:
+                                    # Same value as any_uuid below: redundant with it, not load-bearing, but
+                                    # lets get_unique_cfw_uuid short-circuit before add_compute_framework's locked path.
                                     inner_ep.tfs_ids = {store_val}
                                     inner_ep.features.any_uuid = (
                                         store_val  # Resets the any_uuid to one of the left side
@@ -747,7 +749,9 @@ Available join types:
 
         swap_merge_sides = False
 
-        # link_fw is sourced from link_trekker.data, so this branch is defensive, not expected to trigger.
+        # The queue snapshots trekker keys before ResolveComputeFrameworks.links runs; LinkTrekker.invert_link
+        # can later re-key an inverted link, so link_fw may already be stale here. This branch re-resolves
+        # the link under its flipped key, the normal path for an inverted-orientation join.
         if len(children_uuids) == 0:
             # No child needs the declared orientation, so destination and source are the other way around.
             destination_framework = link_fw[2]
@@ -756,9 +760,7 @@ Available join types:
             swap_merge_sides = True
             attempted_key = (link, destination_framework, source_framework)
 
-            for stored_links, uuids in link_trekker.data.items():
-                if (link, destination_framework, source_framework) == stored_links:
-                    children_uuids.update(uuids)
+            children_uuids.update(link_trekker.data.get(attempted_key, set()))
 
             if len(children_uuids) == 0:
                 raise ValueError(f"Link {link} has no matching uuids.")

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -496,8 +496,6 @@ Available join types:
                                         inner_ep, store_val
                                     )
                                 else:
-                                    # Same value as any_uuid below: redundant with it, not load-bearing, but
-                                    # lets get_unique_cfw_uuid short-circuit before add_compute_framework's locked path.
                                     inner_ep.tfs_ids = {store_val}
                                     inner_ep.features.any_uuid = (
                                         store_val  # Resets the any_uuid to one of the left side
@@ -749,9 +747,6 @@ Available join types:
 
         swap_merge_sides = False
 
-        # The queue snapshots trekker keys before ResolveComputeFrameworks.links runs; LinkTrekker.invert_link
-        # can later re-key an inverted link, so link_fw may already be stale here. This branch re-resolves
-        # the link under its flipped key, the normal path for an inverted-orientation join.
         if len(children_uuids) == 0:
             # No child needs the declared orientation, so destination and source are the other way around.
             destination_framework = link_fw[2]

--- a/tests/test_core/test_integration/test_core/test_same_framework_join_tfs_ids.py
+++ b/tests/test_core/test_integration/test_core/test_same_framework_join_tfs_ids.py
@@ -1,0 +1,98 @@
+"""A same-compute-framework, non-APPEND/UNION join whose child requires both raw sides directly
+resolves through ExecutionPlan.add_tfs's inner_ep.tfs_ids branch and produces correct joined data.
+"""
+
+from typing import Any, Optional
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import Link
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+LEFT_KEYS = [1, 2, 3]
+LEFT_VALUES = [10, 20, 30]
+RIGHT_KEYS = [1, 2, 3]
+RIGHT_VALUES = [100, 200, 300]
+SUMMED_VALUES = [110, 220, 330]
+
+
+class SftfsLeft(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"sftfs_left_key", "sftfs_left_value"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"sftfs_left_key": LEFT_KEYS, "sftfs_left_value": LEFT_VALUES}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("sftfs_left_key",))]
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SftfsRight(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"sftfs_right_key", "sftfs_right_value"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"sftfs_right_key": RIGHT_KEYS, "sftfs_right_value": RIGHT_VALUES}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("sftfs_right_key",))]
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SftfsChild(FeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name="sftfs_left_key"),
+            Feature(name="sftfs_left_value"),
+            Feature(name="sftfs_right_key"),
+            Feature(name="sftfs_right_value"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        summed = (data["sftfs_left_value"] + data["sftfs_right_value"]).tolist()
+        return {cls.get_class_name(): summed}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+def test_same_framework_inner_join_child_requiring_both_sides_computes_correct_sums() -> None:
+    link = Link.inner_on(SftfsLeft, SftfsRight)
+
+    results = mloda.run_all(
+        [Feature(name=SftfsChild.get_class_name())],
+        links={link},
+        compute_frameworks={PandasDataFrame},
+        plugin_collector=PluginCollector.enabled_feature_groups({SftfsLeft, SftfsRight, SftfsChild}),
+    )
+
+    matching = [frame for frame in results if SftfsChild.get_class_name() in frame.columns]
+    assert len(matching) == 1
+
+    values = sorted(matching[0][SftfsChild.get_class_name()].tolist())
+    assert values == sorted(SUMMED_VALUES)

--- a/tests/test_core/test_prepare/test_add_tfs_same_framework_join_tfs_ids.py
+++ b/tests/test_core/test_prepare/test_add_tfs_same_framework_join_tfs_ids.py
@@ -1,0 +1,90 @@
+"""White-box pin for add_tfs's same-compute-framework, non-APPEND/UNION join branch: it must set
+``inner_ep.tfs_ids`` to the destination-side parent uuid, not leave it empty.
+"""
+
+from uuid import UUID, uuid4
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.provider import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import JoinSpec
+from mloda.user import Link
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+class SameFwBaseFG(FeatureGroup):
+    """Unmatchable base so a leaked subclass stays invisible to feature resolution."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class SameFwLeftFG(SameFwBaseFG):
+    pass
+
+
+class SameFwRightFG(SameFwBaseFG):
+    pass
+
+
+def _feature(name: str, cfw: type[ComputeFramework]) -> Feature:
+    feature = Feature(name)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _same_framework_join_scenario() -> tuple[JoinStep, FeatureGroupStep, UUID]:
+    """One same-cfw, INNER JoinStep and its destination-side FeatureGroupStep, wired so the
+    step's own uuid is the join's destination-side uuid and its required_uuids already carry
+    both sides, exactly what add_tfs's ``else: inner_ep.tfs_ids = {store_val}`` branch checks for."""
+    dest_feature = _feature("same_fw_dest", PandasDataFrame)
+    dest_uuid = dest_feature.uuid
+    src_uuid = uuid4()
+
+    link = Link.inner(JoinSpec(SameFwLeftFG, "id"), JoinSpec(SameFwRightFG, "id"))
+    join_step = JoinStep(
+        link=link,
+        destination_framework=PandasDataFrame,
+        source_framework=PandasDataFrame,
+        required_uuids=set(),
+        destination_framework_uuids={dest_uuid},
+        source_framework_uuids={src_uuid},
+    )
+
+    feature_set = FeatureSet()
+    feature_set.add(dest_feature)
+    inner_ep = FeatureGroupStep(
+        SameFwLeftFG,
+        feature_set,
+        {dest_uuid, src_uuid},
+        PandasDataFrame,
+    )
+
+    return join_step, inner_ep, dest_uuid
+
+
+def test_same_framework_non_append_union_join_sets_tfs_ids_to_destination_side_uuid() -> None:
+    join_step, inner_ep, dest_uuid = _same_framework_join_scenario()
+
+    ExecutionPlan().add_tfs([join_step, inner_ep], Graph())
+
+    assert inner_ep.tfs_ids == {dest_uuid}, (
+        f"expected tfs_ids to pin the destination-side uuid {dest_uuid}, got: {inner_ep.tfs_ids}"
+    )


### PR DESCRIPTION
## Summary

Two long-standing comments flagged suspected broken behavior in the join-resolution engine without saying what was actually wrong. Investigated both; neither was a bug, but one comment was misleading and one code path had no test coverage.

- `ExecutionPlan.run_link`'s trekker lookup: the loop scanning for a matching link key is replaced with a direct dict lookup (behavior identical, since the loop always matched at most one key). The comment claiming the swap fallback below it "never triggers" was wrong: it is the normal path for an inverted-orientation join, after `LinkTrekker.invert_link` re-keys a trekker entry the queue had already snapshotted under its original orientation. Replaced with an accurate explanation, and simplified the matching lookup in that branch the same way.
- `FeatureGroupStep.tfs_ids`: the same-compute-framework join path in `add_tfs` sets this field to a plain feature uuid instead of a `TransformFrameworkStep` uuid, which a comment flagged as a possible bug. It isn't: `CfwManager` resolves `tfs_ids` purely by set membership, independent of where the uuid came from. Documented this, and added a white-box test pinning the field to the correct value, since the existing end-to-end coverage could not detect a regression there (a neighboring fallback silently covers for it).

## Testing

`tox` passes (9631 passed, 170 skipped, 2 xfailed, ruff/mypy/bandit clean). Added regression coverage for a same-compute-framework, non-APPEND/UNION join path that previously had none, plus a white-box test on `add_tfs` for the `tfs_ids` field itself.

Closes #1248