### PR TITLE
feat: add otel alias extra now that the registry package is released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ duckdb = ["duckdb", "pyarrow"]
 sqlite = ["pyarrow"]
 iceberg = ["pyiceberg", "pyarrow"]
 spark = ["pyspark", "pyarrow"]
+# mloda-community-otel pins mloda core to a version range; a version bump of mloda core past that
+# range makes uv lock fail with this extra enabled. Widen the pin in mloda-community-otel first.
+otel = ["mloda-community-otel>=0.4.6"]
 sklearn = [
     "scikit-learn>=1.0.0",
     "joblib>=1.0.0",
@@ -165,7 +168,9 @@ extend-select = ["UP006", "UP007"]
 exclude-newer = "7 days"
 # decorator 5.3.0 ships empty License metadata so pip-licenses can't classify it; 5.3.1 fixes this.
 # Opt decorator out of the rolling window so the latest published version is always accepted.
-exclude-newer-package = { decorator = "2099-01-01T00:00:00Z" }
+# mloda-community-otel is mloda's own registry package (same org/maintainer); the 7-day buffer
+# mainly guards against unvetted third-party releases, so opt it out like decorator.
+exclude-newer-package = { decorator = "2099-01-01T00:00:00Z", mloda-community-otel = "2099-01-01T00:00:00Z" }
 # Constraints applied only to transitive dependencies to remediate Dependabot security alerts.
 # - urllib3 >= 2.7.0: GHSA decompression-bomb bypass + sensitive headers across origins
 # - idna   >= 3.15:   idna.encode() bypass of CVE-2024-3651 fix

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
@@ -221,5 +221,5 @@ class TestPluginLoader:
                     PluginLoader.all()
 
     def test_optional_plugin_dependencies_has_no_orphaned_opentelemetry_entry(self) -> None:
-        """opentelemetry was only imported by OtelExtender, deleted on this branch; nothing imports it now."""
+        """mloda core has no first-party opentelemetry import; mloda-community-otel is an external package."""
         assert "opentelemetry" not in OPTIONAL_PLUGIN_DEPENDENCIES

--- a/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
+++ b/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -38,6 +41,18 @@ def test_sqlite_extra_exists_and_contains_pyarrow() -> None:
     assert "sqlite" in optional, f"No sqlite extra found in pyproject.toml. Available extras: {list(optional.keys())}"
     sqlite_deps = optional["sqlite"]
     assert any("pyarrow" in dep for dep in sqlite_deps), f"Expected pyarrow in sqlite extra. Got: {sqlite_deps}"
+
+
+def test_otel_extra_exists_and_aliases_registry_package() -> None:
+    """An otel optional-dependency extra must exist and be a pure alias of mloda-community-otel."""
+    optional = _load_optional_deps()
+    assert "otel" in optional, f"No otel extra found in pyproject.toml. Available extras: {list(optional.keys())}"
+    otel_deps = optional["otel"]
+    assert len(otel_deps) == 1, f"Expected otel extra to be a single-package alias. Got: {otel_deps}"
+    canonical_names = {canonicalize_name(Requirement(dep).name) for dep in otel_deps}
+    assert canonicalize_name("mloda-community-otel") in canonical_names, (
+        f"Expected mloda-community-otel in otel extra. Got: {otel_deps}"
+    )
 
 
 def test_all_extra_references_sqlite() -> None:

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -121,7 +121,9 @@ def _normalize_extra_name(name: str) -> str:
 class TestExtrasConsistency:
     # nopyarrow_test is a test-only extra that must omit pyarrow (used by the
     # nopyarrow tox env); like spark, it is intentionally not part of [all].
-    INTENTIONALLY_EXCLUDED_FROM_ALL = {"all", "spark", "nopyarrow_test"}
+    # otel pins its own compatible mloda version range, so bundling it into [all]
+    # would couple mloda[all]'s installability to that external package's release cadence.
+    INTENTIONALLY_EXCLUDED_FROM_ALL = {"all", "spark", "nopyarrow_test", "otel"}
 
     def test_all_extras_uses_self_references(self) -> None:
         extras = _load_extras()
@@ -140,6 +142,17 @@ class TestExtrasConsistency:
 
         missing = expected_normalized - referenced_normalized
         assert not missing, f"[all] is missing references to extras groups: {missing}"
+
+    def test_excluded_groups_absent_from_all(self) -> None:
+        extras = _load_extras()
+        referenced = {entry.split("[")[1].rstrip("]") for entry in extras["all"]}
+        referenced_normalized = {_normalize_extra_name(r) for r in referenced}
+
+        excluded_groups = self.INTENTIONALLY_EXCLUDED_FROM_ALL - {"all"}
+        excluded_normalized = {_normalize_extra_name(g) for g in excluded_groups}
+
+        reintroduced = excluded_normalized & referenced_normalized
+        assert not reintroduced, f"[all] must not reference intentionally-excluded extras groups: {reintroduced}"
 
     def test_scikit_learn_version_consistent(self) -> None:
         extras = _load_extras()

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 decorator = "2099-01-01T00:00:00Z"
+mloda-community-otel = "2099-01-01T00:00:00Z"
 
 [manifest]
 constraints = [
@@ -1479,6 +1480,9 @@ nopyarrow-test = [
     { name = "pytest-xdist" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
+otel = [
+    { name = "mloda-community-otel" },
+]
 pandas = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1551,6 +1555,7 @@ requires-dist = [
     { name = "mloda", extras = ["sqlite"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["test"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["text-cleaning"], marker = "extra == 'all'" },
+    { name = "mloda-community-otel", marker = "extra == 'otel'", specifier = ">=0.4.6" },
     { name = "mypy", marker = "extra == 'test'" },
     { name = "nltk", marker = "extra == 'text-cleaning'", specifier = ">=3.8" },
     { name = "notebook", marker = "extra == 'docs'" },
@@ -1584,7 +1589,19 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'test'" },
     { name = "types-toml", marker = "extra == 'test'" },
 ]
-provides-extras = ["test", "pyarrow", "pandas", "polars", "duckdb", "sqlite", "iceberg", "spark", "sklearn", "text-cleaning", "nopyarrow-test", "docs", "all"]
+provides-extras = ["test", "pyarrow", "pandas", "polars", "duckdb", "sqlite", "iceberg", "spark", "otel", "sklearn", "text-cleaning", "nopyarrow-test", "docs", "all"]
+
+[[package]]
+name = "mloda-community-otel"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mloda" },
+    { name = "opentelemetry-api" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d1/ccf96b74658350fa12c18914b8c12d34e9052c0cd16727dede8e60700955/mloda_community_otel-0.4.6-py3-none-any.whl", hash = "sha256:d0702c55bd794a59b64aac6e88041dab585cf497e9bf876f2faf2468b0500a53", size = 5798, upload-time = "2026-09-05T07:56:49.283Z" },
+]
 
 [[package]]
 name = "mmh3"
@@ -2092,6 +2109,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/22/5f378a9d4633c98f28c4709d4144b1a4630c5c09e109d2e781e2d26c8fe1/numpy-2.4.5-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0e63caf31a1df06338ae63d999f7a33a675ced62eea9c9b02db4b1c1f45cff38", size = 15798292, upload-time = "2026-05-15T20:25:10.689Z" },
     { url = "https://files.pythonhosted.org/packages/63/1c/cec582febef798c99888892d92dc1d28dfe29cb427c41f44d13d0dec208f/numpy-2.4.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d8fc52b85a7b45e474be53eddf08e006d22e381a4e41bcde8e4aa08da0e7d198", size = 16747406, upload-time = "2026-05-15T20:25:13.879Z" },
     { url = "https://files.pythonhosted.org/packages/b1/dc/d358a16a6fec86cf736b8fbe67386044b3fa2aded1a80cff90e836799301/numpy-2.4.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:40c71d50a4da1a7c317af419461052d3911a5770bfc5fd55baf52cc45e7a2c20", size = 12504085, upload-time = "2026-05-15T20:25:16.667Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
mloda core previously shipped an `otel` extra that installed opentelemetry
packages directly for a no-op OtelExtender stub. That was removed once the
real implementation moved to a separate registry package,
`mloda-community-otel`, which was merged but not yet published.

That package is now on PyPI, so this restores the `otel` extra as an alias:

```
otel = ["mloda-community-otel>=0.4.6"]
```

It is intentionally left out of the `all` extra, matching how `spark` and
`nopyarrow_test` are also excluded, so `mloda[all]` doesn't inherit the
registry package's own compatible-version range.

A comment documents a real coupling risk: mloda-community-otel pins an
upper bound on mloda core itself, so a future mloda minor release needs a
compatible mloda-community-otel release first, or `uv lock` will fail for
this extra.

Also tightens the pyproject.toml extras tests: the otel alias assertion now
parses the dependency name properly instead of a substring match, and a new
test locks in that intentionally-excluded extras groups never sneak back
into `all`.