### PR TITLE
fix: use artifact_to_load for artifact key resolution, not name_of_one_feature

### DIFF
--- a/mloda/core/abstract_plugins/components/base_artifact.py
+++ b/mloda/core/abstract_plugins/components/base_artifact.py
@@ -79,9 +79,9 @@ class BaseArtifact(ABC):
         """
 
         options = cls.get_singular_option_from_options(features)
-        if options is None or features.name_of_one_feature is None:
+        if options is None or features.artifact_to_load is None:
             return None
-        return options[str(features.name_of_one_feature)]
+        return options[features.artifact_to_load]
 
     @classmethod
     def get_singular_option_from_options(cls, features: FeatureSet) -> Options | None:

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -167,9 +167,7 @@ class FeatureSet:
 
     def get_name_of_one_feature(self) -> FeatureName:
         """Return the alphabetically smallest feature name added to the set (deterministic regardless of add() order)."""
-        FeatureSetValidator.validate_feature_added(
-            self.name_of_one_feature if self.name_of_one_feature else None, "get_name_of_one_feature"
-        )
+        FeatureSetValidator.validate_feature_added(self.name_of_one_feature, "get_name_of_one_feature")
         assert self.name_of_one_feature is not None  # Type narrowing for mypy
         return self.name_of_one_feature
 

--- a/mloda_plugins/feature_group/experimental/forecasting/forecasting_artifact.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/forecasting_artifact.py
@@ -121,10 +121,10 @@ class ForecastingArtifact(BaseArtifact):
 
         options = cls.get_singular_option_from_options(features)
 
-        if options is None or features.name_of_one_feature is None:
+        if options is None or features.artifact_to_load is None:
             return None
 
-        serialized_artifact = options.get(str(features.name_of_one_feature))
+        serialized_artifact = options.get(features.artifact_to_load)
         if serialized_artifact is None:
             return None
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
@@ -189,3 +189,21 @@ class TestFeatureSetConstructorConvergesToAlphabeticallySmallest:
         features.add_artifact_name()
 
         assert features.artifact_to_save == "a_col"
+
+
+class TestGetNameOfOneFeatureEmptyNameNotTreatedAsUnset:
+    """An empty-string FeatureName is a genuinely set value, not the "unset" sentinel."""
+
+    def test_empty_name_does_not_raise(self) -> None:
+        features = FeatureSet()
+        features.add(Feature(""))
+
+        assert features.get_name_of_one_feature() == FeatureName("")
+
+    def test_empty_name_wins_as_alphabetically_smallest(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("a_col"))
+        features.add(Feature(""))
+
+        assert features.name_of_one_feature == FeatureName("")
+        assert features.get_name_of_one_feature() == FeatureName("")

--- a/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
+++ b/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
@@ -1,0 +1,68 @@
+"""Pin BaseArtifact.custom_loader to key off artifact_to_load, not name_of_one_feature (always the
+alphabetically smallest feature name, independent of which feature the artifact is stored under)."""
+
+from mloda.provider import BaseArtifact, FeatureSet
+from mloda.user import Feature, Options
+
+
+class TestBaseArtifactCustomLoaderUsesArtifactToLoad:
+    def test_loads_stored_value_when_artifact_key_is_not_alphabetically_smallest(self) -> None:
+        shared_options = Options({"z_col": "stored_value"})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.add_artifact_name()
+
+        # Sanity on the two attributes the bug conflates.
+        assert features.artifact_to_load == "z_col"
+        assert features.name_of_one_feature == "a_col"
+
+        result = BaseArtifact.custom_loader(features)
+
+        assert result == "stored_value"
+
+    def test_load_uses_artifact_to_load_when_artifact_key_is_not_alphabetically_smallest(self) -> None:
+        shared_options = Options({"z_col": "stored_value"})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.add_artifact_name()
+
+        result = BaseArtifact.load(features)
+
+        assert result == "stored_value"
+
+
+class TestFeatureSetResolveArtifactForRuntimeUsesArtifactToLoad:
+    """resolve_artifact_for_runtime() is the second producer of artifact_to_load, used on the
+    prepare() + run(artifacts=...) path; it must feed custom_loader/load the same way add_artifact_name() does."""
+
+    def test_loads_runtime_value_when_artifact_key_is_not_alphabetically_smallest(self) -> None:
+        shared_options = Options({})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.resolve_artifact_for_runtime({"z_col": "runtime_value"})
+
+        # Sanity on the two attributes the bug conflates.
+        assert features.artifact_to_load == "z_col"
+        assert features.name_of_one_feature == "a_col"
+
+        result = BaseArtifact.custom_loader(features)
+
+        assert result == "runtime_value"
+
+    def test_load_uses_artifact_to_load_when_resolved_at_runtime(self) -> None:
+        shared_options = Options({})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.resolve_artifact_for_runtime({"z_col": "runtime_value"})
+
+        result = BaseArtifact.load(features)
+
+        assert result == "runtime_value"

--- a/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_artifact_custom_loader.py
+++ b/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_artifact_custom_loader.py
@@ -1,0 +1,40 @@
+"""Pin ForecastingArtifact.custom_loader to key off artifact_to_load, not name_of_one_feature.
+Same bug pattern as BaseArtifact.custom_loader."""
+
+from mloda.provider import FeatureSet
+from mloda.user import Feature, Options
+from mloda_plugins.feature_group.experimental.forecasting.forecasting_artifact import ForecastingArtifact
+
+
+class TestForecastingArtifactCustomLoaderUsesArtifactToLoad:
+    def test_loads_stored_value_when_artifact_key_is_not_alphabetically_smallest(self) -> None:
+        serialized = ForecastingArtifact._serialize_artifact({"feature_names": ["sales"]})
+        shared_options = Options({"z_col": serialized})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.add_artifact_name()
+
+        # Sanity on the two attributes the bug conflates.
+        assert features.artifact_to_load == "z_col"
+        assert features.name_of_one_feature == "a_col"
+
+        result = ForecastingArtifact.custom_loader(features)
+
+        assert result is not None
+        assert result["feature_names"] == ["sales"]
+
+    def test_load_uses_artifact_to_load_when_artifact_key_is_not_alphabetically_smallest(self) -> None:
+        serialized = ForecastingArtifact._serialize_artifact({"feature_names": ["sales"]})
+        shared_options = Options({"z_col": serialized})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.add_artifact_name()
+
+        result = ForecastingArtifact.load(features)
+
+        assert result is not None
+        assert result["feature_names"] == ["sales"]


### PR DESCRIPTION
## Summary

Two related correctness gaps in FeatureSet/BaseArtifact name resolution:

1. `BaseArtifact.custom_loader` and `ForecastingArtifact.custom_loader` re-derived the artifact's options key from `name_of_one_feature` (always the alphabetically smallest feature name in the set), instead of using `artifact_to_load`, the key that `FeatureSet.add_artifact_name()` / `resolve_artifact_for_runtime()` actually resolved as holding the stored artifact. When those two names differ, the loader missed the real artifact entirely.

2. `FeatureSet.get_name_of_one_feature()` treated a genuinely-set empty-string feature name as unset, because it checked truthiness instead of `is None`, raising `ValueError` for a value that was valid.

## Fix

- `custom_loader` in both artifact classes now keys off `artifact_to_load`.
- `get_name_of_one_feature()` now passes `name_of_one_feature` straight through to the validator, which already does an explicit `is None` check.

## Test plan

- [x] New tests cover both the `add_artifact_name()` and `resolve_artifact_for_runtime()` producers of `artifact_to_load`, through both `custom_loader` and the public `BaseArtifact.load()` entry point
- [x] New tests cover the empty-name case for `get_name_of_one_feature()`
- [x] Full `tox` passes