### PR TITLE
fix: correctness bugs in joins, aggregation, filters, and encoding

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_filter_engine.py
@@ -142,6 +142,11 @@ class IcebergFilterEngine(BaseFilterEngine):
             elif len(expressions) == 2 and And is not None:
                 return And(expressions[0], expressions[1])
 
+            return None
+
+        else:
+            raise NotImplementedError(f"Unsupported Iceberg filter type: {filter_type!r}")
+
         return None
 
     @classmethod

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_filter_engine.py
@@ -56,7 +56,9 @@ class PandasFilterEngine(BaseFilterEngine):
         value = filter_feature.parameter.value
         if value is None:
             raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-        return data[data[filter_feature.name].astype(str).str.contains(value, regex=True)]
+        column = data[filter_feature.name]
+        mask = column.notna() & column.astype(str).str.contains(value, regex=True, na=False)
+        return data[mask]
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_lazy_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_lazy_merge_engine.py
@@ -30,7 +30,12 @@ class PolarsLazyMergeEngine(PolarsMergeEngine):
         return column_name in result.collect_schema().names()
 
     def handle_empty_data(
-        self, left_data: Any, right_data: Any, left_idx: str | list[str], right_idx: str | list[str]
+        self,
+        left_data: Any,
+        right_data: Any,
+        left_idx: str | list[str],
+        right_idx: str | list[str],
+        join_type: str = "inner",
     ) -> Any:
         """For LazyFrames, skip empty data handling and let Polars handle it efficiently."""
         return None

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
@@ -107,7 +107,12 @@ class PolarsMergeEngine(BaseMergeEngine):
         return column_name in result.columns
 
     def handle_empty_data(
-        self, left_data: Any, right_data: Any, left_idx: str | list[str], right_idx: str | list[str]
+        self,
+        left_data: Any,
+        right_data: Any,
+        left_idx: str | list[str],
+        right_idx: str | list[str],
+        join_type: str = "inner",
     ) -> Any:
         """Handle empty data cases. Override in subclasses for different data types."""
         if self.is_empty_data(left_data) or self.is_empty_data(right_data):
@@ -121,6 +126,10 @@ class PolarsMergeEngine(BaseMergeEngine):
                     if col not in combined_schema:
                         combined_schema[col] = right_data[col].dtype
                 return pl.DataFrame(schema=combined_schema)
+            elif join_type != "inner":
+                # For left/right/outer joins, only one side is empty: the native join preserves
+                # the non-empty side's rows and nulls the other side's columns.
+                return None
             elif self.is_empty_data(left_data):
                 # Left empty - ensure left has compatible schema with right join column
                 left_schema = dict(left_data.schema)
@@ -143,6 +152,24 @@ class PolarsMergeEngine(BaseMergeEngine):
                 return pl.DataFrame(schema=right_schema)
         return None
 
+    def _align_empty_side_join_key_dtypes(
+        self, left_data: Any, right_data: Any, left_idx: str | list[str], right_idx: str | list[str]
+    ) -> tuple[Any, Any]:
+        """Cast an empty side's join key column(s) to the non-empty side's dtype, no-op otherwise."""
+        left_cols = [left_idx] if isinstance(left_idx, str) else left_idx
+        right_cols = [right_idx] if isinstance(right_idx, str) else right_idx
+        left_empty = self.is_empty_data(left_data)
+        right_empty = self.is_empty_data(right_data)
+        if left_empty and not right_empty:
+            for l_col, r_col in zip(left_cols, right_cols):
+                if l_col in self.get_column_names(left_data) and r_col in self.get_column_names(right_data):
+                    left_data = left_data.with_columns(pl.col(l_col).cast(right_data[r_col].dtype))
+        elif right_empty and not left_empty:
+            for l_col, r_col in zip(left_cols, right_cols):
+                if l_col in self.get_column_names(left_data) and r_col in self.get_column_names(right_data):
+                    right_data = right_data.with_columns(pl.col(r_col).cast(left_data[l_col].dtype))
+        return left_data, right_data
+
     def join_logic(
         self, join_type: str, left_data: Any, right_data: Any, left_index: Index, right_index: Index, jointype: JoinType
     ) -> Any:
@@ -156,9 +183,14 @@ class PolarsMergeEngine(BaseMergeEngine):
             right_idx = right_index.index[0]
 
         # Handle empty data cases
-        empty_result = self.handle_empty_data(left_data, right_data, left_idx, right_idx)
+        empty_result = self.handle_empty_data(left_data, right_data, left_idx, right_idx, join_type)
         if empty_result is not None:
             return empty_result
+
+        # One side is empty and falls through to a native join (left/right/outer): an empty
+        # side built without explicit dtypes infers Null join-key columns, which polars' join
+        # rejects against the non-empty side's typed columns. Align the dtype so the join can run.
+        left_data, right_data = self._align_empty_side_join_key_dtypes(left_data, right_data, left_idx, right_idx)
 
         # For differing single-key names, keep both keys via coalesce=False (correct null semantics).
         # Only pass coalesce when the installed polars supports it; older versions degrade to legacy behavior.

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
@@ -127,8 +127,7 @@ class PolarsMergeEngine(BaseMergeEngine):
                         combined_schema[col] = right_data[col].dtype
                 return pl.DataFrame(schema=combined_schema)
             elif join_type != "inner":
-                # For left/right/outer joins, only one side is empty: the native join preserves
-                # the non-empty side's rows and nulls the other side's columns.
+                # Left/right/outer with one side empty: let the native join run, it handles this correctly.
                 return None
             elif self.is_empty_data(left_data):
                 # Left empty - ensure left has compatible schema with right join column
@@ -187,9 +186,7 @@ class PolarsMergeEngine(BaseMergeEngine):
         if empty_result is not None:
             return empty_result
 
-        # One side is empty and falls through to a native join (left/right/outer): an empty
-        # side built without explicit dtypes infers Null join-key columns, which polars' join
-        # rejects against the non-empty side's typed columns. Align the dtype so the join can run.
+        # An empty side's join key infers Null dtype, which polars' join rejects against the typed side.
         left_data, right_data = self._align_empty_side_join_key_dtypes(left_data, right_data, left_idx, right_idx)
 
         # For differing single-key names, keep both keys via coalesce=False (correct null semantics).

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
@@ -69,10 +69,7 @@ class PolarsLazyAggregatedFeatureGroup(AggregatedFeatureGroup):
 
     @classmethod
     def _row_wise_variance(cls, columns: list[Any]) -> Any:
-        """Row-wise sample variance (ddof=1) across columns, skipping nulls per row.
-
-        Returns null for rows with fewer than 2 valid values, matching pandas' .var(axis=1, skipna=True).
-        """
+        """Row-wise sample variance (ddof=1), skipping nulls; null when a row has fewer than 2 valid values."""
         valid_count = pl.sum_horizontal(*[col.is_not_null().cast(pl.Int64) for col in columns])
         mean_val = pl.mean_horizontal(*columns)
         sq_dev_sum = pl.sum_horizontal(*[(col - mean_val).pow(2) for col in columns])

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
@@ -68,6 +68,17 @@ class PolarsLazyAggregatedFeatureGroup(AggregatedFeatureGroup):
         return data.with_columns(result.alias(feature_name))
 
     @classmethod
