### PR TITLE
minor: expose CompositeExtender as public API via mloda.steward

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -84,7 +84,7 @@
 | strictyaml              | 1.7.3           | MIT License                                        |
 | tenacity                | 9.1.4           | Apache Software License                            |
 | threadpoolctl           | 3.6.0           | BSD License                                        |
-| tornado                 | 6.5.7           | Apache Software License                            |
+| tornado                 | 6.5.8           | Apache Software License                            |
 | tqdm                    | 4.67.3          | MPL-2.0 AND MIT                                    |
 | traitlets               | 5.15.0          | BSD License                                        |
 | typeguard               | 4.5.2           | MIT                                                |

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -203,7 +203,7 @@ Every failure a plugin can cause falls into one of three tiers:
   `available_only=True`, exactly as a genuinely unavailable one would be.
 - **Skip.** An entry that is not meant to be documented is dropped silently:
   classes defined in `__main__`, and the abstract bases (`get_extender_docs`
-  skips `Extender` and `_CompositeExtender` explicitly; the FeatureGroup and
+  skips `Extender` and `CompositeExtender` explicitly; the FeatureGroup and
   ComputeFramework roots never appear because `get_all_subclasses` omits them).
   Redefinition duplicates are collapsed rather than listed twice (see below).
 - **Propagate.** Errors that are not a single plugin's introspection fault are

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -13,7 +13,7 @@ from mloda.core.abstract_plugins.components.utils import as_str, safe_field
 from mloda.core.abstract_plugins.function_extender import (
     Extender,
     ExtenderHook,
-    _CompositeExtender,
+    CompositeExtender,
     _invoke_extender,
 )
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -736,7 +736,7 @@ class ComputeFramework(ABC):
             return matching_extenders[0]
 
         sorted_extenders = sorted(matching_extenders, key=lambda e: e.priority)
-        return _CompositeExtender(sorted_extenders, wrapper_function_enum)
+        return CompositeExtender(sorted_extenders, wrapper_function_enum)
 
     @final
     def _build_hook_context(self, hook: ExtenderHook, feature_group: Any, features: Any) -> HookContext:

--- a/mloda/core/abstract_plugins/function_extender.py
+++ b/mloda/core/abstract_plugins/function_extender.py
@@ -125,18 +125,21 @@ class Extender(ABC):
 
 
 def get_function_extender(function_extender: set[Extender], hook: ExtenderHook) -> Optional[Extender]:
-    """Select the Extender(s) wrapping hook: None, the sole match, or a priority-sorted _CompositeExtender."""
+    """Select the Extender(s) wrapping hook: None, the sole match, or a priority-sorted CompositeExtender."""
     matching_extenders = [ext for ext in function_extender if hook in ext.wraps()]
     if len(matching_extenders) == 0:
         return None
     if len(matching_extenders) == 1:
         return matching_extenders[0]
     sorted_extenders = sorted(matching_extenders, key=lambda e: e.priority)
