### PR TITLE
fix: pin release publish job to the exact released commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,10 @@ name: Release
 on:
   workflow_dispatch:
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   github_release:
     name: GitHub Release
@@ -103,11 +107,18 @@ jobs:
 
       - name: Capture released commit SHA
         id: release_sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        if: steps.semantic.outputs.new_release_published == 'true'
+        env:
+          VERSION: ${{ steps.semantic.outputs.new_release_version }}
+        run: |
+          sha=$(git rev-parse --verify "refs/tags/$VERSION^{commit}")
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: github_release
-    if: needs.github_release.outputs.new_release_published == 'true'
+    if: >-
+      needs.github_release.outputs.new_release_published == 'true' &&
+      needs.github_release.outputs.new_release_sha != ''
     runs-on: ubuntu-24.04
     steps:
       - name: Check out the released commit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_sha: ${{ steps.release_sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,19 +101,20 @@ jobs:
           CI: true
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
+      - name: Capture released commit SHA
+        id: release_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   publish:
     needs: github_release
     if: needs.github_release.outputs.new_release_published == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out the code
+      - name: Check out the released commit
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: main
-
-      - name: Fetch changes on main
-        run: git pull origin main
+          ref: ${{ needs.github_release.outputs.new_release_sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

The release workflow has two jobs: `github_release` runs semantic-release, which decides the next version, tags it, and pushes; `publish` builds the wheel and uploads it to PyPI. `publish` checked out `main` (and re-pulled it) instead of the commit `github_release` had just tagged.

With multiple contributors able to merge concurrently, a PR merged to main in the window between the tag and the publish build would get silently pulled into the wheel and shipped under a version number whose changelog never mentioned it. The git tag and the published PyPI artifact could diverge in content.

## Changes

- `github_release` now resolves and outputs the exact commit SHA from the tag semantic-release created, rather than relying on `HEAD` right after the step exits, since semantic-release can exit 0 without tagging on its own branch-behind-remote guard.
- `publish` checks out that SHA instead of `main`, and no longer re-pulls `main`.
- `publish` is gated on a non-empty SHA in addition to the existing published flag, so an unresolved SHA fails the run instead of silently falling back to `main`'s tip.
- The workflow now serializes concurrent `workflow_dispatch` runs so two manual releases cannot race each other.

## Test plan

- [x] `tox -e python310` passes (9705 passed, 170 skipped, 2 xfailed; ruff, mypy --strict, bandit, license check all clean)
- [x] Workflow YAML validated with a YAML parser
- [ ] CI on this PR