+    def _row_wise_variance(cls, columns: list[Any]) -> Any:
+        """Row-wise sample variance (ddof=1) across columns, skipping nulls per row.
+
+        Returns null for rows with fewer than 2 valid values, matching pandas' .var(axis=1, skipna=True).
+        """
+        valid_count = pl.sum_horizontal(*[col.is_not_null().cast(pl.Int64) for col in columns])
+        mean_val = pl.mean_horizontal(*columns)
+        sq_dev_sum = pl.sum_horizontal(*[(col - mean_val).pow(2) for col in columns])
+        return pl.when(valid_count > 1).then(sq_dev_sum / (valid_count - 1)).otherwise(None)
+
+    @classmethod
     def _perform_aggregation(cls, data: Any, aggregation_type: str, in_features: list[str]) -> Any:
         """
         Perform the aggregation using Polars lazy expressions.
@@ -104,14 +115,11 @@ class PolarsLazyAggregatedFeatureGroup(AggregatedFeatureGroup):
                 # Count non-null values across columns
                 return pl.sum_horizontal(*[col.is_not_null().cast(pl.Int64) for col in columns])
             elif aggregation_type == "std":
-                # Polars doesn't have horizontal std, compute manually
-                mean_val = pl.mean_horizontal(*columns)
-                variance = pl.mean_horizontal(*[(col - mean_val).pow(2) for col in columns])
-                return variance.sqrt()
+                # Polars doesn't have horizontal std, compute manually (ddof=1, null-skipping)
+                return cls._row_wise_variance(columns).sqrt()
             elif aggregation_type == "var":
-                # Polars doesn't have horizontal var, compute manually
-                mean_val = pl.mean_horizontal(*columns)
-                return pl.mean_horizontal(*[(col - mean_val).pow(2) for col in columns])
+                # Polars doesn't have horizontal var, compute manually (ddof=1, null-skipping)
+                return cls._row_wise_variance(columns)
             elif aggregation_type == "median":
                 # Polars doesn't have horizontal median, use concat and median
                 raise ValueError("Median aggregation across multiple columns is not supported in Polars")

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -4,6 +4,7 @@ PyArrow implementation for aggregated feature groups.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -91,27 +92,34 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
             # PyArrow doesn't have direct horizontal operations, need to implement manually
             columns = [data.column(name) for name in in_features]
 
-            arrays = [col.to_numpy() for col in columns]
+            # Cast to float64 first so integer-with-nulls columns promote to float-with-NaN
+            # instead of becoming an unusable object dtype in to_numpy().
+            arrays = [pc.cast(col, pa.float64()).to_numpy() for col in columns]
             stacked = np.column_stack(arrays)
 
-            if aggregation_type == "sum":
-                result = np.sum(stacked, axis=1)
-            elif aggregation_type == "min":
-                result = np.min(stacked, axis=1)
-            elif aggregation_type == "max":
-                result = np.max(stacked, axis=1)
-            elif aggregation_type in ["avg", "mean"]:
-                result = np.mean(stacked, axis=1)
-            elif aggregation_type == "count":
-                result = np.sum(~np.isnan(stacked), axis=1)
-            elif aggregation_type == "std":
-                result = np.std(stacked, axis=1)
-            elif aggregation_type == "var":
-                result = np.var(stacked, axis=1)
-            elif aggregation_type == "median":
-                result = np.median(stacked, axis=1)
-            else:
-                raise ValueError(f"Unsupported aggregation type: {aggregation_type}")
+            with warnings.catch_warnings():
+                # An all-NaN row triggers a RuntimeWarning (e.g. "Mean of empty slice"); the
+                # resulting NaN is the intended output, matching pandas' skipna behavior.
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+
+                if aggregation_type == "sum":
+                    result = np.nansum(stacked, axis=1)
+                elif aggregation_type == "min":
+                    result = np.nanmin(stacked, axis=1)
+                elif aggregation_type == "max":
+                    result = np.nanmax(stacked, axis=1)
+                elif aggregation_type in ["avg", "mean"]:
+                    result = np.nanmean(stacked, axis=1)
+                elif aggregation_type == "count":
+                    result = np.sum(~np.isnan(stacked), axis=1)
+                elif aggregation_type == "std":
+                    result = np.nanstd(stacked, axis=1, ddof=1)
+                elif aggregation_type == "var":
+                    result = np.nanvar(stacked, axis=1, ddof=1)
+                elif aggregation_type == "median":
+                    result = np.nanmedian(stacked, axis=1)
+                else:
+                    raise ValueError(f"Unsupported aggregation type: {aggregation_type}")
 
             # Convert back to PyArrow array (will be added as column)
             return result
@@ -130,9 +138,9 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
             elif aggregation_type == "count":
                 return pc.count(column).as_py()
             elif aggregation_type == "std":
-                return pc.stddev(column).as_py()
+                return pc.stddev(column, ddof=1).as_py()
             elif aggregation_type == "var":
-                return pc.variance(column).as_py()
+                return pc.variance(column, ddof=1).as_py()
             elif aggregation_type == "median":
                 # PyArrow doesn't have a direct median function
                 # We can approximate it using quantile with q=0.5

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -92,8 +92,13 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
             # PyArrow doesn't have direct horizontal operations, need to implement manually
             columns = [data.column(name) for name in in_features]
 
-            # Cast to float64 first so integer-with-nulls columns promote to NaN instead of numpy object dtype.
-            arrays = [pc.cast(col, pa.float64()).to_numpy() for col in columns]
+            # Cast to float64 only when a null is present, so it can be represented as NaN for the
+            # np.nan* reducers to skip. Casting unconditionally would both force every result to
+            # float64 and silently lose precision for int64 values beyond +/-2**53.
+            if any(col.null_count > 0 for col in columns):
+                arrays = [pc.cast(col, pa.float64()).to_numpy() for col in columns]
+            else:
+                arrays = [col.to_numpy() for col in columns]
             stacked = np.column_stack(arrays)
 
             with warnings.catch_warnings():

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 
@@ -54,12 +55,19 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
     @classmethod
     def _add_result_to_data(cls, data: pa.Table, feature_name: str, result: Any) -> pa.Table:
         """Add the result to the Table."""
-        # Create an array with the aggregated result repeated for each row
-        repeat_count = data.num_rows
-        repeated_result = pa.array([result] * repeat_count)
+        if isinstance(result, np.ndarray):
+            # Multi-column (row-wise) aggregation: one value per row already.
+            result_array = pa.array(result)
+        else:
+            # Single-column (vertical) aggregation: a scalar broadcast to every row.
+            result_array = pa.array([result] * data.num_rows)
 
-        # Add the new column to the table
-        return data.append_column(feature_name, repeated_result)
+        if feature_name in data.schema.names:
+            column_index = data.schema.names.index(feature_name)
+            data = data.remove_column(column_index)
+            return data.append_column(feature_name, result_array)
+        else:
+            return data.append_column(feature_name, result_array)
 
     @classmethod
     def _perform_aggregation(cls, data: pa.Table, aggregation_type: str, in_features: list[str]) -> Any:
@@ -82,9 +90,6 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
             # Multi-column: aggregate across columns row-wise
             # PyArrow doesn't have direct horizontal operations, need to implement manually
             columns = [data.column(name) for name in in_features]
-
-            # Convert columns to numpy for easier row-wise operations
-            import numpy as np
 
             arrays = [col.to_numpy() for col in columns]
             stacked = np.column_stack(arrays)

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -92,14 +92,12 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
             # PyArrow doesn't have direct horizontal operations, need to implement manually
             columns = [data.column(name) for name in in_features]
 
-            # Cast to float64 first so integer-with-nulls columns promote to float-with-NaN
-            # instead of becoming an unusable object dtype in to_numpy().
+            # Cast to float64 first so integer-with-nulls columns promote to NaN instead of numpy object dtype.
             arrays = [pc.cast(col, pa.float64()).to_numpy() for col in columns]
             stacked = np.column_stack(arrays)
 
             with warnings.catch_warnings():
-                # An all-NaN row triggers a RuntimeWarning (e.g. "Mean of empty slice"); the
-                # resulting NaN is the intended output, matching pandas' skipna behavior.
+                # An all-NaN row triggers a RuntimeWarning; the resulting NaN is intended (matches pandas skipna).
                 warnings.simplefilter("ignore", category=RuntimeWarning)
 
                 if aggregation_type == "sum":

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -4,8 +4,7 @@ PyArrow implementation for aggregated feature groups.
 
 from __future__ import annotations
 
-import warnings
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import pyarrow as pa
@@ -15,6 +14,26 @@ from mloda.provider import ComputeFramework
 
 from mloda.user.pyarrow import PyArrowTable
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+
+
+def _reduce_without_nan_warning(
+    stacked: np.ndarray[Any, Any],
+    degenerate_rows: np.ndarray[Any, Any],
+    reducer: Callable[[np.ndarray[Any, Any]], np.ndarray[Any, Any]],
+) -> np.ndarray[Any, Any]:
+    """Run a np.nan* row-wise reducer without ever triggering its RuntimeWarning.
+
+    Rows flagged as degenerate (e.g. all-NaN, or too few valid values for ddof=1) have their
+    NaN cells temporarily patched with 0.0 in a copy so the reducer never sees a degenerate
+    row; those rows' results are then overwritten back to NaN, matching the unpatched result.
+    """
+    if not degenerate_rows.any():
+        return reducer(stacked)
+    patched = stacked.copy()
+    nan_mask = np.isnan(patched)
+    patched[degenerate_rows[:, np.newaxis] & nan_mask] = 0.0
+    result = reducer(patched)
+    return np.where(degenerate_rows, np.nan, result)
 
 
 class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
@@ -101,28 +120,38 @@ class PyArrowAggregatedFeatureGroup(AggregatedFeatureGroup):
                 arrays = [col.to_numpy() for col in columns]
             stacked = np.column_stack(arrays)
 
-            with warnings.catch_warnings():
-                # An all-NaN row triggers a RuntimeWarning; the resulting NaN is intended (matches pandas skipna).
-                warnings.simplefilter("ignore", category=RuntimeWarning)
-
-                if aggregation_type == "sum":
-                    result = np.nansum(stacked, axis=1)
-                elif aggregation_type == "min":
-                    result = np.nanmin(stacked, axis=1)
+            # np.nansum and the count below never warn on an all-NaN row (nansum returns 0,
+            # count is not nan-aware). The other reducers warn on rows they can't skipna
+            # over: an all-NaN row for min/max/mean/median, or a row with fewer than 2 valid
+            # values for std/var (ddof=1 needs >=2). Route those through the helper, which
+            # patches just the degenerate rows so the warning never fires, instead of
+            # suppressing it process-wide via warnings.catch_warnings().
+            if aggregation_type == "sum":
+                result = np.nansum(stacked, axis=1)
+            elif aggregation_type == "count":
+                result = np.sum(~np.isnan(stacked), axis=1)
+            elif aggregation_type in ["min", "max", "avg", "mean", "median"]:
+                all_nan_rows = np.sum(~np.isnan(stacked), axis=1) == 0
+                if aggregation_type == "min":
+                    result = _reduce_without_nan_warning(stacked, all_nan_rows, lambda a: np.nanmin(a, axis=1))
                 elif aggregation_type == "max":
-                    result = np.nanmax(stacked, axis=1)
+                    result = _reduce_without_nan_warning(stacked, all_nan_rows, lambda a: np.nanmax(a, axis=1))
                 elif aggregation_type in ["avg", "mean"]:
-                    result = np.nanmean(stacked, axis=1)
-                elif aggregation_type == "count":
-                    result = np.sum(~np.isnan(stacked), axis=1)
-                elif aggregation_type == "std":
-                    result = np.nanstd(stacked, axis=1, ddof=1)
-                elif aggregation_type == "var":
-                    result = np.nanvar(stacked, axis=1, ddof=1)
-                elif aggregation_type == "median":
-                    result = np.nanmedian(stacked, axis=1)
+                    result = _reduce_without_nan_warning(stacked, all_nan_rows, lambda a: np.nanmean(a, axis=1))
                 else:
-                    raise ValueError(f"Unsupported aggregation type: {aggregation_type}")
+                    result = _reduce_without_nan_warning(stacked, all_nan_rows, lambda a: np.nanmedian(a, axis=1))
+            elif aggregation_type in ["std", "var"]:
+                under_two_valid_rows = np.sum(~np.isnan(stacked), axis=1) < 2
+                if aggregation_type == "std":
+                    result = _reduce_without_nan_warning(
+                        stacked, under_two_valid_rows, lambda a: np.nanstd(a, axis=1, ddof=1)
+                    )
+                else:
+                    result = _reduce_without_nan_warning(
+                        stacked, under_two_valid_rows, lambda a: np.nanvar(a, axis=1, ddof=1)
+                    )
+            else:
+                raise ValueError(f"Unsupported aggregation type: {aggregation_type}")
 
             # Convert back to PyArrow array (will be added as column)
             return result

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -266,8 +266,7 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
                     if max_indices:
                         group_value = value_counts.field("values")[max_indices[0]].as_py()
             elif imputation_method == "ffill":
-                # For ffill, we need to find the last non-null value before this row in the group.
-                # `i` is the global row index, so translate it to the row's position within the group.
+                # `i` is the global row index; translate it to the row's position within the group.
                 group_row_indices = pc.indices_nonzero(group_mask).to_pylist()
                 local_idx = group_row_indices.index(i)
                 valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
@@ -278,8 +277,7 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
                         last_valid_idx = max(valid_indices_before)
                         group_value = group_data[last_valid_idx].as_py()
             elif imputation_method == "bfill":
-                # For bfill, we need to find the first non-null value after this row in the group.
-                # `i` is the global row index, so translate it to the row's position within the group.
+                # `i` is the global row index; translate it to the row's position within the group.
                 group_row_indices = pc.indices_nonzero(group_mask).to_pylist()
                 local_idx = group_row_indices.index(i)
                 valid_indices = pc.indices_nonzero(pc.is_valid(group_data))

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -267,26 +267,32 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
                         group_value = value_counts.field("values")[max_indices[0]].as_py()
             elif imputation_method == "ffill":
                 # `i` is the global row index; translate it to the row's position within the group.
+                # A null group key yields an all-null group_mask, so `i` won't be found; there is
+                # no identifiable group to ffill from, so fall back to the overall value.
                 group_row_indices = pc.indices_nonzero(group_mask).to_pylist()
-                local_idx = group_row_indices.index(i)
-                valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
-                if len(valid_indices) > 0:
-                    # Find the largest valid index that is less than the current group-local index
-                    valid_indices_before = [idx for idx in valid_indices.to_pylist() if idx < local_idx]
-                    if valid_indices_before:
-                        last_valid_idx = max(valid_indices_before)
-                        group_value = group_data[last_valid_idx].as_py()
+                if i in group_row_indices:
+                    local_idx = group_row_indices.index(i)
+                    valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
+                    if len(valid_indices) > 0:
+                        # Find the largest valid index that is less than the current group-local index
+                        valid_indices_before = [idx for idx in valid_indices.to_pylist() if idx < local_idx]
+                        if valid_indices_before:
+                            last_valid_idx = max(valid_indices_before)
+                            group_value = group_data[last_valid_idx].as_py()
             elif imputation_method == "bfill":
                 # `i` is the global row index; translate it to the row's position within the group.
+                # A null group key yields an all-null group_mask, so `i` won't be found; there is
+                # no identifiable group to bfill from, so fall back to the overall value.
                 group_row_indices = pc.indices_nonzero(group_mask).to_pylist()
-                local_idx = group_row_indices.index(i)
-                valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
-                if len(valid_indices) > 0:
-                    # Find the smallest valid index that is greater than the current group-local index
-                    valid_indices_after = [idx for idx in valid_indices.to_pylist() if idx > local_idx]
-                    if valid_indices_after:
-                        next_valid_idx = min(valid_indices_after)
-                        group_value = group_data[next_valid_idx].as_py()
+                if i in group_row_indices:
+                    local_idx = group_row_indices.index(i)
+                    valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
+                    if len(valid_indices) > 0:
+                        # Find the smallest valid index that is greater than the current group-local index
+                        valid_indices_after = [idx for idx in valid_indices.to_pylist() if idx > local_idx]
+                        if valid_indices_after:
+                            next_valid_idx = min(valid_indices_after)
+                            group_value = group_data[next_valid_idx].as_py()
 
             # If the group imputation value is None, fall back to the overall value
             if group_value is None:

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -110,9 +110,9 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
 
                     # Find all indices where count equals max_count
                     max_indices = []
-                    for i in range(len(counts)):
-                        if counts[i].as_py() == max_count:
-                            max_indices.append(i)
+                    for count_idx in range(len(counts)):
+                        if counts[count_idx].as_py() == max_count:
+                            max_indices.append(count_idx)
 
                     # Use the first index with maximum count
                     if max_indices:
@@ -206,9 +206,9 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
 
                 # Find all indices where count equals max_count
                 max_indices = []
-                for i in range(len(counts)):
-                    if counts[i].as_py() == max_count:
-                        max_indices.append(i)
+                for count_idx in range(len(counts)):
+                    if counts[count_idx].as_py() == max_count:
+                        max_indices.append(count_idx)
 
                 # Use the first index with maximum count
                 if max_indices:
@@ -258,28 +258,34 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
 
                     # Find all indices where count equals max_count
                     max_indices = []
-                    for i in range(len(counts)):
-                        if counts[i].as_py() == max_count:
-                            max_indices.append(i)
+                    for count_idx in range(len(counts)):
+                        if counts[count_idx].as_py() == max_count:
+                            max_indices.append(count_idx)
 
                     # Use the first index with maximum count
                     if max_indices:
                         group_value = value_counts.field("values")[max_indices[0]].as_py()
             elif imputation_method == "ffill":
-                # For ffill, we need to find the last non-null value before this row in the group
+                # For ffill, we need to find the last non-null value before this row in the group.
+                # `i` is the global row index, so translate it to the row's position within the group.
+                group_row_indices = pc.indices_nonzero(group_mask).to_pylist()
+                local_idx = group_row_indices.index(i)
                 valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
                 if len(valid_indices) > 0:
-                    # Find the largest valid index that is less than the current index
-                    valid_indices_before = [idx for idx in valid_indices.to_pylist() if idx < i]
+                    # Find the largest valid index that is less than the current group-local index
+                    valid_indices_before = [idx for idx in valid_indices.to_pylist() if idx < local_idx]
                     if valid_indices_before:
                         last_valid_idx = max(valid_indices_before)
                         group_value = group_data[last_valid_idx].as_py()
             elif imputation_method == "bfill":
-                # For bfill, we need to find the first non-null value after this row in the group
+                # For bfill, we need to find the first non-null value after this row in the group.
+                # `i` is the global row index, so translate it to the row's position within the group.
+                group_row_indices = pc.indices_nonzero(group_mask).to_pylist()
+                local_idx = group_row_indices.index(i)
                 valid_indices = pc.indices_nonzero(pc.is_valid(group_data))
                 if len(valid_indices) > 0:
-                    # Find the smallest valid index that is greater than the current index
-                    valid_indices_after = [idx for idx in valid_indices.to_pylist() if idx > i]
+                    # Find the smallest valid index that is greater than the current group-local index
+                    valid_indices_after = [idx for idx in valid_indices.to_pylist() if idx > local_idx]
                     if valid_indices_after:
                         next_valid_idx = min(valid_indices_after)
                         group_value = group_data[next_valid_idx].as_py()

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -355,10 +355,8 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
                     # Add the fraction to the betweenness centrality
                     betweenness.iloc[v] += num_paths_through_v / num_paths
 
-        # Normalize by the maximum possible betweenness. The ordered-pair loop above
-        # sums sigma_st(v)/sigma_st over every (s, t): for undirected graphs each unordered
-        # pair is visited twice with an identical value, for directed graphs each ordered
-        # pair contributes independently, so (n-1)(n-2) is the correct divisor either way.
+        # The ordered-pair loop double-counts each unordered pair for undirected graphs and
+        # covers each direction separately for directed graphs, so (n-1)(n-2) is correct either way.
         if n > 2:
             betweenness = betweenness / ((n - 1) * (n - 2))
 

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -146,7 +146,7 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         if centrality_type == "degree":
             centrality_scores = cls._calculate_degree_centrality(adj_matrix, nodes, graph_type)
         elif centrality_type == "betweenness":
-            centrality_scores = cls._calculate_betweenness_centrality(adj_matrix, nodes, graph_type)
+            centrality_scores = cls._calculate_betweenness_centrality(adj_matrix, nodes)
         elif centrality_type == "closeness":
             centrality_scores = cls._calculate_closeness_centrality(adj_matrix, nodes)
         elif centrality_type == "eigenvector":
@@ -295,16 +295,13 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         return closeness
 
     @classmethod
-    def _calculate_betweenness_centrality(
-        cls, adj_matrix: pd.DataFrame, nodes: np.ndarray[Any, Any], graph_type: str = "undirected"
-    ) -> pd.Series:
+    def _calculate_betweenness_centrality(cls, adj_matrix: pd.DataFrame, nodes: np.ndarray[Any, Any]) -> pd.Series:
         """
         Calculate betweenness centrality for each node.
 
         Args:
             adj_matrix: Adjacency matrix
             nodes: Array of unique node identifiers
