### PR TITLE
fix: make FeatureSet artifact key deterministic across add order

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -166,6 +166,7 @@ class FeatureSet:
         return tuple(sorted({feature.name for feature in self.features if feature.initial_requested_data}))
 
     def get_name_of_one_feature(self) -> FeatureName:
+        """Return the alphabetically smallest feature name added to the set (deterministic regardless of add() order)."""
         FeatureSetValidator.validate_feature_added(
             self.name_of_one_feature if self.name_of_one_feature else None, "get_name_of_one_feature"
         )

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -67,7 +67,8 @@ class FeatureSet:
 
     def add(self, feature: Feature) -> None:
         self.features.add(feature)
-        self.name_of_one_feature = feature.name
+        if self.name_of_one_feature is None or feature.name < self.name_of_one_feature:
+            self.name_of_one_feature = feature.name
         if self.options is None:
             self.options = feature.options
         if self.any_uuid is None:

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
@@ -4,7 +4,10 @@ These pin the NEW API:
 - get_all_names() -> tuple[str, ...] sorted alphabetically
 - get_initial_requested_features() -> tuple[FeatureName, ...] sorted alphabetically
 - get_sorted_features() -> tuple[Feature, ...] sorted by feature.name
+- name_of_one_feature / get_name_of_one_feature() -> alphabetically smallest name, order-independent
 """
+
+import itertools
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -67,3 +70,55 @@ class TestGetSortedFeatures:
 
         assert isinstance(sorted_features, tuple)
         assert all(isinstance(feature, Feature) for feature in sorted_features)
+
+
+class TestNameOfOneFeatureDeterministic:
+    def test_out_of_order_add_picks_alphabetically_smallest_attribute(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("c_col"))
+        features.add(Feature("a_col"))
+        features.add(Feature("b_col"))
+
+        assert features.name_of_one_feature == FeatureName("a_col")
+
+    def test_out_of_order_add_picks_alphabetically_smallest_via_getter(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("c_col"))
+        features.add(Feature("a_col"))
+        features.add(Feature("b_col"))
+
+        assert features.get_name_of_one_feature() == FeatureName("a_col")
+
+    def test_last_added_feature_is_not_always_the_result(self) -> None:
+        # Guards against the old "last call wins" behavior: adding the alphabetically
+        # smallest name first must not make it lose to a later, larger name.
+        features = FeatureSet()
+        features.add(Feature("a_col"))
+        features.add(Feature("z_col"))
+
+        assert features.get_name_of_one_feature() == FeatureName("a_col")
+
+    def test_order_independent_across_explicit_orderings(self) -> None:
+        names = ["c_col", "a_col", "b_col"]
+        orderings = [names, list(reversed(names)), sorted(names), ["b_col", "c_col", "a_col"]]
+
+        results = set()
+        for ordering in orderings:
+            features = FeatureSet()
+            for name in ordering:
+                features.add(Feature(name))
+            results.add(features.get_name_of_one_feature())
+
+        assert results == {FeatureName("a_col")}
+
+    def test_order_independent_across_all_permutations(self) -> None:
+        names = ["delta", "alpha", "charlie", "bravo"]
+        expected = FeatureName(min(names))
+
+        for ordering in itertools.permutations(names):
+            features = FeatureSet()
+            for name in ordering:
+                features.add(Feature(name))
+
+            assert features.get_name_of_one_feature() == expected
+            assert features.name_of_one_feature == expected

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
@@ -122,3 +122,70 @@ class TestNameOfOneFeatureDeterministic:
 
             assert features.get_name_of_one_feature() == expected
             assert features.name_of_one_feature == expected
+
+
+class TestAddArtifactNameDeterministic:
+    """add_artifact_name() must resolve artifact_to_save deterministically, regardless of add() order."""
+
+    def test_artifact_to_save_is_alphabetically_smallest_name(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("c_col"))
+        features.add(Feature("a_col"))
+        features.add(Feature("b_col"))
+
+        features.add_artifact_name()
+
+        assert features.artifact_to_save == "a_col"
+
+    def test_artifact_to_save_matches_across_explicit_orderings(self) -> None:
+        names = ["c_col", "a_col", "b_col"]
+        orderings = [names, list(reversed(names)), sorted(names), ["b_col", "c_col", "a_col"]]
+
+        results = set()
+        for ordering in orderings:
+            features = FeatureSet()
+            for name in ordering:
+                features.add(Feature(name))
+            features.add_artifact_name()
+            results.add(features.artifact_to_save)
+
+        assert results == {"a_col"}
+
+    def test_artifact_to_save_matches_across_all_permutations(self) -> None:
+        names = ["delta", "alpha", "charlie", "bravo"]
+        expected = min(names)
+
+        for ordering in itertools.permutations(names):
+            features = FeatureSet()
+            for name in ordering:
+                features.add(Feature(name))
+            features.add_artifact_name()
+
+            assert features.artifact_to_save == expected
+
+
+class TestNameOfOneFeatureMatchesSortedNamesInvariant:
+    def test_name_of_one_feature_equals_first_of_get_all_names(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("z_col"))
+        features.add(Feature("m_col"))
+        features.add(Feature("d_col"))
+        features.add(Feature("a_col"))
+
+        assert features.name_of_one_feature == features.get_all_names()[0]
+
+
+class TestFeatureSetConstructorConvergesToAlphabeticallySmallest:
+    """FeatureSet(features=[...]) is a distinct entry point into add(); must converge like direct .add() calls."""
+
+    def test_name_of_one_feature_via_constructor(self) -> None:
+        features = FeatureSet(features=[Feature("c_col"), Feature("a_col"), Feature("b_col")])
+
+        assert features.name_of_one_feature == FeatureName("a_col")
+
+    def test_add_artifact_name_via_constructor(self) -> None:
+        features = FeatureSet(features=[Feature("c_col"), Feature("a_col"), Feature("b_col")])
+
+        features.add_artifact_name()
+
+        assert features.artifact_to_save == "a_col"


### PR DESCRIPTION
## Summary

`FeatureSet.add()` unconditionally overwrote `name_of_one_feature` on every call, so for a `FeatureSet` built from multiple features (iterated from a `set[Feature]`), the resulting name depended on Python's set iteration order. This name feeds the artifact save/load key and API-input-class matching, so a non-deterministic value there could produce inconsistent artifact keys across runs.

`name_of_one_feature` now converges to the alphabetically smallest feature name across all `add()` calls, matching the ordering convention already used by `get_all_names()` and `get_sorted_features()` in the same file.

## Changes

- `mloda/core/abstract_plugins/components/feature_set.py`: `add()` only updates `name_of_one_feature` when the new feature's name sorts before the current one; documents the guarantee on `get_name_of_one_feature()`.
- Tests covering order-independence of `name_of_one_feature`, the `add_artifact_name()` deterministic key, the `name_of_one_feature == get_all_names()[0]` invariant, and the list-constructor entry point.

Closes #1239