### PR TITLE
fix: avoid KeyError when a diamond dependency shares a grandchild

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1086,7 +1086,7 @@ Available join types:
 
             for c_o_c in child_of_child:
                 if c_o_c in children_uuids:
-                    new_children_uuids.remove(c_o_c)
+                    new_children_uuids.discard(c_o_c)
 
         return new_children_uuids
 

--- a/tests/test_core/test_prepare/test_execution_plan_diamond_pruning.py
+++ b/tests/test_core/test_prepare/test_execution_plan_diamond_pruning.py
@@ -1,0 +1,24 @@
+"""reduce_children_to_one_level must survive a shared grandchild reached from two children."""
+
+from uuid import uuid4
+
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+
+
+def test_reduce_children_to_one_level_prunes_a_grandchild_shared_by_two_children() -> None:
+    plan = ExecutionPlan()
+    graph = Graph()
+
+    child_1 = uuid4()
+    child_2 = uuid4()
+    shared_grandchild = uuid4()
+
+    graph.adjacency_list[child_1] = [shared_grandchild]
+    graph.adjacency_list[child_2] = [shared_grandchild]
+
+    children_uuids = {child_1, child_2, shared_grandchild}
+
+    result = plan.reduce_children_to_one_level(children_uuids, graph)
+
+    assert result == {child_1, child_2}


### PR DESCRIPTION
Closes #1230

## Summary

`ExecutionPlan.reduce_children_to_one_level` prunes a set of child uuids down to their topmost consumers by removing any uuid that is itself reachable as a child-of-child of another member of the set. It checked membership against the original set but removed from a separate, shrinking copy. When a grandchild was shared by two different children in a diamond-shaped dependency graph, it got removed once by whichever child was processed first, then a second child that also referenced it tried to remove it again, raising `KeyError` since it was already gone.

The removal is now a no-op when the target is already absent, which is exactly the right behavior here: the set of uuids to prune is fixed up front from the original (unmodified) set, so an element nominated for removal more than once still only needs to be excluded once.

## Test plan

- Added a test reproducing the exact diamond shape (two children sharing one grandchild) and asserting the correct reduced set, not just the absence of a crash.
- Full local test suite, ruff, mypy --strict, and bandit all pass.