### PR TITLE
fix: fix dead null-count fast path in pyarrow missing-value imputation

### DIFF
--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -4,13 +4,12 @@ PyArrow implementation for missing value imputation feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
 
 from mloda.provider import ComputeFramework
-
 from mloda.user.pyarrow import PyArrowTable
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
@@ -53,8 +52,8 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: pa.Table,
         imputation_method: str,
         in_features: list[str],
-        constant_value: Optional[Any] = None,
-        group_by_features: Optional[list[str]] = None,
+        constant_value: Any | None = None,
+        group_by_features: list[str] | None = None,
     ) -> pa.Array:
         """
         Perform the imputation using PyArrow compute functions.
@@ -80,7 +79,7 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
             source_column = data.column(source_feature)
 
             # If there are no missing values, return the original column
-            if pc.count(pc.is_null(source_column)).as_py() == 0:
+            if source_column.null_count == 0:
                 return source_column
 
             # If group_by_features is provided, perform grouped imputation
@@ -167,7 +166,7 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: pa.Table,
         imputation_method: str,
         in_features: str,  # Note: grouped imputation only supports single column
-        constant_value: Optional[Any],
+        constant_value: Any | None,
         group_by_features: list[str],
     ) -> pa.Array:
         """

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
@@ -2,15 +2,10 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
-from mloda.user import mloda
-from mloda.user import Feature
 from mloda.provider import FeatureSet
-from mloda.user import Options
-from mloda.user import PluginCollector
-
+from mloda.user import Feature, Options, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.pyarrow import PyArrowMissingValueFeatureGroup
-
 from tests.test_plugins.feature_group.experimental.test_missing_value_feature_group.test_missing_value_utils import (
     PyArrowMissingValueTestDataCreator,
     validate_missing_value_features,
@@ -79,6 +74,30 @@ class TestPyArrowMissingValueFeatureGroup:
     def test_compute_framework_rule(self) -> None:
         """Test compute_framework_rule method."""
         assert PyArrowMissingValueFeatureGroup.compute_framework_rule() == {PyArrowTable}
+
+    def test_perform_imputation_no_missing_values_fast_path(self) -> None:
+        """Test that columns without missing values trigger the fast path and return the column unchanged."""
+        table = pa.Table.from_pydict({"values": [10, 20, 30, 40]})
+        col = table.column("values")
+        assert col.null_count == 0
+
+        # Fast path returns unchanged column without error even if method is otherwise unhandled
+        result = PyArrowMissingValueFeatureGroup._perform_imputation(
+            table, "invalid_method_skipped_by_fast_path", ["values"]
+        )
+        assert result.equals(col)
+        assert result.to_pylist() == [10, 20, 30, 40]
+
+    def test_perform_imputation_with_missing_values_takes_imputation_path(
+        self, sample_table_with_missing: pa.Table
+    ) -> None:
+        """Test that columns with missing values do not take the fast path and undergo imputation."""
+        orig_col = sample_table_with_missing.column("income")
+        assert orig_col.null_count > 0
+
+        result = PyArrowMissingValueFeatureGroup._perform_imputation(sample_table_with_missing, "mean", ["income"])
+        assert not result.equals(orig_col)
+        assert result.null_count == 0
 
     def test_perform_imputation_mean(self, sample_table_with_missing: pa.Table) -> None:
         """Test _perform_imputation method with mean imputation."""


### PR DESCRIPTION
Closes #1264

### Summary of Changes
- Replace `pc.count(pc.is_null(source_column)).as_py() == 0` in `PyArrowMissingValueFeatureGroup._perform_imputation` with `source_column.null_count == 0`.
  - Previously, `pc.is_null(source_column)` produced a boolean array that never contains nulls, causing `pc.count()` (which counts valid/non-null elements by default) to return `len(source_column)`. Consequently, the fast path only evaluated to True when the table had 0 rows.
  - Using `source_column.null_count == 0` correctly checks for absent missing values in O(1) and avoids redundant imputation work.
- Add unit tests verifying:
  - Fast path triggers when `null_count == 0` and returns the column unchanged.
  - Imputation is performed as expected when missing values are present.

### Verification
- `uv run pytest tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/ -v` (59/59 passed)
- `uv run ruff check` & `uv run ruff format`
- `uv run mypy --strict --ignore-missing-imports`
