### PR TITLE
fix: stop sklearn artifact tests from deleting concurrent workers' files

### DIFF
--- a/tests/test_plugins/feature_group/experimental/sklearn/test_scaling_feature_group/test_scaling_feature_group_integration.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_scaling_feature_group/test_scaling_feature_group_integration.py
@@ -7,6 +7,7 @@ import pytest
 from typing import Any
 
 from mloda.user import Feature
+from mloda.user import Options
 from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -34,7 +35,7 @@ class ScalingIntegrationTestDataCreator(ATestDataCreator):
 class TestScalingFeatureGroupIntegration:
     """Integration test for ScalingFeatureGroup."""
 
-    def test_scaling_with_aggregated_source_and_artifacts(self) -> None:
+    def test_scaling_with_aggregated_source_and_artifacts(self, tmp_path: Any) -> None:
         """Test scaling feature group using aggregated feature as source with artifact save/load."""
         # Skip test if sklearn not available
         try:
@@ -50,7 +51,7 @@ class TestScalingFeatureGroupIntegration:
         )
 
         # Create features: aggregated feature and scaling of that aggregated feature
-        scaling_feature = Feature("Sales__sum_aggr__standard_scaled")
+        scaling_feature = Feature("Sales__sum_aggr__standard_scaled", Options({"artifact_storage_path": str(tmp_path)}))
 
         # Phase 1: Train and save artifacts
         api1 = mloda(
@@ -78,12 +79,10 @@ class TestScalingFeatureGroupIntegration:
         assert scaled_values.std() == 0.0
 
         # Phase 2: Load artifacts and apply to same data (simulating reuse)
-        from mloda.user import Options
-
         # Create features with artifact options for reuse
         scaling_feature_reuse = Feature(
             "Sales__sum_aggr__standard_scaled",
-            Options(artifacts1),
+            Options({**artifacts1, "artifact_storage_path": str(tmp_path)}),
         )
 
         api2 = mloda(

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_sklearn_artifact.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_sklearn_artifact.py
@@ -2,6 +2,8 @@
 Tests for SklearnArtifact.
 """
 
+from pathlib import Path
+
 from mloda.user import Feature
 import pytest
 from unittest.mock import Mock, patch
@@ -68,19 +70,18 @@ class TestSklearnArtifact:
             with pytest.raises(ImportError, match="joblib is required"):
                 SklearnArtifact._deserialize_artifact('{"fitted_transformer": "dummy"}')
 
-    def test_custom_saver(self) -> None:
+    def test_custom_saver(self, tmp_path: Path) -> None:
         """Test custom_saver method."""
         # Skip test if sklearn/joblib not available
         try:
             import joblib  # noqa: F401
             from sklearn.preprocessing import StandardScaler
-            import tempfile  # noqa: F401
             import os
         except ImportError:
             pytest.skip("scikit-learn or joblib not available")
 
         features = FeatureSet()
-        features.add(Feature("test_custom_saver_feature", Options()))
+        features.add(Feature("test_custom_saver_feature", Options({"artifact_storage_path": str(tmp_path)})))
 
         # Use the new multiple artifact format
         artifact = {
@@ -90,22 +91,11 @@ class TestSklearnArtifact:
             }
         }
 
-        try:
-            result = SklearnArtifact.custom_saver(features, artifact)
-            assert isinstance(result, dict)
-            assert "test_artifact_key" in result
-            # Verify file was created
-            assert os.path.exists(result["test_artifact_key"])
-        finally:
-            # Clean up
-            try:
-                import glob
-
-                artifact_files = glob.glob("/tmp/sklearn_artifact_*.joblib")  # nosec
-                for file_path in artifact_files:
-                    os.remove(file_path)
-            except Exception:  # nosec
-                pass
+        result = SklearnArtifact.custom_saver(features, artifact)
+        assert isinstance(result, dict)
+        assert "test_artifact_key" in result
+        # Verify file was created
+        assert os.path.exists(result["test_artifact_key"])
 
     def test_custom_loader_no_options(self) -> None:
         """Test custom_loader when no options are available."""
@@ -131,14 +121,13 @@ class TestSklearnArtifact:
             result = SklearnArtifact.custom_loader(features)
             assert result is None
 
-    def test_custom_loader_with_artifact(self) -> None:
+    def test_custom_loader_with_artifact(self, tmp_path: Path) -> None:
         """Test custom_loader with stored artifact."""
         # Skip test if sklearn/joblib not available
         try:
             import joblib  # noqa: F401
             from sklearn.preprocessing import StandardScaler
             import os
-            import glob
         except ImportError:
             pytest.skip("scikit-learn or joblib not available")
 
@@ -154,30 +143,21 @@ class TestSklearnArtifact:
 
         # Mock features with unique name
         features = FeatureSet()
-        features.add(Feature("test_with_artifact_feature_unique", Options({})))
+        features.add(Feature("test_with_artifact_feature_unique", Options({"artifact_storage_path": str(tmp_path)})))
 
-        try:
-            # First save the artifact
-            saved_paths = SklearnArtifact.custom_saver(features, artifact)
-            assert isinstance(saved_paths, dict)
-            assert "test_with_artifact_key" in saved_paths
-            assert os.path.exists(saved_paths["test_with_artifact_key"])
+        # First save the artifact
+        saved_paths = SklearnArtifact.custom_saver(features, artifact)
+        assert isinstance(saved_paths, dict)
+        assert "test_with_artifact_key" in saved_paths
+        assert os.path.exists(saved_paths["test_with_artifact_key"])
 
-            # Then load it
-            result = SklearnArtifact.custom_loader(features)
+        # Then load it
+        result = SklearnArtifact.custom_loader(features)
 
-            assert result is not None
-            assert isinstance(result, dict)
-            assert "test_with_artifact_key" in result
-            loaded_artifact = result["test_with_artifact_key"]
-            assert "fitted_transformer" in loaded_artifact
-            assert "feature_names" in loaded_artifact
-            assert loaded_artifact["feature_names"] == ["feature1", "feature2"]
-        finally:
-            # Clean up
-            try:
-                artifact_files = glob.glob("/tmp/sklearn_artifact_*.joblib")  # nosec
-                for file_path in artifact_files:
-                    os.remove(file_path)
-            except Exception:  # nosec
-                pass
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "test_with_artifact_key" in result
+        loaded_artifact = result["test_with_artifact_key"]
+        assert "fitted_transformer" in loaded_artifact
+        assert "feature_names" in loaded_artifact
+        assert loaded_artifact["feature_names"] == ["feature1", "feature2"]

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_sklearn_artifact_no_shared_tempdir_cleanup.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_sklearn_artifact_no_shared_tempdir_cleanup.py
@@ -1,0 +1,21 @@
+"""No test may clean up artifact files it did not itself create by globbing the shared system temp dir."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SIBLING_TEST_FILE = Path(__file__).resolve().parent / "test_sklearn_artifact.py"
+
+# A blanket glob against this pattern deletes every matching file in /tmp, including files
+# written concurrently by other tests or pytest-xdist workers, not just files this test created.
+UNSCOPED_GLOB_PATTERN = "/tmp/sklearn_artifact_*.joblib"  # nosec
+
+
+def test_test_sklearn_artifact_has_no_unscoped_glob_cleanup() -> None:
+    source = SIBLING_TEST_FILE.read_text()
+    assert UNSCOPED_GLOB_PATTERN not in source, (
+        f"{SIBLING_TEST_FILE.name} must not glob-delete '{UNSCOPED_GLOB_PATTERN}': "
+        "this pattern matches artifact files owned by other, concurrently-running tests/workers, "
+        "not just files this test created. Clean up only the exact path(s) this test saved."
+    )


### PR DESCRIPTION
## Summary

`test_scaling_with_aggregated_source_and_artifacts` occasionally failed with `Artifact not found for key ... Available artifacts: []`. The root cause: `test_custom_saver` and `test_custom_loader_with_artifact` cleaned up after themselves with an unscoped `glob.glob("/tmp/sklearn_artifact_*.joblib")` that deleted every matching file in the shared system temp dir, including artifacts written concurrently by other tests or pytest-xdist workers. The flaky test wrote its own artifact to that same shared, unscoped location, so it could be deleted mid-test by an unrelated worker's cleanup.

## Fix

Scope all three tests to an explicit `artifact_storage_path` backed by pytest's `tmp_path`, matching the pattern already used by the other sklearn integration tests (encoding, pipeline, chaining), and drop the now-unnecessary manual `/tmp` cleanup.

Also adds a regression test guarding against a test in this file ever reintroducing an unscoped glob-delete against the shared temp dir.

## Test plan

- [x] New regression test passes
- [x] Full sklearn test tree passes under `-n 8`
- [x] Previously-flaky test run repeatedly under `-n 8` with no failures
- [x] Full `tox` passes