-            graph_type: Type of graph (directed or undirected)
 
         Returns:
             A pandas Series with betweenness centrality scores

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -146,7 +146,7 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         if centrality_type == "degree":
             centrality_scores = cls._calculate_degree_centrality(adj_matrix, nodes, graph_type)
         elif centrality_type == "betweenness":
-            centrality_scores = cls._calculate_betweenness_centrality(adj_matrix, nodes)
+            centrality_scores = cls._calculate_betweenness_centrality(adj_matrix, nodes, graph_type)
         elif centrality_type == "closeness":
             centrality_scores = cls._calculate_closeness_centrality(adj_matrix, nodes)
         elif centrality_type == "eigenvector":
@@ -295,13 +295,16 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         return closeness
 
     @classmethod
-    def _calculate_betweenness_centrality(cls, adj_matrix: pd.DataFrame, nodes: np.ndarray[Any, Any]) -> pd.Series:
+    def _calculate_betweenness_centrality(
+        cls, adj_matrix: pd.DataFrame, nodes: np.ndarray[Any, Any], graph_type: str = "undirected"
+    ) -> pd.Series:
         """
         Calculate betweenness centrality for each node.
 
         Args:
             adj_matrix: Adjacency matrix
             nodes: Array of unique node identifiers
+            graph_type: Type of graph (directed or undirected)
 
         Returns:
             A pandas Series with betweenness centrality scores
@@ -352,9 +355,12 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
                     # Add the fraction to the betweenness centrality
                     betweenness.iloc[v] += num_paths_through_v / num_paths
 
-        # Normalize by the maximum possible betweenness
+        # Normalize by the maximum possible betweenness. The ordered-pair loop above
+        # sums sigma_st(v)/sigma_st over every (s, t): for undirected graphs each unordered
+        # pair is visited twice with an identical value, for directed graphs each ordered
+        # pair contributes independently, so (n-1)(n-2) is the correct divisor either way.
         if n > 2:
-            betweenness = betweenness / ((n - 1) * (n - 2) / 2)
+            betweenness = betweenness / ((n - 1) * (n - 2))
 
         return betweenness
 

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -90,8 +90,7 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
         # Extract the specified column
         feature_data = data[source_feature]
 
-        # Handle missing values the same way as _apply_encoder does at transform time,
-        # so the encoder learns "unknown" as a category and never sees an unseen label.
+        # Match _apply_encoder's transform-time policy so the encoder never sees an unseen label.
         feature_data = feature_data.fillna("unknown")
 
         # For categorical encoders, we need to handle the data format properly

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -90,9 +90,9 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
         # Extract the specified column
         feature_data = data[source_feature]
 
-        # Handle missing values by dropping rows with NaN
-        # This is a simple strategy - more sophisticated handling could be added
-        feature_data = feature_data.dropna()
+        # Handle missing values the same way as _apply_encoder does at transform time,
+        # so the encoder learns "unknown" as a category and never sees an unseen label.
+        feature_data = feature_data.fillna("unknown")
 
         # For categorical encoders, we need to handle the data format properly
         # LabelEncoder expects 1D array, OneHotEncoder and OrdinalEncoder expect 2D array

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -91,7 +91,9 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
         feature_data = data[source_feature]
 
         # Match _apply_encoder's transform-time policy so the encoder never sees an unseen label.
-        feature_data = feature_data.fillna("unknown")
+        # Normalize the whole column to a uniform string dtype so a numeric column with NaN
+        # does not mix floats and "unknown" strings, which sklearn's fit validation rejects.
+        feature_data = feature_data.where(feature_data.notna(), "unknown").astype(str)
 
         # For categorical encoders, we need to handle the data format properly
         # LabelEncoder expects 1D array, OneHotEncoder and OrdinalEncoder expect 2D array
@@ -117,8 +119,9 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
         feature_data = data[source_feature]
 
         # Handle missing values - for prediction, we need to handle them differently
-        # than during training. For categorical data, we'll use the string "unknown"
-        feature_data = feature_data.fillna("unknown")
+        # than during training. For categorical data, we'll use the string "unknown".
+        # Must stay policy-identical with _extract_training_data.
+        feature_data = feature_data.where(feature_data.notna(), "unknown").astype(str)
 
         # Convert to appropriate format for sklearn
         feature_values = feature_data.to_numpy()

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
@@ -117,14 +117,24 @@ class TestIcebergFilterEngine:
         assert expression is not None
 
     def test_build_iceberg_expression_unsupported(self) -> None:
-        """Test building expression for unsupported filter type."""
+        """Test that an unsupported filter type raises NotImplementedError."""
         feature = Feature("name")
         filter_type = FilterType.REGEX
         parameter = {"value": "^A"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
-        expression = IcebergFilterEngine._build_iceberg_expression(single_filter)
-        assert expression is None
+        with pytest.raises(NotImplementedError):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_categorical_inclusion_raises(self) -> None:
+        """Unknown filter types must raise NotImplementedError, not silently fall through to None."""
+        feature = Feature("category")
+        filter_type = FilterType.CATEGORICAL_INCLUSION
+        parameter = {"values": ["A", "B"]}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(NotImplementedError):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
 
     def test_extract_parameter_value(self) -> None:
         """Test extracting parameter values."""
@@ -225,6 +235,17 @@ class TestIcebergFilterEngine:
 
         # Should only apply the age filter (unknown_column is not in get_all_names)
         mock_iceberg_table.scan.assert_called_once()
+
+    def test_apply_filters_categorical_inclusion_raises(self, mock_iceberg_table: Mock, mock_feature_set: Mock) -> None:
+        """apply_filters must not silently drop an unsupported filter and return the unfiltered table."""
+        category_filter = SingleFilter(Feature("category"), FilterType.CATEGORICAL_INCLUSION, {"values": ["A", "B"]})
+        mock_feature_set.filters = [category_filter]
+
+        with pytest.raises(NotImplementedError):
+            IcebergFilterEngine.apply_filters(mock_iceberg_table, mock_feature_set)
+
+        # An unfiltered scan would indicate the filter was silently dropped instead of raising.
+        mock_iceberg_table.scan.assert_not_called()
 
     def test_standard_filter_methods_not_implemented(self) -> None:
         """Test that standard filter methods raise NotImplementedError."""

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
@@ -59,19 +59,11 @@ class TestPandasFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         return list(result["id"].tolist())
 
     def test_do_regex_filter_excludes_null_rows(self) -> None:
-        """A regex matching the literal string "nan" must not match null cells.
+        """A regex matching "a" must not match null cells that stringify to "nan" via astype(str).
 
-        ``.astype(str)`` on a null "name" cell (``np.nan``) can produce the literal
-        string "nan", so the pattern "a" (a substring of "nan") wrongly matches that
-        null row too. Only the genuinely matching "cat" row should survive; "dog" (no
-        "a") and the null row must both be excluded.
-
-        pandas >= 3.0 defaults ``future.infer_string`` to True, under which
-        ``.astype(str)`` happens to preserve missing values instead of stringifying
-        them, masking this bug. This project's tox matrix also runs pandas 2.3.3
-        (Python 3.10), whose default is False, so the option is pinned explicitly here
-        to exercise the code path the bug report describes on every supported pandas
-        version, including the one installed in this environment.
+        pandas >= 3.0 defaults ``future.infer_string`` to True, under which ``.astype(str)``
+        preserves missing values instead of stringifying them, masking this bug. Pin the option
+        explicitly so the test exercises the buggy code path regardless of installed pandas version.
         """
         with pd.option_context("future.infer_string", False):
             data = pd.DataFrame(

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
@@ -3,7 +3,12 @@
 from typing import Any
 
 import pytest
+import numpy as np
 import pandas as pd
+
+from mloda.user import Feature
+from mloda.user import SingleFilter
+from mloda.user import FilterType
 
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_filter_engine import PandasFilterEngine
 
@@ -52,3 +57,35 @@ class TestPandasFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
 
     def get_id_column_values(self, result: Any) -> list[int]:
         return list(result["id"].tolist())
+
+    def test_do_regex_filter_excludes_null_rows(self) -> None:
+        """A regex matching the literal string "nan" must not match null cells.
+
+        ``.astype(str)`` on a null "name" cell (``np.nan``) can produce the literal
+        string "nan", so the pattern "a" (a substring of "nan") wrongly matches that
+        null row too. Only the genuinely matching "cat" row should survive; "dog" (no
+        "a") and the null row must both be excluded.
+
+        pandas >= 3.0 defaults ``future.infer_string`` to True, under which
+        ``.astype(str)`` happens to preserve missing values instead of stringifying
+        them, masking this bug. This project's tox matrix also runs pandas 2.3.3
+        (Python 3.10), whose default is False, so the option is pinned explicitly here
+        to exercise the code path the bug report describes on every supported pandas
+        version, including the one installed in this environment.
+        """
+        with pd.option_context("future.infer_string", False):
+            data = pd.DataFrame(
+                {
+                    "id": [1, 2, 3],
+                    "name": ["cat", "dog", np.nan],
+                }
+            )
+            feature = Feature("name")
+            filter_type = FilterType.REGEX
+            parameter = {"value": "a"}
+            single_filter = SingleFilter(feature, filter_type, parameter)
+
+            result = PandasFilterEngine.do_regex_filter(data, single_filter)
+
+        assert result["id"].tolist() == [1]
+        assert result["name"].tolist() == ["cat"]

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_merge_engine.py
@@ -238,6 +238,75 @@ class TestPolarsMergeEngine:
         result = engine.merge_inner(empty_df, empty_df, index_obj, index_obj)
         assert len(result) == 0
 
+    def test_merge_left_with_empty_right(self, index_obj: Any) -> None:
+        """Left join against an empty right side must keep all left rows, right cols null."""
+        left_data = pl.DataFrame({"idx": [1, 2, 3], "col1": ["a", "b", "c"]})
+        right_data = pl.DataFrame({"idx": [], "col2": []})
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_left(left_data, right_data, index_obj, index_obj)
+
+        assert len(result) == 3
+        result_sorted = result.sort("idx")
+        assert result_sorted["idx"].to_list() == [1, 2, 3]
+        assert result_sorted["col1"].to_list() == ["a", "b", "c"]
+        assert result_sorted["col2"].to_list() == [None, None, None]
+
+    def test_merge_right_with_empty_left(self, index_obj: Any) -> None:
+        """Right join against an empty left side must keep all right rows, left cols null."""
+        left_data = pl.DataFrame({"idx": [], "col1": []})
+        right_data = pl.DataFrame({"idx": [1, 2, 3], "col2": ["x", "y", "z"]})
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_right(left_data, right_data, index_obj, index_obj)
+
+        assert len(result) == 3
+        result_sorted = result.sort("idx")
+        assert result_sorted["idx"].to_list() == [1, 2, 3]
+        assert result_sorted["col2"].to_list() == ["x", "y", "z"]
+        assert result_sorted["col1"].to_list() == [None, None, None]
+
+    def test_merge_full_outer_with_empty_right(self, index_obj: Any) -> None:
+        """Full outer join with an empty right side must keep all left rows, right cols null."""
+        left_data = pl.DataFrame({"idx": [1, 2, 3], "col1": ["a", "b", "c"]})
+        right_data = pl.DataFrame({"idx": [], "col2": []})
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_full_outer(left_data, right_data, index_obj, index_obj)
+
+        assert len(result) == 3
+        result_sorted = result.sort("idx")
+        assert result_sorted["idx"].to_list() == [1, 2, 3]
+        assert result_sorted["col1"].to_list() == ["a", "b", "c"]
+        assert result_sorted["col2"].to_list() == [None, None, None]
+
+    def test_merge_full_outer_with_empty_left(self, index_obj: Any) -> None:
+        """Full outer join with an empty left side must keep all right rows, left cols null."""
+        left_data = pl.DataFrame({"idx": [], "col1": []})
+        right_data = pl.DataFrame({"idx": [1, 2, 3], "col2": ["x", "y", "z"]})
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_full_outer(left_data, right_data, index_obj, index_obj)
+
+        assert len(result) == 3
+        result_sorted = result.sort("idx")
+        assert result_sorted["idx"].to_list() == [1, 2, 3]
+        assert result_sorted["col2"].to_list() == ["x", "y", "z"]
+        assert result_sorted["col1"].to_list() == [None, None, None]
+
+    def test_merge_inner_with_empty_side_still_zero_rows(self, index_obj: Any) -> None:
+        """Inner join with either side empty is correctly 0 rows (guard, not the bug)."""
+        left_data = pl.DataFrame({"idx": [1, 2, 3], "col1": ["a", "b", "c"]})
+        right_data = pl.DataFrame({"idx": [], "col2": []})
+
+        engine = PolarsMergeEngine()
+
+        result = engine.merge_inner(left_data, right_data, index_obj, index_obj)
+        assert len(result) == 0
+
+        result = engine.merge_inner(right_data, left_data, index_obj, index_obj)
+        assert len(result) == 0
+
     def test_merge_with_complex_data(self) -> None:
         """Test merge with more complex data structures."""
         left_data = pl.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]})

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
@@ -275,8 +275,6 @@ class TestPandasEncodingFeatureGroup:
 
         mock_import.return_value = {"LabelEncoder": LabelEncoder}
 
