### PR TITLE
fix: Index.__eq__ returns NotImplemented instead of raising

### DIFF
--- a/mloda/core/abstract_plugins/components/index/index.py
+++ b/mloda/core/abstract_plugins/components/index/index.py
@@ -17,7 +17,7 @@ class Index:
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Index):
-            raise Exception(f"Cannot compare Index with {type(other)}.")
+            return NotImplemented
         return self.index == other.index
 
     def __hash__(self) -> int:

--- a/tests/test_core/test_index/test_index_equality.py
+++ b/tests/test_core/test_index/test_index_equality.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from mloda.user import Index
+
+
+class TestIndexEquality:
+    """Unit tests for Index.__eq__ / __hash__ per Python's data model."""
+
+    def test_eq_none_returns_false(self) -> None:
+        """Comparing an Index against None must be False, not raise."""
+        assert (Index(("a",)) == None) is False  # noqa: E711
+
+    def test_membership_check_with_mixed_list(self) -> None:
+        """`in` must fall through non-Index elements without raising."""
+        assert Index(("a",)) in ["x", Index(("a",))]
+
+    def test_dict_lookup_with_colliding_tuple_key_misses(self) -> None:
+        """A plain tuple key must never match an Index, even on hash collision."""
+        d = {("a",): 1}
+        assert d.get(Index(("a",))) is None  # type: ignore[call-overload]
+
+    def test_two_indexes_not_equal(self) -> None:
+        """Real Index-to-Index comparison still works after the fix."""
+        assert Index(("a",)) != Index(("b",))


### PR DESCRIPTION
Closes #1238

## Summary

`Index.__eq__` raised a bare `Exception` for any non-`Index` operand instead of returning `NotImplemented` per Python's data model. This broke comparing an `Index` against `None`, membership checks in mixed-type containers, and dict/set lookups against a plain tuple whose hash happens to collide with an `Index` (since `__hash__` returns `hash(self.index)`, identical to the tuple's own hash).

`__eq__` now returns `NotImplemented` for a non-`Index` operand, letting Python fall back to the other side's comparison and ultimately treat mismatched types as unequal instead of raising.

## Test plan

- Added tests covering equality against `None`, membership in a mixed-type list, a dict lookup with a hash-colliding plain-tuple key, and a sanity check that real `Index`-to-`Index` comparison is unaffected.
- Full local test suite, ruff, mypy --strict, and bandit all pass.