### PR TITLE
fix: skip generic alias attributes when registering plugin modules

### DIFF
--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -17,6 +17,7 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_policy import PluginPoli
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     PluginRegistry,
     PluginSource,
+    _is_class,
     register_module_plugins,
     warn_policy_denied,
 )
@@ -180,7 +181,7 @@ class PluginLoader:
         registry = PluginRegistry.default()
         keys: list[str] = []
         for cls in manifest:
-            if not isinstance(cls, type):
+            if not _is_class(cls):
                 raise TypeError(f"Entry point '{label}' manifest contains a non-class item: {cls!r}.")
             if not issubclass(cls, base_type):
                 raise TypeError(

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -6,6 +6,7 @@ import dataclasses
 import inspect
 import logging
 import threading
+import types
 from dataclasses import dataclass
 from enum import Enum
 from types import ModuleType
@@ -78,9 +79,14 @@ class PluginRegistryEntry:
 PluginRegistrySnapshot = dict[str, PluginRegistryEntry]
 
 
+def _is_class(obj: object) -> bool:
+    """Python 3.10 reports a types.GenericAlias such as tuple[str, ...] as a type; issubclass then raises."""
+    return isinstance(obj, type) and not isinstance(obj, types.GenericAlias)
+
+
 def _resolve_plugin_type(cls: type[Any]) -> type[Any]:
     for base in _PLUGIN_BASE_TYPES:
-        if isinstance(cls, type) and issubclass(cls, base):
+        if _is_class(cls) and issubclass(cls, base):
             return base
     raise ValueError(f"{cls!r} is not a subclass of FeatureGroup, ComputeFramework, or Extender.")
 
@@ -263,7 +269,7 @@ def register_module_plugins(module: ModuleType, *, source: PluginSource | str = 
     registry = PluginRegistry.default()
     keys: list[str] = []
     for obj in vars(module).values():
-        if not isinstance(obj, type) or obj in _PLUGIN_BASE_TYPES:
+        if not _is_class(obj) or obj in _PLUGIN_BASE_TYPES:
             continue
         if not issubclass(obj, _PLUGIN_BASE_TYPES) or obj.__module__ != module.__name__:
             continue

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_generic_alias_attributes.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_generic_alias_attributes.py
@@ -1,0 +1,87 @@
+"""Pins Python 3.10's GenericAlias isinstance(obj, type) quirk in the plugin registry.
+
+On Python 3.10 alone, isinstance(tuple[str, ...], type) is True for a types.GenericAlias, so a
+module-level type alias attribute passes the registry's isinstance(obj, type) filter and then
+issubclass() raises TypeError instead of being skipped as a non-class attribute.
+"""
+
+import gc
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    _resolve_plugin_type,
+    register_module_plugins,
+)
+from mloda.user import PluginLoader
+
+SYNTHETIC_MODULE_NAME = "synthetic_generic_alias_plugin_module"
+
+
+def _default_key(cls: type[Any]) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def _build_synthetic_module() -> tuple[types.ModuleType, type[Any]]:
+    module = types.ModuleType(SYNTHETIC_MODULE_NAME)
+
+    class _GenericAliasProbeFG(FeatureGroup):
+        @classmethod
+        def calculate_feature(cls, data: Any, features: Any) -> Any:
+            return {}
+
+    _GenericAliasProbeFG.__module__ = module.__name__
+    setattr(module, "_GenericAliasProbeFG", _GenericAliasProbeFG)
+    setattr(module, "Alias", tuple[tuple[str, str | None], ...])
+    return module, _GenericAliasProbeFG
+
+
+class TestRegisterModulePluginsSkipsGenericAliasAttribute:
+    def test_register_module_plugins_skips_generic_alias_attribute(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        module, cls = _build_synthetic_module()
+        monkeypatch.setitem(sys.modules, module.__name__, module)
+
+        try:
+            keys = register_module_plugins(module)
+            assert keys == [_default_key(cls)], (
+                "register_module_plugins must register only the concrete feature group, skipping the "
+                "module-level generic alias attribute"
+            )
+        finally:
+            registry.clear()
+            delattr(module, "_GenericAliasProbeFG")
+            delattr(module, "Alias")
+            del cls, module
+            gc.collect()
+
+
+class TestResolvePluginTypeRejectsGenericAlias:
+    def test_resolve_plugin_type_rejects_generic_alias_with_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            _resolve_plugin_type(tuple[str, ...])
+
+
+class TestIsClassHelper:
+    def test_is_class_rejects_generic_alias_and_accepts_classes(self) -> None:
+        from mloda.core.abstract_plugins.plugin_registry.plugin_registry import _is_class
+
+        assert _is_class(tuple[str, ...]) is False
+        assert _is_class(list[int]) is False
+        assert _is_class(int) is True
+        assert _is_class(FeatureGroup) is True
+        assert _is_class(object()) is False
+
+
+class TestEntryPointManifestRejectsGenericAlias:
+    def test_entry_point_manifest_reports_generic_alias_as_non_class(self) -> None:
+        loader = PluginLoader()
+        with pytest.raises(TypeError, match="non-class item"):
+            loader._register_manifest("synthetic_label", "mloda.feature_groups", FeatureGroup, (tuple[str, ...],))


### PR DESCRIPTION
## Summary

Split out of #1295 so the plugin-loader fix can land and be reviewed on its own. #1295 depends on it: the shared commit drops out of that branch on rebase once this merges.

On Python 3.10, `isinstance(tuple[str, ...], type)` is `True` for a `types.GenericAlias`, and `issubclass()` against an ABC (all three plugin base types are ABCs) then raises `TypeError: issubclass() arg 1 must be a class`. Any plugin module with a module-level generic alias attribute, whether defined there or imported (for example `from mloda.steward import OutputSchema` once #1295 lands), crashed `register_module_plugins` and the entry-point manifest check at plugin load. Python 3.11+ reports the alias as a non-type and skipped it silently.

## Change

- `plugin_registry.py`: one `_is_class` guard (`isinstance(obj, type)` and not a `types.GenericAlias`) shared by `register_module_plugins` and `_resolve_plugin_type`.
- `plugin_loader.py`: the entry-point manifest check uses the same guard, so a generic alias in a manifest is reported as a non-class item instead of raising from `issubclass`.

## Tests

`tests/test_core/test_abstract_plugins/test_plugin_registry/test_generic_alias_attributes.py`: registry and manifest registration of a module carrying a generic alias attribute, the `_is_class` helper, and `_resolve_plugin_type` rejecting an alias with `ValueError`. The 3.10 CI job exercises the quirk itself; on 3.11+ the tests pass through the pre-existing skip path.