-        # Category column contains a NaN. Fit must fill it with "unknown" (the same
-        # sentinel used at transform time) so the encoder learns that label too.
         data = pd.DataFrame({"category": ["a", "b", None, "a", "b"]})
 
         features = FeatureSet()

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
@@ -298,6 +298,27 @@ class TestPandasEncodingFeatureGroup:
     @patch(
         "mloda_plugins.feature_group.experimental.sklearn.encoding.pandas.PandasEncodingFeatureGroup._import_sklearn_components"
     )
+    def test_end_to_end_label_encoding_with_numeric_nan_does_not_crash(self, mock_import: Any) -> None:
+        """FIT's fillna("unknown") on a numeric column mixes floats and a string, crashing LabelEncoder.fit."""
+        try:
+            from sklearn.preprocessing import LabelEncoder
+        except ImportError:
+            return  # Skip test if sklearn not available
+
+        mock_import.return_value = {"LabelEncoder": LabelEncoder}
+
+        data = pd.DataFrame({"category": [1.0, 2.0, None, 1.0]})
+
+        features = FeatureSet()
+        features.add(Feature("category__label_encoded"))
+
+        result_data = PandasEncodingFeatureGroup.calculate_feature(data, features)
+
+        assert "category__label_encoded" in result_data.columns
+
+    @patch(
+        "mloda_plugins.feature_group.experimental.sklearn.encoding.pandas.PandasEncodingFeatureGroup._import_sklearn_components"
+    )
     def test_end_to_end_onehot_encoding(self, mock_import: Any) -> None:
         """Test end-to-end one-hot encoding workflow."""
         # Skip test if sklearn not available

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
@@ -57,9 +57,9 @@ class TestPandasEncodingFeatureGroup:
 
         training_data = PandasEncodingFeatureGroup._extract_training_data(data, "category")
 
