### PR TITLE
[Fix]  Preserve in_features order 

### DIFF
--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -247,7 +247,7 @@ class Options:
     def __setitem__(self, key: str, value: Any) -> None:
         self.set(key, value)
 
-    def get_in_features(self) -> "frozenset[Feature]":
+    def get_in_features(self) -> "tuple[Feature, ...]":
         val = self.get(DefaultOptionKeys.in_features)
 
         if not val:
@@ -271,17 +271,20 @@ class Options:
             else:
                 raise TypeError(f"Cannot convert {type(item)} to Feature. Expected Feature object or str.")
 
-        if isinstance(val, (list, tuple, set, frozenset)):
-            return frozenset(_convert_to_feature(item) for item in val)
+        if isinstance(val, (set, frozenset)):
+            converted = sorted((_convert_to_feature(item) for item in val), key=lambda feature: str(feature.name))
+            return tuple(dict.fromkeys(converted))
+        elif isinstance(val, (list, tuple)):
+            return tuple(dict.fromkeys(_convert_to_feature(item) for item in val))
         elif isinstance(val, str):
             # Handle comma-separated strings
             if "," in val:
                 feature_names = [name.strip() for name in val.split(",")]
-                return frozenset(_convert_to_feature(name) for name in feature_names)
+                return tuple(dict.fromkeys(_convert_to_feature(name) for name in feature_names))
             else:
-                return frozenset([_convert_to_feature(val)])
+                return (_convert_to_feature(val),)
         elif hasattr(val, "options"):  # Handle Feature objects
-            return frozenset([_convert_to_feature(val)])
+            return (_convert_to_feature(val),)
         else:
             raise TypeError(
                 f"Unsupported source feature {val!r} of type {type(val).__name__}. "

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -5,7 +5,7 @@ This module handles the conversion from validated configuration data
 to mloda Feature instances.
 """
 
-from typing import Any
+from typing import Any, cast
 
 # Import from the component modules, NOT the `mloda.user` facade: that facade
 # imports load_features_from_config from this module, so a facade import here
@@ -19,6 +19,10 @@ from mloda.core.api.feature_config.models import (
     validate_nested_in_features,
 )
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+
+def _ordered_unique_in_features(in_features: list[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(in_features))
 
 
 def build_nested_feature(value: dict[str, Any]) -> Feature:
@@ -141,8 +145,9 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
                 group = process_nested_features(item.group_options or {})
                 context = process_nested_features(item.context_options or {})
                 if item.in_features:
-                    # Always convert to frozenset for consistency
-                    context[DefaultOptionKeys.in_features] = frozenset(item.in_features)
+                    context[DefaultOptionKeys.in_features] = _ordered_unique_in_features(
+                        cast(list[str], item.in_features)
+                    )
                 options = Options(
                     group=group,
                     context=context,
@@ -156,8 +161,7 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
             elif item.in_features:
                 # Process nested features in options before creating Feature
                 processed_options = process_nested_features(item.options)
-                # Always convert to frozenset for consistency (even single items)
-                source_value = frozenset(item.in_features)
+                source_value = _ordered_unique_in_features(cast(list[str], item.in_features))
                 options = Options(group=processed_options, context={DefaultOptionKeys.in_features: source_value})
                 feature = Feature(name=feature_name, options=options, feature_group=item.feature_group)
                 features.append(feature)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -403,7 +403,7 @@ class _MarkedAbortOptions(Options):
 
     marker: BaseException
 
-    def get_in_features(self) -> "frozenset[Feature]":
+    def get_in_features(self) -> "tuple[Feature, ...]":
         raise self.marker
 
 
@@ -677,9 +677,7 @@ class TestFeatureChainParserMixinExtractSourceFeatures:
         result = MockFeatureGroup._extract_source_features(feature)
 
         # Should return list of feature names from get_in_features()
-        assert len(result) == 2
-        assert "feature_a" in result
-        assert "feature_b" in result
+        assert result == ["feature_a", "feature_b"]
 
     def test_extract_source_features_custom_separator(self) -> None:
         """Test extraction with custom separator (comma instead of ampersand)."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -506,3 +506,34 @@ class TestOptionsGetInFeaturesUnresolvableTruthyValue:
         """The unsupported-type message keeps naming the type alongside the value."""
         message = self._message(value)
         assert type(value).__name__ in message, message
+
+
+class TestOptionsGetInFeaturesOrdering:
+    """get_in_features preserves ordered declarations and stabilizes unordered inputs."""
+
+    @pytest.mark.parametrize(
+        "ordered_input",
+        [
+            pytest.param(["z_source", "a_source", "z_source"], id="list"),
+            pytest.param(("z_source", "a_source", "z_source"), id="tuple"),
+            pytest.param("z_source, a_source, z_source", id="comma_separated_string"),
+        ],
+    )
+    def test_ordered_input_preserves_order_and_first_occurrence(self, ordered_input: object) -> None:
+        result = Options(context={IN_FEATURES: ordered_input}).get_in_features()
+
+        assert isinstance(result, tuple)
+        assert [feature.name for feature in result] == ["z_source", "a_source"]
+
+    @pytest.mark.parametrize(
+        "unordered_input",
+        [
+            pytest.param({"z_source", "a_source"}, id="set"),
+            pytest.param(frozenset({"z_source", "a_source"}), id="frozenset"),
+        ],
+    )
+    def test_legacy_unordered_input_uses_stable_name_order(self, unordered_input: object) -> None:
+        result = Options(context={IN_FEATURES: unordered_input}).get_in_features()
+
+        assert isinstance(result, tuple)
+        assert [feature.name for feature in result] == ["a_source", "z_source"]

--- a/tests/test_core/test_api/feature_config/test_feature_config_chained.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_chained.py
@@ -89,8 +89,7 @@ def test_load_chained_feature_as_string() -> None:
     # The in_features should be added to options as in_features
     # It should be in the context section, not group, as a frozenset
     in_features_value = feature.options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset)
