### PR TITLE
docs: mark RunContext internal, not part of the public API

### DIFF
--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -83,6 +83,7 @@ class ComputeFramework(ABC):
         self.column_names: set[str] = set()
         self.function_extender = function_extender if function_extender is not None else set()
         # Set post-construction so a subclass's fixed __init__ signature isn't broken.
+        # RunContext is internal; hook authors should read run_id/carrier off HookContext instead.
         self.run_context: RunContext = RunContext()
         self.worker_index: int | None = None
 

--- a/mloda/core/abstract_plugins/run_context.py
+++ b/mloda/core/abstract_plugins/run_context.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True)
 class RunContext:
-    """Per-run values every ComputeFramework carries into hooks and spawn workers; keep it picklable."""
+    """Internal, not part of the public API.
+
+    Per-run values every ComputeFramework carries into hooks and spawn workers; keep it picklable.
+    """
 
     run_id: str | None = None
     carrier: dict[str, str] | None = field(default=None, hash=False)  # a dict cannot hash; equality still compares it

--- a/tests/test_core/test_abstract_plugins/test_run_context.py
+++ b/tests/test_core/test_abstract_plugins/test_run_context.py
@@ -102,3 +102,16 @@ class TestRunContextReplace:
 
         assert replaced.carrier == ctx.carrier
         assert replaced.carrier is not ctx.carrier
+
+
+class TestRunContextIsInternal:
+    def test_docstring_states_the_class_is_internal_and_not_public_api(self) -> None:
+        assert RunContext.__doc__ is not None
+        assert "internal" in RunContext.__doc__.lower()
+        assert "not part of the public api" in RunContext.__doc__.lower()
+
+    def test_not_exported_from_the_provider_facade(self) -> None:
+        import mloda.provider as provider
+
+        assert "RunContext" not in provider.__all__
+        assert not hasattr(provider, "RunContext")

--- a/tests/test_core/test_abstract_plugins/test_run_context.py
+++ b/tests/test_core/test_abstract_plugins/test_run_context.py
@@ -5,6 +5,9 @@ import pickle  # nosec B403
 
 import pytest
 
+import mloda.provider as provider
+import mloda.steward as steward
+import mloda.user as user
 from mloda.core.abstract_plugins.run_context import RunContext
 
 
@@ -110,8 +113,12 @@ class TestRunContextIsInternal:
         assert "internal" in RunContext.__doc__.lower()
         assert "not part of the public api" in RunContext.__doc__.lower()
 
-    def test_not_exported_from_the_provider_facade(self) -> None:
-        import mloda.provider as provider
-
+    def test_not_exported_from_any_facade(self) -> None:
         assert "RunContext" not in provider.__all__
         assert not hasattr(provider, "RunContext")
+
+        assert "RunContext" not in steward.__all__
+        assert not hasattr(steward, "RunContext")
+
+        assert "RunContext" not in user.__all__
+        assert not hasattr(user, "RunContext")


### PR DESCRIPTION
## Summary

Resolves the open question of whether `RunContext` should be a deliberate public export or internal plumbing. It stays internal: `RunContext.__doc__` now states plainly that the class is internal and not part of the public API, and `mloda/core/abstract_plugins/compute_framework.py` notes at the assignment site that hook authors should read `run_id`/`carrier` off `HookContext` instead, which already exports both fields via `mloda.steward`.

No behavior changes. `HookContext` already carried its own `run_id`/`carrier`, populated from `RunContext` at hook-build time, so nothing downstream needed to change.

## Test plan

- Added `TestRunContextIsInternal` to `tests/test_core/test_abstract_plugins/test_run_context.py`: the docstring states the class is internal, and `RunContext` stays absent from `mloda.provider`, `mloda.steward`, and `mloda.user`.
- Full `tox` gate passes (tests, ruff format/check, mypy --strict, bandit).