-        # Should drop NaN values during training
-        assert training_data.shape == (4,)
-        assert list(training_data) == ["A", "B", "A", "B"]
+        # Should fill NaN with "unknown" during training, matching the transform-time policy
+        assert training_data.shape == (5,)
+        assert list(training_data) == ["A", "B", "unknown", "A", "B"]
 
     @patch(
         "mloda_plugins.feature_group.experimental.sklearn.encoding.pandas.PandasEncodingFeatureGroup._import_sklearn_components"
@@ -262,6 +262,40 @@ class TestPandasEncodingFeatureGroup:
         # LabelEncoder should assign 0, 1, 2 to A, B, C respectively
         expected_values = [0, 1, 2, 0, 1]  # A=0, B=1, C=2
         assert list(result_data["category__label_encoded"]) == expected_values
+
+    @patch(
+        "mloda_plugins.feature_group.experimental.sklearn.encoding.pandas.PandasEncodingFeatureGroup._import_sklearn_components"
+    )
+    def test_end_to_end_label_encoding_with_nan_does_not_crash(self, mock_import: Any) -> None:
+        """Fit fills NaN with 'unknown' (same as transform), so LabelEncoder.transform never sees an unseen label."""
+        try:
+            from sklearn.preprocessing import LabelEncoder
+        except ImportError:
+            return  # Skip test if sklearn not available
+
+        mock_import.return_value = {"LabelEncoder": LabelEncoder}
+
+        # Category column contains a NaN. Fit must fill it with "unknown" (the same
+        # sentinel used at transform time) so the encoder learns that label too.
+        data = pd.DataFrame({"category": ["a", "b", None, "a", "b"]})
+
+        features = FeatureSet()
+        features.add(Feature("category__label_encoded"))
+
+        result_data = PandasEncodingFeatureGroup.calculate_feature(data, features)
+
+        assert "category__label_encoded" in result_data.columns
+
+        # Ground truth: fit/transform a fresh LabelEncoder on the same fillna'd data.
+        filled = data["category"].fillna("unknown")
+        expected = LabelEncoder().fit(filled).transform(filled)
+
+        assert list(result_data["category__label_encoded"]) == list(expected)
+
+        # The row that had None must have a defined, non-null integer code.
+        nan_row_code = result_data["category__label_encoded"].iloc[2]
+        assert pd.notna(nan_row_code)
+        assert 0 <= nan_row_code < len(set(filled))
 
     @patch(
         "mloda_plugins.feature_group.experimental.sklearn.encoding.pandas.PandasEncodingFeatureGroup._import_sklearn_components"

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_polars_lazy_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_polars_lazy_aggregated_feature_group.py
@@ -56,6 +56,20 @@ def sample_lazy_dataframe() -> Any:
 
 
 @pytest.fixture
+def multi_source_lazy_dataframe_with_null() -> Any:
+    """Three source columns (metrics~0..2), row index 2 has a null in metrics~1."""
+    if not POLARS_AVAILABLE:
+        pytest.skip("Polars not available")
+
+    data = {
+        "metrics~0": [1.0, 4.0, 100.0, 8.0],
+        "metrics~1": [2.0, 10.0, None, 8.0],
+        "metrics~2": [3.0, 7.0, 25.0, 9.0],
+    }
+    return pl.LazyFrame(data)
+
+
+@pytest.fixture
 def feature_set_sum() -> FeatureSet:
     """Create a feature set with a sum aggregation feature."""
     feature_set = FeatureSet()
@@ -230,6 +244,49 @@ class TestPolarsLazyAggregatedFeatureGroup:
         finally:
             # Restore the original AGGREGATION_TYPES
             AggregatedFeatureGroup.AGGREGATION_TYPES = original_types
+
+
+@pytest.mark.skipif(pl is None, reason="Polars not available")
+class TestPolarsLazyAggregatedFeatureGroupMultiColumnDdofAndNullSkip:
+    """Pins down ddof=1 (sample statistics) with null-skip semantics for row-wise std/var.
+
+    Ground truth is computed inline from pandas' .std(axis=1, skipna=True)/.var(axis=1, skipna=True),
+    which already implement ddof=1 with a valid-value-count denominator that skips nulls.
+    """
+
+    def test_perform_aggregation_std_multi_column_matches_pandas_skipna_ddof1(
+        self, multi_source_lazy_dataframe_with_null: Any
+    ) -> None:
+        result_expr = PolarsLazyAggregatedFeatureGroup._perform_aggregation(
+            multi_source_lazy_dataframe_with_null, "std", ["metrics~0", "metrics~1", "metrics~2"]
+        )
+        result_df = multi_source_lazy_dataframe_with_null.with_columns(result_expr.alias("test_std")).collect()
+        result = result_df["test_std"].to_list()
+
+        source = multi_source_lazy_dataframe_with_null.collect().to_pandas()
+        expected = source[["metrics~0", "metrics~1", "metrics~2"]].std(axis=1, skipna=True)  # ddof=1 by default
+
+        for row_index in range(len(expected)):
+            assert abs(result[row_index] - expected[row_index]) < 1e-6, (
+                f"row {row_index}: expected {expected[row_index]} (pandas ddof=1, skipna), got {result[row_index]}"
+            )
+
+    def test_perform_aggregation_var_multi_column_matches_pandas_skipna_ddof1(
+        self, multi_source_lazy_dataframe_with_null: Any
+    ) -> None:
+        result_expr = PolarsLazyAggregatedFeatureGroup._perform_aggregation(
+            multi_source_lazy_dataframe_with_null, "var", ["metrics~0", "metrics~1", "metrics~2"]
+        )
+        result_df = multi_source_lazy_dataframe_with_null.with_columns(result_expr.alias("test_var")).collect()
+        result = result_df["test_var"].to_list()
+
+        source = multi_source_lazy_dataframe_with_null.collect().to_pandas()
+        expected = source[["metrics~0", "metrics~1", "metrics~2"]].var(axis=1, skipna=True)  # ddof=1 by default
+
+        for row_index in range(len(expected)):
+            assert abs(result[row_index] - expected[row_index]) < 1e-6, (
+                f"row {row_index}: expected {expected[row_index]} (pandas ddof=1, skipna), got {result[row_index]}"
+            )
 
 
 @pytest.mark.skipif(pl is None, reason="Polars not available")

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_polars_lazy_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_polars_lazy_aggregated_feature_group.py
@@ -248,11 +248,7 @@ class TestPolarsLazyAggregatedFeatureGroup:
 
 @pytest.mark.skipif(pl is None, reason="Polars not available")
 class TestPolarsLazyAggregatedFeatureGroupMultiColumnDdofAndNullSkip:
-    """Pins down ddof=1 (sample statistics) with null-skip semantics for row-wise std/var.
-
-    Ground truth is computed inline from pandas' .std(axis=1, skipna=True)/.var(axis=1, skipna=True),
-    which already implement ddof=1 with a valid-value-count denominator that skips nulls.
-    """
+    """Pins ddof=1 with null-skip semantics for row-wise std/var against pandas .std/.var(axis=1, skipna=True)."""
 
     def test_perform_aggregation_std_multi_column_matches_pandas_skipna_ddof1(
         self, multi_source_lazy_dataframe_with_null: Any

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
@@ -49,6 +49,17 @@ def feature_set_multiple() -> FeatureSet:
     return feature_set
 
 
+@pytest.fixture
+def multi_source_table() -> pa.Table:
+    """Table with multi-column source features (metrics~0, metrics~1) for row-wise aggregation."""
+    return pa.table(
+        {
+            "metrics~0": [1, 2, 3, 4],
+            "metrics~1": [10, 20, 30, 40],
+        }
+    )
+
+
 class TestPyArrowAggregatedFeatureGroup:
     """Tests for the PyArrowAggregatedFeatureGroup class."""
 
@@ -172,6 +183,53 @@ class TestPyArrowAggregatedFeatureGroup:
         finally:
             # Restore the original AGGREGATION_TYPES
             AggregatedFeatureGroup.AGGREGATION_TYPES = original_types
+
+
+class TestPyArrowAggregatedFeatureGroupMultiColumn:
+    """Pins down bugs in _add_result_to_data for multi-column (row-wise) aggregation results."""
+
+    def test_add_result_to_data_multi_column_result_is_flat_not_nested(self, multi_source_table: pa.Table) -> None:
+        """A row-wise numpy result must become a flat length-n column, not an n-by-n nested ListArray."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table, "sum", ["metrics~0", "metrics~1"]
+        )
+
+        updated = PyArrowAggregatedFeatureGroup._add_result_to_data(multi_source_table, "metrics__sum_aggr", result)
+
+        result_col = updated.column("metrics__sum_aggr")
+        assert not pa.types.is_list(result_col.type), (
+            f"expected a flat scalar column, got nested list type {result_col.type}"
+        )
+        assert len(result_col) == multi_source_table.num_rows
+        assert result_col.to_pylist() == [11, 22, 33, 44]
+
+    def test_add_result_to_data_recompute_does_not_duplicate_column(self, multi_source_table: pa.Table) -> None:
+        """Calling _add_result_to_data twice for the same feature_name must not duplicate the column."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table, "sum", ["metrics~0", "metrics~1"]
+        )
+
+        once = PyArrowAggregatedFeatureGroup._add_result_to_data(multi_source_table, "metrics__sum_aggr", result)
+        twice = PyArrowAggregatedFeatureGroup._add_result_to_data(once, "metrics__sum_aggr", result)
+
+        assert twice.schema.names.count("metrics__sum_aggr") == 1
+
+    def test_calculate_feature_multi_column_row_wise_sum(self, multi_source_table: pa.Table) -> None:
+        """End-to-end: calculate_feature must produce a flat per-row column and not duplicate on recompute."""
+        feature_set = FeatureSet()
+        feature_set.add(Feature("metrics__sum_aggr"))
+
+        result = PyArrowAggregatedFeatureGroup.calculate_feature(multi_source_table, feature_set)
+
+        result_col = result.column("metrics__sum_aggr")
+        assert not pa.types.is_list(result_col.type), (
+            f"expected a flat scalar column, got nested list type {result_col.type}"
+        )
+        assert len(result_col) == multi_source_table.num_rows
+        assert result_col.to_pylist() == [11, 22, 33, 44]
+
+        recomputed = PyArrowAggregatedFeatureGroup.calculate_feature(result, feature_set)
+        assert recomputed.schema.names.count("metrics__sum_aggr") == 1
 
 
 class TestAggPyArrowIntegration:

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
@@ -60,6 +60,29 @@ def multi_source_table() -> pa.Table:
     )
 
 
+@pytest.fixture
+def multi_source_table_with_null() -> pa.Table:
+    """Two source columns, row index 2 has a null in metrics~0 only."""
+    return pa.table(
+        {
+            "metrics~0": pa.array([1.0, 2.0, None, 4.0], type=pa.float64()),
+            "metrics~1": pa.array([10.0, 20.0, 30.0, 40.0], type=pa.float64()),
+        }
+    )
+
+
+@pytest.fixture
+def multi_source_table_three_columns() -> pa.Table:
+    """Three source columns, no nulls, distinct values so std/var is meaningful."""
+    return pa.table(
+        {
+            "metrics~0": [1.0, 4.0, 100.0, 8.0],
+            "metrics~1": [2.0, 10.0, 50.0, 8.0],
+            "metrics~2": [3.0, 7.0, 25.0, 9.0],
+        }
+    )
+
+
 class TestPyArrowAggregatedFeatureGroup:
     """Tests for the PyArrowAggregatedFeatureGroup class."""
 
@@ -100,16 +123,14 @@ class TestPyArrowAggregatedFeatureGroup:
     def test_perform_aggregation_std(self, sample_table: pa.Table) -> None:
         """Test _perform_aggregation method with std aggregation."""
         result = PyArrowAggregatedFeatureGroup._perform_aggregation(sample_table, "std", ["sales"])
-        # PyArrow uses a different formula for standard deviation than Pandas
-        # PyArrow uses the population standard deviation (n), while Pandas uses the sample standard deviation (n-1)
-        assert abs(result - 141.42) < 0.1  # Std of [100, 200, 300, 400, 500] with population formula
+        # ddof=1 sample standard deviation, matching pandas' default.
+        assert abs(result - 158.11) < 0.1  # Std of [100, 200, 300, 400, 500] with sample formula
 
     def test_perform_aggregation_var(self, sample_table: pa.Table) -> None:
         """Test _perform_aggregation method with var aggregation."""
         result = PyArrowAggregatedFeatureGroup._perform_aggregation(sample_table, "var", ["sales"])
-        # PyArrow uses a different formula for variance than Pandas
-        # PyArrow uses the population variance (n), while Pandas uses the sample variance (n-1)
-        assert abs(result - 20000) < 0.1  # Var of [100, 200, 300, 400, 500] with population formula
+        # ddof=1 sample variance, matching pandas' default.
+        assert abs(result - 25000) < 0.1  # Var of [100, 200, 300, 400, 500] with sample formula
 
     def test_perform_aggregation_median(self, sample_table: pa.Table) -> None:
         """Test _perform_aggregation method with median aggregation."""
@@ -230,6 +251,99 @@ class TestPyArrowAggregatedFeatureGroupMultiColumn:
 
         recomputed = PyArrowAggregatedFeatureGroup.calculate_feature(result, feature_set)
         assert recomputed.schema.names.count("metrics__sum_aggr") == 1
+
+
+class TestPyArrowAggregatedFeatureGroupDdofAndNullSkip:
+    """Pins down ddof=1 (sample statistics) and null-skip semantics for std/var/sum/count.
+
+    Ground truth for every assertion is computed from pandas inline (never hardcoded),
+    since pandas' single-column .std()/.var() and multi-column .sum(axis=1, skipna=True)/
+    .std(axis=1, skipna=True) already implement the target semantics.
+    """
+
+    def test_perform_aggregation_std_single_column_matches_pandas_ddof1(self, sample_table: pa.Table) -> None:
+        """PyArrow single-column std must use ddof=1 (sample), not ddof=0 (population)."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(sample_table, "std", ["sales"])
+
+        expected = pd.Series(sample_table.column("sales").to_pylist()).std()  # ddof=1 by default
+
+        assert abs(result - expected) < 1e-6
+
+    def test_perform_aggregation_var_single_column_matches_pandas_ddof1(self, sample_table: pa.Table) -> None:
+        """PyArrow single-column var must use ddof=1 (sample), not ddof=0 (population)."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(sample_table, "var", ["sales"])
+
+        expected = pd.Series(sample_table.column("sales").to_pylist()).var()  # ddof=1 by default
+
+        assert abs(result - expected) < 1e-6
+
+    def test_perform_aggregation_sum_multi_column_skips_null(self, multi_source_table_with_null: pa.Table) -> None:
+        """A null in one source column must be skipped, not propagated as NaN, for the row's sum."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table_with_null, "sum", ["metrics~0", "metrics~1"]
+        )
+
+        expected = pd.DataFrame(
+            {
+                "metrics~0": multi_source_table_with_null.column("metrics~0").to_pylist(),
+                "metrics~1": multi_source_table_with_null.column("metrics~1").to_pylist(),
+            }
+        ).sum(axis=1, skipna=True)
+
+        for row_index in range(len(expected)):
+            assert not pd.isna(result[row_index]), (
+                f"row {row_index}: expected a skip-null sum, got NaN (null propagated instead of skipped)"
+            )
+            assert abs(result[row_index] - expected[row_index]) < 1e-9
+
+    def test_perform_aggregation_count_multi_column_excludes_null_without_crashing(
+        self, multi_source_table_with_null: pa.Table
+    ) -> None:
+        """Count across columns must not crash and must exclude the null value for the affected row."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table_with_null, "count", ["metrics~0", "metrics~1"]
+        )
+
+        # Row index 2 has a null in metrics~0, so only metrics~1 counts.
+        assert result[2] == 1
+
+    def test_perform_aggregation_std_multi_column_matches_pandas_ddof1(
+        self, multi_source_table_three_columns: pa.Table
+    ) -> None:
+        """PyArrow row-wise std across columns must use ddof=1 (sample), not ddof=0."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table_three_columns, "std", ["metrics~0", "metrics~1", "metrics~2"]
+        )
+
+        expected = pd.DataFrame(
+            {
+                "metrics~0": multi_source_table_three_columns.column("metrics~0").to_pylist(),
+                "metrics~1": multi_source_table_three_columns.column("metrics~1").to_pylist(),
+                "metrics~2": multi_source_table_three_columns.column("metrics~2").to_pylist(),
+            }
+        ).std(axis=1)  # ddof=1 by default
+
+        for row_index in range(len(expected)):
+            assert abs(result[row_index] - expected[row_index]) < 1e-6
+
+    def test_perform_aggregation_var_multi_column_matches_pandas_ddof1(
+        self, multi_source_table_three_columns: pa.Table
+    ) -> None:
+        """PyArrow row-wise var across columns must use ddof=1 (sample), not ddof=0."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table_three_columns, "var", ["metrics~0", "metrics~1", "metrics~2"]
+        )
+
+        expected = pd.DataFrame(
+            {
+                "metrics~0": multi_source_table_three_columns.column("metrics~0").to_pylist(),
+                "metrics~1": multi_source_table_three_columns.column("metrics~1").to_pylist(),
+                "metrics~2": multi_source_table_three_columns.column("metrics~2").to_pylist(),
+            }
+        ).var(axis=1)  # ddof=1 by default
+
+        for row_index in range(len(expected)):
+            assert abs(result[row_index] - expected[row_index]) < 1e-6
 
 
 class TestAggPyArrowIntegration:

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
@@ -341,6 +341,46 @@ class TestPyArrowAggregatedFeatureGroupDdofAndNullSkip:
             assert abs(result[row_index] - expected[row_index]) < 1e-6
 
 
