### PR TITLE
fix: DROP_COMPLETE handshake dropped by poll_result_queues; wait loop busy-spins

### DIFF
--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -360,6 +360,7 @@ class ExecutionOrchestrator:
             if isinstance(data_to_drop, frozenset):
                 self.data_lifecycle_manager.track_data_to_drop[cfw.uuid] = set(data_to_drop)
         else:
+            self.worker_manager.clear_completed_drop(cfw.uuid)
             command_queue.put(feature_uuids_to_possible_drop)
 
             flyway_datasets = self.cfw_register.get_uuid_flyway_datasets(cfw.uuid)

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -23,6 +23,8 @@ class WorkerManager:
         self.process_register: dict[UUID, tuple[Any, Any, Any]] = {}
         self.result_queues_collection: set[Any] = set()
         self.result_uuids_collection: set[UUID] = set()
+        # cfw_uuid of DROP_COMPLETE tuples drained by poll_result_queues before wait_for_drop_completion read them.
+        self.completed_drops: set[UUID] = set()
         # cfw_uuid -> step uuids dispatched to that worker. Needed because a worker that
         # exits cleanly is invisible to find_dead_workers, so the only way to notice the
         # loss is that steps were assigned to it and no result ever arrived.
@@ -67,11 +69,8 @@ class WorkerManager:
         command_queue.put(command)
 
     def poll_result_queues(self) -> None:
-        """Non-blocking poll all result queues, collect step-UUID strings.
-
-        The result queue also carries ("DROP_COMPLETE", cfw_uuid) control tuples;
-        skip non-str messages rather than pass them to UUID().
-        """
+        """Non-blocking poll of all result queues; collects step-UUID strings and drains DROP_COMPLETE tuples into
+        completed_drops."""
         for r_queue in self.result_queues_collection:
             try:
                 msg = r_queue.get(block=False)
@@ -79,6 +78,8 @@ class WorkerManager:
                 continue
             if isinstance(msg, str):
                 self.result_uuids_collection.add(UUID(msg))
+            elif isinstance(msg, tuple) and len(msg) == 2 and msg[0] == "DROP_COMPLETE":
+                self.completed_drops.add(msg[1])
 
     def record_assignment(self, cfw_uuid: UUID, step_uuids: set[UUID]) -> None:
         """Remember that these steps were dispatched to this worker."""
@@ -121,14 +122,18 @@ class WorkerManager:
         return step_uuid in self.result_uuids_collection
 
     def wait_for_drop_completion(self, result_queue: Any, cfw_uuid: UUID, timeout: float = 5.0) -> None:
-        """Poll queue until ("DROP_COMPLETE", cfw_uuid) received or timeout."""
+        """Poll queue until ("DROP_COMPLETE", cfw_uuid) is received or timeout, checking completed_drops first."""
         start_time = time.time()
         while time.time() - start_time < timeout:
+            if cfw_uuid in self.completed_drops:
+                self.completed_drops.discard(cfw_uuid)
+                return
             try:
                 msg = result_queue.get(block=False)
                 if isinstance(msg, tuple) and len(msg) == 2 and msg[0] == "DROP_COMPLETE" and msg[1] == cfw_uuid:
                     return
                 result_queue.put(msg, block=False)
+                time.sleep(0.001)
             except queue.Empty:
                 time.sleep(0.001)
         logger.warning(f"Drop operation for CFW {cfw_uuid} timed out after {timeout}s")

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -121,6 +121,11 @@ class WorkerManager:
         """Return step_uuid in result_uuids_collection."""
         return step_uuid in self.result_uuids_collection
 
+    def clear_completed_drop(self, cfw_uuid: UUID) -> None:
+        """Discard a stale drop flag; a cfw goes through multiple drop cycles, and a late completion
+        drained for an earlier cycle must not be mistaken for a later one."""
+        self.completed_drops.discard(cfw_uuid)
+
     def wait_for_drop_completion(self, result_queue: Any, cfw_uuid: UUID, timeout: float = 5.0) -> None:
         """Poll queue until ("DROP_COMPLETE", cfw_uuid) is received or timeout, checking completed_drops first."""
         start_time = time.time()

--- a/tests/test_core/test_runtime/test_worker_manager.py
+++ b/tests/test_core/test_runtime/test_worker_manager.py
@@ -5,6 +5,7 @@ import queue
 import sys
 import threading
 import time
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 from uuid import UUID, uuid4
@@ -338,6 +339,29 @@ class TestWorkerManagerResultPolling:
         assert UUID(valid_uuid) in manager.result_uuids_collection
         assert other_uuid not in manager.result_uuids_collection
 
+    def test_poll_result_queues_draining_drop_complete_leaves_waiter_stuck(self) -> None:
+        """A DROP_COMPLETE tuple drained by poll_result_queues must still reach wait_for_drop_completion, not vanish."""
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+
+        def get_side_effect() -> Iterator[Any]:
+            yield ("DROP_COMPLETE", cfw_uuid)
+            while True:
+                yield queue.Empty()
+
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = get_side_effect()
+        manager.result_queues_collection.add(mock_queue)
+
+        # Simulate the race: the main loop's poll wins and drains the tuple first.
+        manager.poll_result_queues()
+
+        start_time = time.time()
+        manager.wait_for_drop_completion(mock_queue, cfw_uuid, timeout=1.0)
+        elapsed = time.time() - start_time
+
+        assert elapsed < 0.5
+
 
 class TestWorkerManagerStepCompletion:
     """Test checking if steps are completed."""
