### PR TITLE
fix: correct position-collision handling in link ordering

### DIFF
--- a/mloda/core/prepare/resolve_links.py
+++ b/mloda/core/prepare/resolve_links.py
@@ -152,11 +152,8 @@ class LinkTrekker:
                 new_order[o_uuid] = o_set
             else:
                 # remembering latest position
-                if latest_position in pos_marker:
-                    for i in range(latest_position, len(pos_marker)):
-                        if i not in pos_marker:
-                            latest_position = i + latest_position
-                            break
+                while latest_position in pos_marker:
+                    latest_position += 1
                 pos_marker[latest_position] = (o_uuid, o_set)
 
         if len(pos_marker.keys()):

--- a/tests/test_core/test_prepare/test_resolve_links.py
+++ b/tests/test_core/test_prepare/test_resolve_links.py
@@ -1,0 +1,28 @@
+"""order_ordered_ids_by_relation must not silently drop an entry when two ids collide on one position."""
+
+from collections import OrderedDict
+from uuid import uuid4
+
+from mloda.core.prepare.resolve_links import LinkTrekker
+
+
+def test_order_ordered_ids_by_relation_keeps_both_ids_that_collide_on_one_position() -> None:
+    trekker = LinkTrekker()
+    uuid_a = uuid4()
+    uuid_b = uuid4()
+    uuid_c = uuid4()
+
+    trekker.order = OrderedDict(
+        [
+            (uuid_a, set()),
+            (uuid_b, set()),
+            (uuid_c, {uuid_a, uuid_b}),
+        ]
+    )
+
+    trekker.order_ordered_ids_by_relation()
+
+    assert uuid_a in trekker.order, f"uuid_a was overwritten by the colliding position bug; got: {trekker.order}"
+    assert uuid_b in trekker.order
+    assert uuid_c in trekker.order
+    assert len(trekker.order) == 3

--- a/tests/test_core/test_prepare/test_resolve_links.py
+++ b/tests/test_core/test_prepare/test_resolve_links.py
@@ -22,7 +22,4 @@ def test_order_ordered_ids_by_relation_keeps_both_ids_that_collide_on_one_positi
 
     trekker.order_ordered_ids_by_relation()
 
-    assert uuid_a in trekker.order, f"uuid_a was overwritten by the colliding position bug; got: {trekker.order}"
-    assert uuid_b in trekker.order
-    assert uuid_c in trekker.order
-    assert len(trekker.order) == 3
+    assert list(trekker.order.keys()) == [uuid_c, uuid_a, uuid_b]


### PR DESCRIPTION
Closes #1231

## Summary

`LinkTrekker.order_ordered_ids_by_relation` assigns each link a target position when rebuilding order from dependency relations. When two entries independently resolved to the same target position, the collision-handling code found a genuinely free slot but then discarded it, offsetting the position by an unrelated amount instead of using it directly, and bounded its search by the current size of an internal dict rather than anything meaningful. When no slot existed within that arbitrary bound, the position was assigned without ever finding a free spot, silently overwriting whatever link was already there and dropping it from the final order.

The collision handler now walks forward from the colliding position to the first genuinely free slot, with no artificial bound, so no assignment can overwrite an existing entry.

## Test plan

- Added a test reproducing a three-way position collision (two links independently target the same slot as a third) and asserting the exact resulting order, not just that nothing was dropped.
- Full local test suite, ruff, mypy --strict, and bandit all pass.