+class TestPyArrowAggregatedFeatureGroupMultiColumnIntegerHandling:
+    """Pins int64 handling for multi-column aggregation: no unconditional float64 cast."""
+
+    @pytest.fixture
+    def large_int64_table(self) -> pa.Table:
+        """Two int64 source columns; metrics~0 holds values beyond 2**53 (float64 precision limit)."""
+        return pa.table(
+            {
+                "metrics~0": pa.array([2**60, 2**60 + 1], type=pa.int64()),
+                "metrics~1": pa.array([0, 0], type=pa.int64()),
+            }
+        )
+
+    def test_perform_aggregation_max_multi_column_large_int64_does_not_raise_and_is_precise(
+        self, large_int64_table: pa.Table
+    ) -> None:
+        """An unconditional cast to float64 raises ArrowInvalid for int64 values beyond +/-2**53."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            large_int64_table, "max", ["metrics~0", "metrics~1"]
+        )
+
+        assert int(result[0]) == 2**60
+        assert int(result[1]) == 2**60 + 1
+
+    def test_perform_aggregation_sum_multi_column_no_nulls_preserves_integer_dtype(
+        self, multi_source_table: pa.Table
+    ) -> None:
+        """With no nulls anywhere, the result dtype must stay integer, matching pandas/polars behavior."""
+        result = PyArrowAggregatedFeatureGroup._perform_aggregation(
+            multi_source_table, "sum", ["metrics~0", "metrics~1"]
+        )
+
+        updated = PyArrowAggregatedFeatureGroup._add_result_to_data(multi_source_table, "metrics__sum_aggr", result)
+
+        result_col = updated.column("metrics__sum_aggr")
+        assert pa.types.is_integer(result_col.type), (
+            f"expected integer dtype preserved when no nulls present, got {result_col.type}"
+        )
+
+
 class TestAggPyArrowIntegration:
     """Integration tests for the aggregated feature group using DataCreator."""
 

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_pyarrow_aggregated_feature_group.py
@@ -254,12 +254,7 @@ class TestPyArrowAggregatedFeatureGroupMultiColumn:
 
 
 class TestPyArrowAggregatedFeatureGroupDdofAndNullSkip:
-    """Pins down ddof=1 (sample statistics) and null-skip semantics for std/var/sum/count.
-
-    Ground truth for every assertion is computed from pandas inline (never hardcoded),
-    since pandas' single-column .std()/.var() and multi-column .sum(axis=1, skipna=True)/
-    .std(axis=1, skipna=True) already implement the target semantics.
-    """
+    """Pins ddof=1 and null-skip semantics for std/var/sum/count against pandas ground truth computed inline."""
 
     def test_perform_aggregation_std_single_column_matches_pandas_ddof1(self, sample_table: pa.Table) -> None:
         """PyArrow single-column std must use ddof=1 (sample), not ddof=0 (population)."""

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
@@ -44,6 +44,19 @@ def sample_table_with_missing_offset_group() -> pa.Table:
 
 
 @pytest.fixture
+def sample_table_with_null_group_key() -> pa.Table:
+    """Table where one row's group-by-feature value is itself null (None group key),
+    and the value column also has a null at that same row, so grouped ffill/bfill
+    must resolve that row's own group without crashing."""
+    return pa.Table.from_pydict(
+        {
+            "value": [10, None, 30],
+            "group": ["A", None, "A"],
+        }
+    )
+
+
+@pytest.fixture
 def feature_set_mean() -> FeatureSet:
     """Create a feature set with a mean imputation feature."""
     feature_set = FeatureSet()