-    assert in_features_value == frozenset({"age"})
+    assert in_features_value == ("age",)
 
     # Original options should still be preserved in group
     assert feature.options.group.get("param") == "value"
@@ -146,7 +145,6 @@ def test_load_chained_feature_from_config() -> None:
     assert isinstance(result[2], Feature)
     assert result[2].name == "age__scale"
     in_features_value = result[2].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset)
-    assert in_features_value == frozenset({"age"})
+    assert in_features_value == ("age",)
     # Original options should be preserved in group
     assert result[2].options.group.get("method") == "standard"

--- a/tests/test_core/test_api/feature_config/test_feature_config_end2end.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_end2end.py
@@ -86,7 +86,7 @@ def test_integration_json_file() -> None:
     assert features[8].name == "age__max_aggr"
     # The in_features should be a frozenset referencing feature 7
     mloda_source_8 = features[8].options.context.get("in_features")
-    assert mloda_source_8 == frozenset({"minmaxscaledage"})
+    assert mloda_source_8 == ("minmaxscaledage",)
 
     # Tenth feature: min_max with in_features="age__max_aggr" in options
     assert isinstance(features[9], Feature)
@@ -105,8 +105,7 @@ def test_integration_json_file() -> None:
     assert features[11].name == "custom_geo_distance"
     # Verify in_features is converted to frozenset and stored correctly
     in_features_11 = features[11].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_11, frozenset)
-    assert in_features_11 == frozenset(["customer_location", "store_location"])
+    assert in_features_11 == ("customer_location", "store_location")
     assert features[11].options.context.get("distance_type") == "euclidean"
 
 
@@ -361,8 +360,7 @@ def test_end2end_multiple_source_features() -> None:
     assert features[5].name == "distance_feature"
     # Verify in_features is converted to frozenset
     in_features_5 = features[5].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_5, frozenset)
