### PR TITLE
fix: base the no-missing-values imputation fast path on null_count

### DIFF
--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -80,7 +80,7 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
             source_column = data.column(source_feature)
 
             # If there are no missing values, return the original column
-            if pc.count(pc.is_null(source_column)).as_py() == 0:
+            if source_column.null_count == 0:
                 return source_column
 
             # If group_by_features is provided, perform grouped imputation

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_pyarrow_missing_value_feature_group.py
@@ -185,6 +185,35 @@ class TestPyArrowMissingValueFeatureGroup:
         with pytest.raises(ValueError):
             PyArrowMissingValueFeatureGroup._perform_imputation(sample_table_with_missing, "invalid", ["income"])
 
+    def test_perform_imputation_no_missing_values_returns_source_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fast path must fire when a non-empty column has no nulls: the column is returned
+        as-is and no imputation compute runs."""
+        table = pa.Table.from_pydict({"income": [50000, 75000, 60000]})
+
+        def _fail(*args: object, **kwargs: object) -> None:
+            raise AssertionError("imputation should be skipped when there are no missing values")
+
+        monkeypatch.setattr(pc, "fill_null", _fail)
+        monkeypatch.setattr(pc, "mean", _fail)
+
+        result = PyArrowMissingValueFeatureGroup._perform_imputation(table, "mean", ["income"])
+
+        assert result.equals(table.column("income"))
+        assert result.null_count == 0
+
+    def test_perform_imputation_with_missing_values_skips_fast_path(self, sample_table_with_missing: pa.Table) -> None:
+        """The fast path must not fire when the column has nulls; imputation still runs."""
+        source_column = sample_table_with_missing.column("income")
+
+        result = PyArrowMissingValueFeatureGroup._perform_imputation(sample_table_with_missing, "mean", ["income"])
+
+        assert result is not source_column
+        assert result.null_count == 0
+        assert not pc.is_null(result[1]).as_py()
+        assert not pc.is_null(result[3]).as_py()
+
     def test_perform_grouped_imputation_mean(self, sample_table_with_missing: pa.Table) -> None:
         """Test _perform_grouped_imputation method with mean imputation by group."""
         result = PyArrowMissingValueFeatureGroup._perform_grouped_imputation(


### PR DESCRIPTION
## Summary

`PyArrowMissingValueFeatureGroup._perform_imputation` guards its "no missing values, return the column unchanged" fast path with `pc.count(pc.is_null(source_column)).as_py() == 0`. `pc.is_null` returns a boolean mask that never itself contains nulls, and `pc.count` counts *valid* entries by default, so the expression always equals `len(source_column)` — the check is only ever true for an empty column. For any non-empty column the fast path never fired: imputation still ran and results stayed correct, but the optimization was dead and the condition was misleading to read.

This swaps the check for `source_column.null_count == 0`, which is what the comment already describes.

## Related issue

Closes #1264

## Type of change

- [x] Bug fix (`fix:`)

## Notes

- Two tests added in `test_pyarrow_missing_value_feature_group.py`:
  - a non-empty column with no nulls now takes the fast path and runs no imputation compute (`pc.fill_null` / `pc.mean` are monkeypatched to fail);
  - a column with nulls still skips the fast path and is imputed.

## Checklist

- [x] Tests added for the change
- [x] `ruff format --check`, `ruff check`, `mypy --strict --ignore-missing-imports`, and `bandit` pass on the touched files
- [x] Targeted test suites pass locally (`tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/` and neighbouring feature-group tests). The full `tox` run could not complete in my sandbox (an unrelated `pytest-xdist` worker crash under parallelism, not a test failure).
- [x] PR title follows Conventional Commits