@@ -225,6 +238,28 @@ class TestPyArrowMissingValueFeatureGroup:
         assert result[7].as_py() == expected[7]
         assert result[6].as_py() == 400
         assert result[7].as_py() == 400
+
+    def test_perform_grouped_imputation_ffill_null_group_key(
+        self, sample_table_with_null_group_key: pa.Table
+    ) -> None:
+        """Grouped ffill must not crash when a row needing imputation has a null group-by key:
+        Arrow's 3-valued equality makes pc.equal(col, null) all-null, so the null-key group mask
+        is all-null and the row's own index is missing from indices_nonzero(group_mask)."""
+        result = PyArrowMissingValueFeatureGroup._perform_grouped_imputation(
+            sample_table_with_null_group_key, "ffill", "value", None, ["group"]
+        )
+        assert isinstance(result, pa.Array)
+        assert len(result) == sample_table_with_null_group_key.num_rows
+
+    def test_perform_grouped_imputation_bfill_null_group_key(
+        self, sample_table_with_null_group_key: pa.Table
+    ) -> None:
+        """Grouped bfill must not crash when a row needing imputation has a null group-by key."""
+        result = PyArrowMissingValueFeatureGroup._perform_grouped_imputation(
+            sample_table_with_null_group_key, "bfill", "value", None, ["group"]
+        )
+        assert isinstance(result, pa.Array)
+        assert len(result) == sample_table_with_null_group_key.num_rows
 
     def test_calculate_feature_single(self, sample_table_with_missing: pa.Table, feature_set_mean: FeatureSet) -> None:
         """Test calculate_feature method with a single imputation."""

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
@@ -239,9 +239,7 @@ class TestPyArrowMissingValueFeatureGroup:
         assert result[6].as_py() == 400
         assert result[7].as_py() == 400
 