-    assert in_features_5 == frozenset(["latitude", "longitude"])
+    assert in_features_5 == ("latitude", "longitude")
     # Verify options are correctly set
     assert features[5].options.group.get("distance_type") == "euclidean"
 
@@ -371,8 +369,7 @@ def test_end2end_multiple_source_features() -> None:
     assert features[6].name == "multi_source_aggregation"
     # Verify in_features is converted to frozenset
     in_features_6 = features[6].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_6, frozenset)
-    assert in_features_6 == frozenset(["sales", "revenue", "profit"])
+    assert in_features_6 == ("sales", "revenue", "profit")
     # Verify options are correctly set
     assert features[6].options.group.get("aggregation") == "sum"
 
@@ -381,8 +378,7 @@ def test_end2end_multiple_source_features() -> None:
     assert features[7].name == "feature_with_both"
     # Verify in_features is converted to frozenset
     in_features_7 = features[7].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_7, frozenset)
-    assert in_features_7 == frozenset(["latitude", "longitude"])
+    assert in_features_7 == ("latitude", "longitude")
     # Verify group options are correctly set
     assert features[7].options.group.get("cache_enabled") is True
     # Verify context options are correctly set (in addition to in_features)
@@ -477,7 +473,7 @@ def test_complete_integration_json() -> None:
     assert isinstance(features[8], Feature), "Feature with aggregation should be a Feature object"
     assert features[8].name == "age__max_aggr", "Feature name should be 'age__max_aggr'"
     mloda_source_8 = features[8].options.context.get("in_features")
-    assert mloda_source_8 == frozenset({"minmaxscaledage"}), "in_features should be frozenset with 'minmaxscaledage'"
+    assert mloda_source_8 == ("minmaxscaledage",), "in_features should be frozenset with 'minmaxscaledage'"
     validated_patterns["feature_reference"] = True
 
     # Feature index 9: min_max with in_features="age__max_aggr" in options
@@ -501,8 +497,7 @@ def test_complete_integration_json() -> None:
     assert isinstance(features[11], Feature), "Second multi-source feature should be a Feature object"
     assert features[11].name == "custom_geo_distance", "Feature name should be 'custom_geo_distance'"
     in_features_11 = features[11].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_11, frozenset), "in_features should be converted to frozenset"
-    assert in_features_11 == frozenset(["customer_location", "store_location"]), (
+    assert in_features_11 == ("customer_location", "store_location"), (
         "in_features should contain customer_location and store_location"
     )
     assert features[11].options.context.get("distance_type") == "euclidean", "distance_type should be 'euclidean'"

--- a/tests/test_core/test_api/feature_config/test_feature_config_loader.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_loader.py
@@ -116,8 +116,7 @@ def test_load_features_with_mloda_source() -> None:
 
     # in_features should be in options.context as a frozenset
     in_features_value = result[0].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset)
-    assert in_features_value == frozenset({"age"})
+    assert in_features_value == ("age",)
 
     # Regular options should be in options.group
     assert result[0].options.group.get("method") == "standard"
@@ -168,8 +167,7 @@ def test_load_features_mixed_chained_and_simple() -> None:
     assert isinstance(result[2], Feature)
     assert result[2].name == "standard_scaled__mean_imputed__age"
     in_features_value = result[2].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset)
-    assert in_features_value == frozenset({"age"})
+    assert in_features_value == ("age",)
     assert result[2].options.group.get("method") == "robust"
 
     # Fourth feature: simple string
@@ -389,8 +387,7 @@ def test_load_appends_tilde_syntax_to_name() -> None:
     assert isinstance(result[1], Feature)
     assert result[1].name == "scale__mean_imputed__age~1"
     in_features_value = result[1].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset)
-    assert in_features_value == frozenset({"age"})
+    assert in_features_value == ("age",)
     assert result[1].options.group.get("scaler") == "robust"
 
     # Third: with group_options and context_options