@@ -568,6 +592,24 @@ class TestWorkerManagerDropCompletion:
         manager.wait_for_drop_completion(mock_queue, cfw_uuid, timeout=1.0)
 
         mock_queue.get.assert_called_with(block=False)
+
+    def test_wait_for_drop_completion_sleeps_after_putting_back_other_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The put-back path must sleep too, not only the queue.Empty() branch, or it busy-spins the CPU."""
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+        other_message = str(uuid4())
+
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = [other_message, ("DROP_COMPLETE", cfw_uuid)]
+
+        sleep_calls: list[float] = []
+        monkeypatch.setattr("mloda.core.runtime.worker_manager.time.sleep", lambda seconds: sleep_calls.append(seconds))
+
+        manager.wait_for_drop_completion(mock_queue, cfw_uuid, timeout=1.0)
+
+        assert sleep_calls, "time.sleep should be called between putting back a non-matching message and the next get"
 
 
 class TestWorkerManagerJoinAll:

--- a/tests/test_core/test_runtime/test_worker_manager.py
+++ b/tests/test_core/test_runtime/test_worker_manager.py
@@ -611,6 +611,45 @@ class TestWorkerManagerDropCompletion:
 
         assert sleep_calls, "time.sleep should be called between putting back a non-matching message and the next get"
 
+    def test_clear_completed_drop_prevents_stale_flag_from_short_circuiting_next_wait(self) -> None:
+        """A worker is reused across a chain of steps, so the same cfw_uuid can be dropped twice.
+
+        If drop #1's DROP_COMPLETE reply arrives late and is drained by an ordinary
+        poll_result_queues() call, completed_drops[cfw_uuid] is set. Before arming the wait
+        for drop #2 (same cfw_uuid, a later drop cycle), the caller must call
+        clear_completed_drop(cfw_uuid) to purge that stale flag, or wait_for_drop_completion
+        would return immediately, wrongly claiming drop #2 done before the worker even
+        started processing it.
+        """
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+
+        # Drop #1's late DROP_COMPLETE gets drained by an ordinary poll.
+        stale_queue = MagicMock()
+        stale_queue.get.side_effect = [("DROP_COMPLETE", cfw_uuid), queue.Empty()]
+        manager.result_queues_collection.add(stale_queue)
+        manager.poll_result_queues()
+
+        assert cfw_uuid in manager.completed_drops
+
+        # Caller must purge the stale flag before arming drop #2's wait.
+        manager.clear_completed_drop(cfw_uuid)
+
+        assert cfw_uuid not in manager.completed_drops
+
+        # Drop #2's queue: no matching DROP_COMPLETE has arrived yet.
+        fresh_queue = MagicMock()
+        fresh_queue.get.side_effect = queue.Empty()
+
+        start_time = time.time()
+        manager.wait_for_drop_completion(fresh_queue, cfw_uuid, timeout=0.2)
+        elapsed = time.time() - start_time
+
+        # Proves the wait actually polled the fresh queue instead of short-circuiting
+        # via the (now-cleared) completed_drops flag.
+        fresh_queue.get.assert_called()
+        assert elapsed > 0.19
+
 
 class TestWorkerManagerJoinAll:
     """Test joining and terminating all tasks."""


### PR DESCRIPTION
## Summary

`WorkerManager.poll_result_queues` only handled string result-queue messages and silently discarded anything else, including the `("DROP_COMPLETE", cfw_uuid)` control tuple a worker sends when a data drop finishes. Since `poll_result_queues` runs frequently from the main run loop on every result queue, it could race ahead of `wait_for_drop_completion` and drain that tuple first, causing the wait to time out and log a warning even though the drop had actually completed. Separately, the wait loop's "put a non-matching message back" path looped immediately with no delay, busy-spinning the CPU for the rest of the timeout window whenever such a message was ahead of the target tuple.

Drained `DROP_COMPLETE` tuples are now recorded so the waiter can still learn about them, and the put-back path now yields the CPU like the empty-queue path already did.

While addressing this, found that a worker can go through multiple sequential drop cycles over its lifetime, so tracking completion by worker id alone let a stale flag from an earlier, already-timed-out cycle be misread as completion of a later, unrelated one. The flag is now cleared before each new drop is armed.

## Test plan

- Added a test reproducing the exact race: a poll drains the completion tuple before the wait starts, and the wait must still return promptly instead of running out its timeout.
- Added a test pinning the busy-spin fix: the put-back path must sleep, verified via a monkeypatched `time.sleep`.
- Added a test for the stale-flag cross-cycle scenario: clearing the flag before a new drop is armed prevents it from short-circuiting the next wait.
- Full local test suite, ruff, mypy --strict, and bandit all pass.