-    def test_perform_grouped_imputation_ffill_null_group_key(
-        self, sample_table_with_null_group_key: pa.Table
-    ) -> None:
+    def test_perform_grouped_imputation_ffill_null_group_key(self, sample_table_with_null_group_key: pa.Table) -> None:
         """Grouped ffill must not crash when a row needing imputation has a null group-by key:
         Arrow's 3-valued equality makes pc.equal(col, null) all-null, so the null-key group mask
         is all-null and the row's own index is missing from indices_nonzero(group_mask)."""
@@ -251,9 +249,7 @@ class TestPyArrowMissingValueFeatureGroup:
         assert isinstance(result, pa.Array)
         assert len(result) == sample_table_with_null_group_key.num_rows
 
-    def test_perform_grouped_imputation_bfill_null_group_key(
-        self, sample_table_with_null_group_key: pa.Table
-    ) -> None:
+    def test_perform_grouped_imputation_bfill_null_group_key(self, sample_table_with_null_group_key: pa.Table) -> None:
         """Grouped bfill must not crash when a row needing imputation has a null group-by key."""
         result = PyArrowMissingValueFeatureGroup._perform_grouped_imputation(
             sample_table_with_null_group_key, "bfill", "value", None, ["group"]

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
@@ -32,6 +32,18 @@ def sample_table_with_missing() -> pa.Table:
 
 
 @pytest.fixture
+def sample_table_with_missing_offset_group() -> pa.Table:
+    """Table where group "B" starts at global row 5 (not row 0), exposing group-local vs
+    global row-index bugs in ffill/bfill grouped imputation."""
+    return pa.Table.from_pydict(
+        {
+            "value": [10, 20, 30, 40, 50, 100, None, None, 400, 500],
+            "group": ["A", "A", "A", "A", "A", "B", "B", "B", "B", "B"],
+        }
+    )
+
+
+@pytest.fixture
 def feature_set_mean() -> FeatureSet:
     """Create a feature set with a mean imputation feature."""
     feature_set = FeatureSet()
@@ -173,6 +185,46 @@ class TestPyArrowMissingValueFeatureGroup:
         # Check that missing values are imputed
         assert not pc.is_null(result[1]).as_py()  # Should be imputed
         assert not pc.is_null(result[3]).as_py()  # Should be imputed
+
+    def test_perform_grouped_imputation_ffill_group_not_starting_at_zero(
+        self, sample_table_with_missing_offset_group: pa.Table
+    ) -> None:
+        """Grouped ffill must resolve each group's last-valid-before-row using the row's position
+        within the group, not its global row index, when the group does not start at row 0."""
+        result = PyArrowMissingValueFeatureGroup._perform_grouped_imputation(
+            sample_table_with_missing_offset_group, "ffill", "value", None, ["group"]
+        )
+
+        df = sample_table_with_missing_offset_group.to_pandas()
+        expected = df.groupby("group")["value"].ffill()
+
+        # Group "B" is [100, None, None, 400, 500] at global rows 5-9.
+        # Both nulls should be filled from the preceding in-group value (100), not the group's last value (500).
+        assert result[6].as_py() == expected[6]
+        assert result[7].as_py() == expected[7]
+        assert result[6].as_py() == 100
+        assert result[7].as_py() == 100
+
+    def test_perform_grouped_imputation_bfill_group_not_starting_at_zero(
+        self, sample_table_with_missing_offset_group: pa.Table
+    ) -> None:
+        """Grouped bfill must resolve each group's first-valid-after-row using the row's position
+        within the group, not its global row index, when the group does not start at row 0."""
+        result = PyArrowMissingValueFeatureGroup._perform_grouped_imputation(
+            sample_table_with_missing_offset_group, "bfill", "value", None, ["group"]
+        )
+
+        df = sample_table_with_missing_offset_group.to_pandas()
+        expected = df.groupby("group")["value"].bfill()
+
+        # Group "B" is [100, None, None, 400, 500] at global rows 5-9.
+        # Both nulls should be filled from the following in-group value (400), not left unfilled.
+        assert not pc.is_null(result[6]).as_py()
+        assert not pc.is_null(result[7]).as_py()
+        assert result[6].as_py() == expected[6]
+        assert result[7].as_py() == expected[7]
+        assert result[6].as_py() == 400
+        assert result[7].as_py() == 400
 
     def test_calculate_feature_single(self, sample_table_with_missing: pa.Table, feature_set_mean: FeatureSet) -> None:
         """Test calculate_feature method with a single imputation."""

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
@@ -124,6 +124,28 @@ class TestPandasNodeCentralityFeatureGroup:
         assert (centrality >= 0).all()
         assert (centrality <= 1).all()
 
+    def test_calculate_betweenness_centrality_path_graph_undirected(self) -> None:
+        """Undirected path a-b-c: only unordered pair (a,c) runs through b, so C_B(b) must be 1.0, not 2.0."""
+        edges = pd.DataFrame(
+            [
+                {"source": "a", "target": "b"},
+                {"source": "b", "target": "c"},
+            ]
+        )
+        nodes = pd.concat([edges["source"], edges["target"]]).unique()
+
+        adj_matrix = PandasNodeCentralityFeatureGroup._create_adjacency_matrix(
+            edges, nodes, "source", "target", None, "undirected"
+        )
+
+        centrality = PandasNodeCentralityFeatureGroup._calculate_betweenness_centrality(adj_matrix, nodes)
+
+        # b sits on the only shortest path between a and c: hand-computed C_B(b) == 1.0
+        assert centrality["b"] == 1.0
+        # a and c are endpoints, on no shortest path between any other pair: C_B == 0.0
+        assert centrality["a"] == 0.0
+        assert centrality["c"] == 0.0
+
     def test_calculate_centrality(self, sample_data: pd.DataFrame) -> None:
         """Test the _calculate_centrality method."""
         # Test degree centrality


### PR DESCRIPTION
Fixes eight independent correctness bugs found across the pandas, polars, pyarrow, iceberg, and sklearn compute framework implementations.

## Fixes

- Polars merge engine returned zero rows for a left/right/outer join when one side was empty, instead of preserving the non-empty side's rows with the other side's columns null. Fixes #1240
- PyArrow grouped ffill/bfill compared a group-local array index against the outer loop's global row index, picking wrong fill values (or silently falling back to the overall value) for any group not starting at row zero. Fixes #1241
- PyArrow multi-column aggregation wrapped an already-per-row result in another repeat-count-sized list, producing a nested list column instead of a flat one, and always appended rather than replaced an existing column on recompute. Fixes #1242
- The Iceberg filter engine silently dropped any filter it could not translate to an Iceberg expression, returning the whole unfiltered table. It now raises for an unsupported filter type. Fixes #1243
- Sklearn categorical encoding used a different NaN policy at fit time than at transform time, crashing on any column containing a null. Fit and transform now share one policy. Fixes #1244
- The pandas regex filter cast a column to string before matching, turning null cells into the literal string "nan" and letting them match a pattern that includes an "a". Null rows are now excluded regardless of what the cast does to them. Fixes #1245
- Aggregation semantics diverged across frameworks: pyarrow used population variance (ddof=0) where pandas and polars use sample variance (ddof=1), and pyarrow propagated null across a whole row instead of skipping it. All three frameworks now agree. Fixes #1246
- Betweenness centrality's ordered-pair loop double-counted every unordered pair for undirected graphs while normalizing by the unordered-pair count, so scores came out twice too large. Fixes #1247

## Notes

A few additional issues surfaced during review of the above (a null group key crashing the pyarrow ffill/bfill fix, a float64 cast in the pyarrow aggregation fix losing precision on large integers and diverging dtype from the other frameworks for the common null-free case, and the sklearn encoding fix breaking numeric categorical columns) are fixed as separate commits on this branch.