@@ -494,7 +491,7 @@ def test_load_features_accepts_in_features_array_of_names() -> None:
 
     assert len(result) == 1
     assert isinstance(result[0], Feature)
-    assert result[0].options.context.get(DefaultOptionKeys.in_features) == frozenset({"age", "weight"})
+    assert result[0].options.context.get(DefaultOptionKeys.in_features) == ("age", "weight")
 
 
 def test_load_features_with_multiple_in_features() -> None:
@@ -533,8 +530,7 @@ def test_load_features_with_multiple_in_features() -> None:
 
     # in_features should be converted to frozenset in options.context with singular key name
     in_features_value = result[0].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset), "in_features should be converted to frozenset"
-    assert in_features_value == frozenset({"latitude", "longitude"})
+    assert in_features_value == ("latitude", "longitude")
 
     # Regular options should still be in options.group
     assert result[0].options.group.get("distance_type") == "euclidean"
@@ -575,17 +571,15 @@ def test_load_creates_frozenset_for_in_features() -> None:
     assert isinstance(result[0], Feature)
     assert result[0].name == "multi_source_aggregation"
     in_features_1 = result[0].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_1, frozenset), "Should be frozenset"
-    assert in_features_1 == frozenset({"sales", "revenue", "profit"})
+    assert in_features_1 == ("sales", "revenue", "profit")
     assert result[0].options.group.get("aggregation") == "sum"
 
     # Second feature: duplicates should be deduplicated by frozenset
     assert isinstance(result[1], Feature)
     assert result[1].name == "duplicate_sources"
     in_features_2 = result[1].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_2, frozenset), "Should be frozenset"
     # frozenset automatically handles duplicates - should contain 2 items, not 3
-    assert in_features_2 == frozenset({"feature1", "feature2"})
+    assert in_features_2 == ("feature1", "feature2")
     assert len(in_features_2) == 2
     assert result[1].options.group.get("method") == "combine"
 
@@ -623,8 +617,7 @@ def test_load_adds_in_features_to_in_features_option() -> None:
     # Should have in_features (singular) in context
     assert DefaultOptionKeys.in_features in result[0].options.context
     in_features_value_0 = result[0].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value_0, frozenset)
-    assert in_features_value_0 == frozenset({"age"})
+    assert in_features_value_0 == ("age",)
 
     # Second feature: multiple sources - stored as frozenset in in_features
     assert isinstance(result[1], Feature)
@@ -632,8 +625,7 @@ def test_load_adds_in_features_to_in_features_option() -> None:
     # Should have in_features (singular) in context (unified key for both single and multiple)
     assert DefaultOptionKeys.in_features in result[1].options.context
     in_features_value = result[1].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_value, frozenset)
-    assert in_features_value == frozenset({"latitude", "longitude"})
+    assert in_features_value == ("latitude", "longitude")
 
 
 def test_nested_feature_branch_follows_the_enum_value(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_core/test_api/feature_config/test_feature_config_multi_source.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_multi_source.py
@@ -100,8 +100,7 @@ def test_load_multiple_sources_as_frozenset() -> None:
     # in_features should be converted to frozenset and stored in context
     # Note: Using DefaultOptionKeys.in_features (singular)
     in_features = result[0].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features, frozenset)
-    assert in_features == frozenset({"latitude", "longitude"})
+    assert in_features == ("latitude", "longitude")
 
     # Regular options should be in group
     assert result[0].options.group.get("method") == "haversine"
@@ -112,8 +111,7 @@ def test_load_multiple_sources_as_frozenset() -> None:
 
     # in_features should be converted to frozenset and stored in context
     in_features_2 = result[1].options.context.get(DefaultOptionKeys.in_features)
-    assert isinstance(in_features_2, frozenset)
-    assert in_features_2 == frozenset({"width", "height"})
+    assert in_features_2 == ("width", "height")
 
     # Group options should be in group
     assert result[1].options.group.get("unit") == "square_meters"