-    return _CompositeExtender(sorted_extenders, hook)
+    return CompositeExtender(sorted_extenders, hook)
 
 
-class _CompositeExtender(Extender):
-    """Internal class that chains multiple Extenders in priority order."""
+class CompositeExtender(Extender):
+    """Chains multiple Extenders together, running them in priority order.
+
+    Constructed internally by get_function_extender(); not meant to be subclassed or instantiated directly.
+    """
 
     def __init__(self, extenders: list[Extender], function_type: Optional[ExtenderHook] = None):
         self.extenders = sorted(extenders, key=lambda e: e.priority)

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -294,7 +294,7 @@ def get_extender_docs(
         description = (ext_class.__doc__ or "").strip() or ext_class.__name__
         module = ext_class.__module__
 
-        if ext_name in ("Extender", "_CompositeExtender"):
+        if ext_name in ("Extender", "CompositeExtender"):
             continue
 
         wraps_list: list[str] = safe_field(lambda: [w.value for w in ext_class().wraps()], [])

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -20,6 +20,7 @@ from mloda.core.api.plugin_docs import (
 from mloda.core.abstract_plugins.function_extender import (
     Extender,
     ExtenderHook,
+    CompositeExtender,
 )
 from mloda.core.abstract_plugins.hook_context import HookContext
 
@@ -65,6 +66,7 @@ __all__ = [
     "Extender",
     "ExtenderHook",
     "HookContext",
+    "CompositeExtender",
     # Server-verified tenant/project/principal context seam
     "verified_context",
     # Plugin registry administration

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_first_party_plugin_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_first_party_plugin_registration.py
@@ -50,7 +50,7 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook, _CompositeExtender
+from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook, CompositeExtender
 from mloda.core.abstract_plugins.plugin_loader.plugin_loader import (
     CORE_PLUGIN_MODULES,
     OPTIONAL_PLUGIN_DEPENDENCIES,
@@ -77,9 +77,9 @@ WHEEL_ROOTS: tuple[str, ...] = ("mloda", "mloda_plugins")
 # the pyproject wheel excludes by test_reserved_namespaces_stay_in_sync_with_pyproject below.
 RESERVED_NAMESPACES: tuple[str, ...] = ("mloda.community", "mloda.enterprise", "mloda.registry", "mloda.testing")
 
-# The one waiver: _CompositeExtender is composed inside ComputeFramework.get_function_extender from an
+# The one waiver: CompositeExtender is composed inside ComputeFramework.get_function_extender from an
 # already-filtered extender set, so it never passes through the strict-mode gate (pinned below).
-_NOT_REGISTRY_GATED: frozenset[type[Any]] = frozenset({_CompositeExtender})
+_NOT_REGISTRY_GATED: frozenset[type[Any]] = frozenset({CompositeExtender})
 
 CORE_DRIFT_MODULE = "mloda.core.first_party_guard_drift_probe"
 
@@ -89,7 +89,7 @@ class _GuardObserverFeatureGroup(FeatureGroup):
 
 
 class _ExtenderHostFramework(ComputeFramework):
-    """Host used to build a _CompositeExtender through the real get_function_extender path."""
+    """Host used to build a CompositeExtender through the real get_function_extender path."""
 
 
 class _GuardExtenderA(Extender):
@@ -341,20 +341,20 @@ class TestGuardDetectsCoreDrift:
 
 
 class TestCompositeExtenderExclusion:
-    """_CompositeExtender is waived by name in _NOT_REGISTRY_GATED, not by a private-name rule."""
+    """CompositeExtender is waived by name in _NOT_REGISTRY_GATED, not by a private-name rule."""
 
     @pytest.mark.timeout(30)
     def test_composite_extender_is_waived_and_would_otherwise_be_flagged(self) -> None:
-        assert _is_bundled_plugin(_CompositeExtender), "sanity: it ships in the wheel"
-        assert not inspect.isabstract(_CompositeExtender), "sanity: it is concrete"
-        assert _CompositeExtender in _NOT_REGISTRY_GATED, "the exclusion must be an explicit waiver"
+        assert _is_bundled_plugin(CompositeExtender), "sanity: it ships in the wheel"
+        assert not inspect.isabstract(CompositeExtender), "sanity: it is concrete"
+        assert CompositeExtender in _NOT_REGISTRY_GATED, "the exclusion must be an explicit waiver"
 
         registered = {_qualid(cls) for cls in _loaded_registry().registered_classes()}
-        assert _qualid(_CompositeExtender) not in registered, (
-            "sanity: no loader path registers _CompositeExtender, so only the waiver keeps it out of the guard"
+        assert _qualid(CompositeExtender) not in registered, (
+            "sanity: no loader path registers CompositeExtender, so only the waiver keeps it out of the guard"
         )
-        assert _qualid(_CompositeExtender) not in _unregistered_wheel_owned(Extender), (
-            "the waiver must keep _CompositeExtender out of the guard: it is internal machinery, never a "
+        assert _qualid(CompositeExtender) not in _unregistered_wheel_owned(Extender), (
+            "the waiver must keep CompositeExtender out of the guard: it is internal machinery, never a "
             "registry-gated plugin"
         )
 
@@ -370,10 +370,10 @@ class TestCompositeExtenderExclusion:
 
         framework = _ExtenderHostFramework(function_extender=surviving)
         composite = framework.get_function_extender(ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE)
-        assert isinstance(composite, _CompositeExtender), "sanity: two matching extenders compose"
+        assert isinstance(composite, CompositeExtender), "sanity: two matching extenders compose"
 
         assert filter_extenders_by_strict_mode({composite}, collector) == set(), (
-            "strict mode would drop a _CompositeExtender, since it is unregistered; it is safe only because "
+            "strict mode would drop a CompositeExtender, since it is unregistered; it is safe only because "
             "ComputeFramework.get_function_extender builds it downstream of the filter, which is why the "
             "registration guard waives it instead of demanding a registry entry for it"
         )

--- a/tests/test_plugins/extender/test_composite_extender.py
+++ b/tests/test_plugins/extender/test_composite_extender.py
@@ -13,7 +13,7 @@ from mloda.core.abstract_plugins.function_extender import (
     ExtenderHook,
     Extender,
 )
-from mloda.core.abstract_plugins.function_extender import _CompositeExtender
+from mloda.core.abstract_plugins.function_extender import CompositeExtender
 from mloda.core.abstract_plugins.run_context import RunContext
 from mloda.provider import ComputeFramework
 
@@ -116,41 +116,41 @@ class TestExtenderPriority:
         assert extender.priority == 50, "Priority should be settable to custom value"
 
 
-class Test_CompositeExtender:
-    """Test _CompositeExtender class that chains multiple extenders."""
+class TestCompositeExtender:
+    """Test CompositeExtender class that chains multiple extenders."""
 
     def test_composite_extender_class_exists(self) -> None:
-        """Test that _CompositeExtender class is defined."""
-        # This will fail until _CompositeExtender is implemented
-        assert _CompositeExtender is not None, "_CompositeExtender class must exist"
+        """Test that CompositeExtender class is defined."""
+        # This will fail until CompositeExtender is implemented
+        assert CompositeExtender is not None, "CompositeExtender class must exist"
 
     def test_composite_extender_inherits_from_wrapper(self) -> None:
-        """Test that _CompositeExtender inherits from Extender."""
+        """Test that CompositeExtender inherits from Extender."""
 
-        # This will fail until _CompositeExtender inherits properly
-        assert issubclass(_CompositeExtender, Extender), "_CompositeExtender must inherit from Extender"
+        # This will fail until CompositeExtender inherits properly
+        assert issubclass(CompositeExtender, Extender), "CompositeExtender must inherit from Extender"
 
     def test_composite_extender_accepts_list_of_extenders(self) -> None:
-        """Test that _CompositeExtender can be initialized with a list of extenders."""
+        """Test that CompositeExtender can be initialized with a list of extenders."""
 
         extender1 = MockExtender("first", priority=10)
         extender2 = MockExtender("second", priority=20)
 
-        # This will fail until _CompositeExtender accepts extenders in __init__
-        composite = _CompositeExtender([extender1, extender2])
-        assert composite is not None, "_CompositeExtender should accept list of extenders"
+        # This will fail until CompositeExtender accepts extenders in __init__
+        composite = CompositeExtender([extender1, extender2])
+        assert composite is not None, "CompositeExtender should accept list of extenders"
 
     def test_composite_extender_chains_multiple_extenders(self) -> None:
-        """Test that _CompositeExtender calls all extenders in the chain."""
+        """Test that CompositeExtender calls all extenders in the chain."""
 
         extender1 = MockExtender("first", priority=10)
         extender2 = MockExtender("second", priority=20)
-        composite = _CompositeExtender([extender1, extender2])
+        composite = CompositeExtender([extender1, extender2])
 
         def test_func(x: int, y: int) -> int:
             return x + y
 
-        # This will fail until _CompositeExtender calls all extenders
+        # This will fail until CompositeExtender calls all extenders
         result = composite(test_func, 5, 3)
 
         assert result == 8, "Function should execute correctly"
@@ -158,16 +158,16 @@ class Test_CompositeExtender:
         assert extender2.call_count == 1, "Second extender should be called"
 
     def test_composite_extender_wraps_returns_union(self) -> None:
-        """Test that _CompositeExtender.wraps() returns union of all wrapped types."""
+        """Test that CompositeExtender.wraps() returns union of all wrapped types."""
 
         extender1 = MockExtender("first")
         extender2 = MockExtender("second")
-        composite = _CompositeExtender([extender1, extender2])
+        composite = CompositeExtender([extender1, extender2])
 
-        # This will fail until _CompositeExtender.wraps() returns proper union
+        # This will fail until CompositeExtender.wraps() returns proper union
         wrapped = composite.wraps()
         assert ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE in wrapped, (
-            "_CompositeExtender should wrap all function types from child extenders"
+            "CompositeExtender should wrap all function types from child extenders"
         )
 
 
@@ -195,8 +195,8 @@ class TestExtenderExecutionOrder:
         extender_low = OrderTrackingExtender("low_priority_10", priority=10)
         extender_mid = OrderTrackingExtender("mid_priority_30", priority=30)
 
-        # This will fail until _CompositeExtender sorts by priority
-        composite = _CompositeExtender([extender_high, extender_low, extender_mid])
+        # This will fail until CompositeExtender sorts by priority
+        composite = CompositeExtender([extender_high, extender_low, extender_mid])
 
         def test_func() -> str:
             return "done"
@@ -224,7 +224,7 @@ class TestExtenderErrorResilience:
         extender2 = MockExtender("failing", priority=20, should_fail=True, raise_on_error=False)
         extender3 = MockExtender("third", priority=30)
 
-        composite = _CompositeExtender([extender1, extender2, extender3])
+        composite = CompositeExtender([extender1, extender2, extender3])
 
         def test_func(x: int) -> int:
             return x * 2
@@ -242,7 +242,7 @@ class TestExtenderErrorResilience:
         extender1 = MockExtender("first", priority=10)
         extender2 = MockExtender("failing", priority=20, should_fail=True, raise_on_error=False)
 
-        composite = _CompositeExtender([extender1, extender2])
+        composite = CompositeExtender([extender1, extender2])
 
         def test_func(x: int) -> int:
             return x * 2
@@ -259,7 +259,7 @@ class TestExtenderErrorResilience:
         """Test that errors from the original function are not caught."""
 
         extender = MockExtender("test", priority=10)
-        composite = _CompositeExtender([extender])
+        composite = CompositeExtender([extender])
 
         def failing_func() -> None:
             raise RuntimeError("Original function error")
@@ -270,10 +270,10 @@ class TestExtenderErrorResilience:
 
 
 class TestGetFunctionExtenderWithComposite:
-    """Test that get_function_extender returns _CompositeExtender for multiple matches."""
+    """Test that get_function_extender returns CompositeExtender for multiple matches."""
 
     def test_get_function_extender_returns_composite_for_multiple_matches(self) -> None:
-        """Test that get_function_extender returns a _CompositeExtender when multiple extenders match."""
+        """Test that get_function_extender returns a CompositeExtender when multiple extenders match."""
 
         # Create a mock ComputeFramework with multiple extenders
         extender1 = MockExtender("first", priority=10)
@@ -287,13 +287,13 @@ class TestGetFunctionExtenderWithComposite:
 
         result = compute_fw.get_function_extender(ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE)
 
-        assert isinstance(result, _CompositeExtender), (
-            "get_function_extender should return _CompositeExtender for multiple matches"
+        assert isinstance(result, CompositeExtender), (
+            "get_function_extender should return CompositeExtender for multiple matches"
         )
-        assert isinstance(result, Extender), "_CompositeExtender should be a Extender"
+        assert isinstance(result, Extender), "CompositeExtender should be a Extender"
 
     def test_get_function_extender_preserves_priority_order(self) -> None:
-        """Test that get_function_extender creates _CompositeExtender with correct priority order."""
+        """Test that get_function_extender creates CompositeExtender with correct priority order."""
 
         # Create extenders in non-priority order
         extender_high = MockExtender("high", priority=50)
@@ -304,10 +304,10 @@ class TestGetFunctionExtenderWithComposite:
         compute_fw.function_extender = [extender_high, extender_low, extender_mid]
         compute_fw.get_function_extender = ComputeFramework.get_function_extender.__get__(compute_fw)
 
-        # This will fail until _CompositeExtender sorts extenders by priority
+        # This will fail until CompositeExtender sorts extenders by priority
         result = compute_fw.get_function_extender(ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE)
 
-        assert isinstance(result, _CompositeExtender), "Should return _CompositeExtender"
+        assert isinstance(result, CompositeExtender), "Should return CompositeExtender"
 
         # Execute and verify order
         execution_order = []
@@ -329,7 +329,7 @@ class TestGetFunctionExtenderWithComposite:
 
         result(test_func)
 
-        assert execution_order == ["low", "mid", "high"], "_CompositeExtender should maintain priority order"
+        assert execution_order == ["low", "mid", "high"], "CompositeExtender should maintain priority order"
 
     def test_get_function_extender_single_match_unchanged(self) -> None:
         """Test that get_function_extender returns single extender directly when only one matches."""
@@ -383,7 +383,7 @@ class TestExtenderRaiseOnErrorContractComposite:
         """A DEFAULT (raise_on_error=True) extender that fails must re-raise, not swallow/fall back."""
 
         failing = MockExtender("boom", priority=10, should_fail=True)  # raise_on_error defaults True
-        composite = _CompositeExtender([failing])
+        composite = CompositeExtender([failing])
 
         def test_func(x: int) -> int:
             return x * 2
@@ -397,7 +397,7 @@ class TestExtenderRaiseOnErrorContractComposite:
         call_marker = {"func_calls": 0}
 
         failing = MockExtender("boom", priority=10, should_fail=True)
-        composite = _CompositeExtender([failing])
+        composite = CompositeExtender([failing])
 
         def test_func(x: int) -> int:
             call_marker["func_calls"] += 1
@@ -415,12 +415,12 @@ class TestExtenderRaiseOnErrorContractComposite:
             return x * 2
 
         # Single breaking extender
-        single = _CompositeExtender([MockExtender("boom", priority=10, should_fail=True)])
+        single = CompositeExtender([MockExtender("boom", priority=10, should_fail=True)])
         with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
             single(test_func, 5)
 
         # Adding a second (non-failing) breaking extender must not change the semantics
-        composite = _CompositeExtender(
+        composite = CompositeExtender(
             [
                 MockExtender("boom", priority=10, should_fail=True),
                 MockExtender("ok", priority=20),
@@ -434,7 +434,7 @@ class TestExtenderRaiseOnErrorContractComposite:
 
         failing = MockExtender("soft", priority=10, should_fail=True, raise_on_error=False)
         other = MockExtender("ok", priority=20)
-        composite = _CompositeExtender([failing, other])
+        composite = CompositeExtender([failing, other])
 
         def test_func(x: int) -> int:
             return x * 2
@@ -515,7 +515,7 @@ class TestWarningOnlyDoesNotSwallowInnerErrors:
 
         warn = MockExtender("warn", priority=10, raise_on_error=False)
         breaking = MockExtender("boom", priority=20, should_fail=True, raise_on_error=True)
-        composite = _CompositeExtender([warn, breaking])
+        composite = CompositeExtender([warn, breaking])
 
         with caplog.at_level(logging.WARNING):
             with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
@@ -539,7 +539,7 @@ class TestWarningOnlyDoesNotSwallowInnerErrors:
             raise RuntimeError("inner boom")
 
         warn = MockExtender("warn", priority=10, raise_on_error=False)
-        composite = _CompositeExtender([warn])
+        composite = CompositeExtender([warn])
 
         with pytest.raises(RuntimeError, match="inner boom"):
             composite(base)
@@ -558,7 +558,7 @@ class TestWarningOnlyDoesNotSwallowInnerErrors:
             return x * 3
 
         post_fail = _PostFailExtender("posty", priority=10)
-        composite = _CompositeExtender([post_fail])
+        composite = CompositeExtender([post_fail])
 
         with caplog.at_level(logging.WARNING):
             result = composite(base, 7)

--- a/tests/test_plugins/extender/test_composite_extender_public_api.py
+++ b/tests/test_plugins/extender/test_composite_extender_public_api.py
@@ -1,0 +1,76 @@
+"""Pins the public rename of ``_CompositeExtender`` -> ``CompositeExtender``.
+
+Covers direct import off the underscored name, re-export from ``mloda.steward``,
+``__all__`` membership, absence of the old private name, and a behavioral sanity
+check that the renamed class still chains extenders correctly.
+"""
+
+from typing import Any
+import mloda.core.abstract_plugins.function_extender as function_extender_module
+
+from mloda.core.abstract_plugins.function_extender import ExtenderHook, Extender
+
+
+class _FakeExtender(Extender):
+    """Minimal concrete Extender double, mirrors MockExtender in test_composite_extender.py."""
+
+    def __init__(self, name: str, priority: int = 100) -> None:
+        self.name = name
+        self.priority = priority
+        self.call_count = 0
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        self.call_count += 1
+        return func(*args, **kwargs)
+
+
+def test_composite_extender_importable_from_function_extender_module() -> None:
+    """CompositeExtender (no underscore) must be importable directly from function_extender."""
+    from mloda.core.abstract_plugins.function_extender import CompositeExtender
+
+    assert CompositeExtender is not None
+
+
+def test_composite_extender_importable_from_steward() -> None:
+    """CompositeExtender must be re-exported from the public mloda.steward package."""
+    from mloda.steward import CompositeExtender
+
+    assert CompositeExtender is not None
+
+
+def test_composite_extender_listed_in_steward_all() -> None:
+    """CompositeExtender must be listed in mloda.steward.__all__."""
+    import mloda.steward as steward
+
+    assert "CompositeExtender" in steward.__all__
+
+
+def test_old_private_name_no_longer_exists() -> None:
+    """The rename drops the old private name; it must not remain as an alias."""
+    assert not hasattr(function_extender_module, "_CompositeExtender"), (
+        "_CompositeExtender must be renamed to CompositeExtender, not aliased"
+    )
+
+
+def test_composite_extender_still_chains_and_aggregates() -> None:
+    """The renamed public CompositeExtender still chains extenders and unions wraps()."""
+    from mloda.core.abstract_plugins.function_extender import CompositeExtender
+
+    extender1 = _FakeExtender("first", priority=10)
+    extender2 = _FakeExtender("second", priority=20)
+    composite = CompositeExtender([extender1, extender2])
+
+    wrapped = composite.wraps()
+    assert ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE in wrapped
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    result = composite(add, 5, 3)
+
+    assert result == 8
+    assert extender1.call_count == 1
+    assert extender2.call_count == 1

--- a/tests/test_plugins/extender/test_extender_introspection.py
+++ b/tests/test_plugins/extender/test_extender_introspection.py
@@ -15,7 +15,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.function_extender import (
     Extender,
     ExtenderHook,
-    _CompositeExtender,
+    CompositeExtender,
 )
 
 
@@ -209,14 +209,14 @@ class TestHookContextExport:
 class TestCompositeExtenderNamePropagation:
     """Regression: every extender in a composite chain must see the real feature group name.
 
-    Today _CompositeExtender.make_wrapper hands all but the innermost extender an
+    Today CompositeExtender.make_wrapper hands all but the innermost extender an
     anonymous `wrapper` closure, so name introspection breaks for the outer ones.
     """
 
     def test_all_extenders_in_chain_resolve_real_class_name(self) -> None:
         ext_a = RecordingExtender(priority=10)
         ext_b = RecordingExtender(priority=20)
-        composite = _CompositeExtender([ext_a, ext_b])
+        composite = CompositeExtender([ext_a, ext_b])
 
         feature_set = build_feature_set()
         result = composite(SampleFeatureGroup.calculate_feature, {"x": [1]}, feature_set)

--- a/tests/test_plugins/extender/test_get_function_extender_lookup.py
+++ b/tests/test_plugins/extender/test_get_function_extender_lookup.py
@@ -5,7 +5,7 @@ from typing import Any
 from mloda.core.abstract_plugins.function_extender import (
     Extender,
     ExtenderHook,
-    _CompositeExtender,
+    CompositeExtender,
     get_function_extender,
 )
 
@@ -53,5 +53,5 @@ class TestGetFunctionExtenderLookup:
 
         result = get_function_extender({high, low, mid}, ExtenderHook.JOIN)
 
-        assert isinstance(result, _CompositeExtender)
+        assert isinstance(result, CompositeExtender)
         assert result.extenders == [low, mid, high]


### PR DESCRIPTION
## Summary
- Renames the internal `_CompositeExtender` (in `mloda.core.abstract_plugins.function_extender`) to public `CompositeExtender` and exports it from `mloda.steward`, alongside its sibling `Extender`, `ExtenderHook`, and `HookContext`.
- Previously there was no public equivalent, which forced downstream consumers (e.g. mloda-registry's otel extender tests) to import the private symbol directly from mloda's internal module.
- All internal call sites, the plugin-registry non-gating waiver, doc mentions, and existing tests are updated to the new name.

## Test plan
- [x] New test file `tests/test_plugins/extender/test_composite_extender_public_api.py` pins: direct import, re-export from `mloda.steward`, `__all__` membership, absence of the old private name, and chaining/aggregation behavior.
- [x] `tests/test_plugins/extender/` (196 passed)
- [x] `tests/test_core/test_abstract_plugins/test_plugin_registry/test_first_party_plugin_registration.py` (19 passed)
- [x] Full `tox` gate green (pytest, ruff format/check, pip-licenses, mypy --strict, bandit); `attribution/ATTRIBUTION.md` regenerated per repo convention (picks up an unrelated tornado patch bump already present in the environment)