### PR TITLE
fix: topologically sort colliding link ids in LinkTrekker

### DIFF
--- a/mloda/core/prepare/resolve_links.py
+++ b/mloda/core/prepare/resolve_links.py
@@ -121,51 +121,39 @@ class LinkTrekker:
                         adjust_order(self.data, k_out, k_in)
 
     def order_ordered_ids_by_relation(self) -> None:
-        """
-        We have currently this:
-        odict_items([(UUID('cad2bdde-3028-47c3-a79b-53110c51a2dd'), {UUID('022d7fe1-2ef6-4d9a-83aa-832738575920')}),
-                    (UUID('022d7fe1-2ef6-4d9a-83aa-832738575920'), {UUID('11b118b5-d714-48ff-87ab-190ecd286f61')})])
-        or
-        odict_items([(UUID('022d7fe1-2ef6-4d9a-83aa-832738575920'), {UUID('11b118b5-d714-48ff-87ab-190ecd286f61')}),
-                    (UUID('cad2bdde-3028-47c3-a79b-53110c51a2dd'), {UUID('022d7fe1-2ef6-4d9a-83aa-832738575920')})])
+        """Stable topological sort (Kahn's algorithm), one id at a time: self.order[k] = {v, ...} means k must
+        precede each v; among all currently-ready ids, the one earliest in the original insertion order is always
+        placed next, a self-edge is a no-op, and any leftover cycle falls back to the original insertion order."""
 
-        The second case is not ok, as this would mean that the first link depends on the second link. This is not the case.
-        Therefore, we reorder this in here.
-        """
+        ids: list[UUID] = list(self.order.keys())
+        id_set: set[UUID] = set(ids)
 
-        new_order: OrderedDict[UUID, set[UUID]] = OrderedDict()
-        pos_marker: dict[int, tuple[UUID, set[UUID]]] = {}
+        edges: dict[UUID, set[UUID]] = {
+            node: {v for v in self.order[node] if v in id_set and v != node} for node in ids
+        }
 
-        for o_pos, (o_uuid, o_set) in enumerate(self.order.items()):
-            latest_position = None
+        in_degree: dict[UUID, int] = dict.fromkeys(ids, 0)
+        for node in ids:
+            for v in edges[node]:
+                in_degree[v] += 1
 
-            for i_pos, (i_uuid, i_set) in enumerate(self.order.items()):
-                if o_pos >= i_pos:
+        placed: set[UUID] = set()
+        result: list[UUID] = []
+
+        while len(placed) < len(ids):
+            for node in ids:
+                if node in placed or in_degree[node] > 0:
                     continue
-
-                if o_uuid not in i_set:
-                    continue
-
-                latest_position = i_pos
-
-            if latest_position is None:
-                new_order[o_uuid] = o_set
+                result.append(node)
+                placed.add(node)
+                for v in edges[node]:
+                    in_degree[v] -= 1
+                break
             else:
-                # remembering latest position
-                while latest_position in pos_marker:
-                    latest_position += 1
-                pos_marker[latest_position] = (o_uuid, o_set)
+                result.extend(node for node in ids if node not in placed)
+                break
 
-        if len(pos_marker.keys()):
-            max_latest_pos = max(pos_marker.keys())
-
-            for i in range(max_latest_pos + 1):
-                if i in pos_marker:
-                    uuid, uuid_set = pos_marker[i]
-                    new_order[uuid] = uuid_set
-                    new_order.move_to_end(uuid)
-
-            self.order = new_order
+        self.order = OrderedDict((node, self.order[node]) for node in result)
 
     def order_links_by_frameworks(self) -> None:
         for trekker, uuids in self.data.items():

--- a/tests/test_core/test_prepare/test_resolve_links.py
+++ b/tests/test_core/test_prepare/test_resolve_links.py
@@ -23,3 +23,69 @@ def test_order_ordered_ids_by_relation_keeps_both_ids_that_collide_on_one_positi
     trekker.order_ordered_ids_by_relation()
 
     assert list(trekker.order.keys()) == [uuid_c, uuid_a, uuid_b]
+
+
+def test_order_ordered_ids_by_relation_respects_precedence_among_colliding_ids() -> None:
+    """Colliding entries (A, B) that both precede D must keep their own relative precedence order."""
+    trekker = LinkTrekker()
+    uuid_a = uuid4()
+    uuid_b = uuid4()
+    uuid_c = uuid4()
+    uuid_d = uuid4()
+    uuid_z = uuid4()
+
+    trekker.order = OrderedDict(
+        [
+            (uuid_c, {uuid_a}),
+            (uuid_a, {uuid_z}),
+            (uuid_b, {uuid_a}),
+            (uuid_d, {uuid_a, uuid_b}),
+        ]
+    )
+
+    trekker.order_ordered_ids_by_relation()
+
+    order_index = {uuid_id: pos for pos, uuid_id in enumerate(trekker.order.keys())}
+
+    assert order_index[uuid_c] < order_index[uuid_a]
+    assert order_index[uuid_b] < order_index[uuid_a]
+    assert order_index[uuid_d] < order_index[uuid_a]
+    assert order_index[uuid_d] < order_index[uuid_b]
+
+
+def test_order_ordered_ids_by_relation_does_not_reorder_an_already_valid_order() -> None:
+    """An id with no relation to anything must not be pulled ahead of a later, unrelated-but-required successor."""
+    trekker = LinkTrekker()
+    uuid_p = uuid4()
+    uuid_q = uuid4()
+    uuid_r = uuid4()
+
+    trekker.order = OrderedDict(
+        [
+            (uuid_p, {uuid_q}),
+            (uuid_q, set()),
+            (uuid_r, set()),
+        ]
+    )
+
+    trekker.order_ordered_ids_by_relation()
+
+    assert list(trekker.order.keys()) == [uuid_p, uuid_q, uuid_r]
+
+
+def test_order_ordered_ids_by_relation_treats_a_self_edge_as_a_no_op() -> None:
+    """A self-referencing entry imposes no real ordering constraint and must not be pushed after unrelated ids."""
+    trekker = LinkTrekker()
+    uuid_k = uuid4()
+    uuid_m = uuid4()
+
+    trekker.order = OrderedDict(
+        [
+            (uuid_k, {uuid_k}),
+            (uuid_m, set()),
+        ]
+    )
+
+    trekker.order_ordered_ids_by_relation()
+
+    assert list(trekker.order.keys()) == [uuid_k, uuid_m]


### PR DESCRIPTION
## Summary

`LinkTrekker.order_ordered_ids_by_relation` resolved position collisions with position arithmetic that never checked whether the colliding entries had a direct or transitive precedence relationship with each other. This could produce a final order that was complete (nothing missing or duplicated) but topologically wrong, for example placing an entry before another entry that was required to precede it.

## Change

Replaces the collision handling with a stable topological sort over the same `self.order` precedence graph:

- Among ids with no remaining unmet precedence, the one earliest in the original insertion order is always placed next, so unrelated ids keep their original relative order.
- A self-referencing entry imposes no ordering constraint (a no-op), matching how self-waits are already treated downstream.
- A leftover cycle (not expected in practice, since a prior step already removes direct two-entry cycles) falls back to appending the remaining ids in their original order instead of looping indefinitely.

## Tests

Added coverage for: colliding entries with a precedence relationship end up in the correct relative order, an already-valid order is left unchanged, and a self-referencing entry is a no-op.