--- a/tests/test_core/test_api/feature_config/test_feature_config_nested_modern_options.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_nested_modern_options.py
@@ -432,7 +432,7 @@ def test_loader_does_not_write_in_features_into_parsed_context_options(monkeypat
     }
     outer = _single_feature(config)
 
-    assert outer.options.context.get(DefaultOptionKeys.in_features) == frozenset({"age"})
+    assert outer.options.context.get(DefaultOptionKeys.in_features) == ("age",)
 
     parsed = captured[0]
     assert isinstance(parsed, FeatureConfig)
@@ -523,7 +523,7 @@ def test_top_level_in_features_with_group_options_still_lands_in_context() -> No
 
     assert outer.options.group == {"threshold": 0.5}
     assert outer.options.context.get("metadata") == "test"
-    assert outer.options.context.get(DefaultOptionKeys.in_features) == frozenset({"age"})
+    assert outer.options.context.get(DefaultOptionKeys.in_features) == ("age",)
 
 
 def test_column_index_suffix_still_applied_with_group_options() -> None:
@@ -567,7 +567,7 @@ def test_in_features_branch_with_options_still_loads() -> None:
     outer = _single_feature(config)
 
     assert outer.options.group == {"method": "standard"}
-    assert outer.options.context.get(DefaultOptionKeys.in_features) == frozenset({"age"})
+    assert outer.options.context.get(DefaultOptionKeys.in_features) == ("age",)
 
 
 def test_options_branch_collision_with_top_level_in_features_still_raises() -> None:

--- a/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_geo_distance.py
+++ b/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_geo_distance.py
@@ -2,6 +2,11 @@
 Tests for the GeoDistanceFeatureGroup.
 """
 
+import json
+import os
+import subprocess  # nosec B404
+import sys
+
 import pandas as pd
 import pytest
 
@@ -32,6 +37,35 @@ class TestGeoDistanceFeatureGroup:
 
         with pytest.raises(ValueError):
             GeoDistanceFeatureGroup.get_point_features("point1__haversine_distance")
+
+    def test_config_operand_order_is_stable_across_hash_seeds(self) -> None:
+        """Config declarations keep point1 and point2 stable in fresh interpreters."""
+        code = """
+import json
+
+from mloda.core.api.feature_config.loader import load_features_from_config
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+
+feature = load_features_from_config(
+    '[{"name": "distance", "in_features": ["z_source", "a_source"], '
+    '"options": {"distance_type": "euclidean"}}]'
+)[0]
+_, point1, point2 = GeoDistanceFeatureGroup._extract_geo_distance_parameters(feature)
+print(json.dumps([str(point1), str(point2)]))
+"""
+
+        for seed in ("1", "2", "3", "17", "42"):
+            env = os.environ.copy()
+            env["PYTHONHASHSEED"] = seed
+            completed = subprocess.run(  # nosec B603
+                [sys.executable, "-c", code],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            assert json.loads(completed.stdout) == ["z_source", "a_source"], f"PYTHONHASHSEED={seed}"
 
     def test_match_feature_group_criteria(self) -> None:
         """Test matching of feature names to feature group criteria."""


### PR DESCRIPTION
<!--
Thanks for contributing to mloda! A few notes before you submit:
- Use a Conventional Commit style PR title (e.g. `fix:`, `feat:`, `docs:`, `chore:`).
- Keep the description focused; delete sections that don't apply.
-->

## Summary

Preserves the declared order of in_features instead of converting ordered inputs to frozenset. The config loader was updated as well so multi-source features,like geo-distance, keep a stable  order. Tests were AI-assisted but checked and reviewed. 

## Related issue

Closes #1237

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [X] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [X] Tests added or updated for the change (and the skip count adjusted if needed)
- [X] Documentation updated where relevant
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
