### PR TITLE
feat: give HookContext keyword defaults for its nullable and collection fields

### DIFF
--- a/docs/docs/chapter1/extender.md
+++ b/docs/docs/chapter1/extender.md
@@ -107,6 +107,22 @@ class FactsExtender(Extender):
         return result
 ```
 
+To unit-test an extender's `__call__` without running the engine, build a `HookContext` directly and `activate()` it. Only `hook`, `feature_group_class`, `feature_group_version` and `compute_framework_name` are required. `plugin_version` and `input_features` default to `None`, `feature_names` defaults to an empty tuple, and every other field defaults to `None`.
+
+```python
+from mloda.steward import ExtenderHook, HookContext
+
+context = HookContext(
+    hook=ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE,
+    feature_group_class="my_plugin.MyFeatureGroup",
+    feature_group_version="1",
+    compute_framework_name="PyArrowTable",
+)
+
+with context.activate():
+    FactsExtender()(lambda: "result")
+```
+
 #### 6. Discovering Extenders
 
 To list all available extenders and their documentation, use the `get_extender_docs()` function from `mloda.steward`.

--- a/mloda/core/abstract_plugins/hook_context.py
+++ b/mloda/core/abstract_plugins/hook_context.py
@@ -25,9 +25,9 @@ class HookContext:
     hook: ExtenderHook
     feature_group_class: str
     feature_group_version: str
-    plugin_version: str | None
-    feature_names: tuple[str, ...]
-    input_features: frozenset[str] | None
+    plugin_version: str | None = None
+    feature_names: tuple[str, ...] = ()
+    input_features: frozenset[str] | None = None
     compute_framework_name: str
     rows_in: int | None = None
     rows_out: int | None = None

--- a/tests/test_plugins/extender/test_hook_context.py
+++ b/tests/test_plugins/extender/test_hook_context.py
@@ -4,6 +4,7 @@ Pins construction, the ambient current()/activate() scope (including nested
 restore), row_count's __len__ gating, and instrument's timing/status bookkeeping.
 """
 
+import dataclasses
 from typing import Any
 
 import pytest
@@ -17,7 +18,7 @@ class _NoLenDouble:
 
 
 def _make_context(**overrides: Any) -> HookContext:
-    required = {
+    required: dict[str, Any] = {
         "hook": ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE,
         "feature_group_class": "tests.something.FakeFeatureGroup",
         "feature_group_version": "v1",
@@ -27,13 +28,13 @@ def _make_context(**overrides: Any) -> HookContext:
         "compute_framework_name": "FakeFramework",
     }
     required.update(overrides)
-    return HookContext(**required)  # type: ignore[arg-type]
+    return HookContext(**required)
 
 
 class TestHookContextConstruction:
     """HookContext construction and defaults."""
 
-    def test_constructs_with_only_required_fields(self) -> None:
+    def test_constructs_with_explicit_fields(self) -> None:
         context = _make_context()
 
         assert context.hook == ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE
@@ -357,3 +358,60 @@ class TestInstrumentPreservesSelf:
         wrapped = instrument(context, plain)
 
         assert not hasattr(wrapped, "__self__")
+
+
+class TestHookContextKeywordDefaults:
+    """Only hook, feature_group_class, feature_group_version, compute_framework_name stay required."""
+
+    def test_short_form_constructs_with_identity_fields_only(self) -> None:
+        context = HookContext(
+            hook=ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE,
+            feature_group_class="tests.something.FakeFeatureGroup",
+            feature_group_version="v1",
+            compute_framework_name="FakeFramework",
+        )
+
+        assert context.plugin_version is None
+        assert context.feature_names == ()
+        assert context.input_features is None
+
+    @pytest.mark.parametrize(
+        "dropped_field",
+        ["hook", "feature_group_class", "feature_group_version", "compute_framework_name"],
+    )
+    def test_identity_field_stays_required(self, dropped_field: str) -> None:
+        kwargs: dict[str, Any] = {
+            "hook": ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE,
+            "feature_group_class": "tests.something.FakeFeatureGroup",
+            "feature_group_version": "v1",
+            "compute_framework_name": "FakeFramework",
+        }
+        del kwargs[dropped_field]
+
+        with pytest.raises(TypeError, match=dropped_field):
+            HookContext(**kwargs)
+
+    def test_exactly_four_fields_have_no_default(self) -> None:
+        required_field_names = {
+            field.name
+            for field in dataclasses.fields(HookContext)
+            if field.default is dataclasses.MISSING and field.default_factory is dataclasses.MISSING
+        }
+
+        assert required_field_names == {
+            "hook",
+            "feature_group_class",
+            "feature_group_version",
+            "compute_framework_name",
+        }
+
+    def test_every_other_field_defaults_to_none(self) -> None:
+        identity_fields = {"hook", "feature_group_class", "feature_group_version", "compute_framework_name"}
+
+        for field in dataclasses.fields(HookContext):
+            if field.name in identity_fields or field.name == "feature_names":
+                continue
+            assert field.default is None, f"{field.name} should default to None"
+
+        feature_names_field = next(field for field in dataclasses.fields(HookContext) if field.name == "feature_names")
+        assert feature_names_field.default == ()


### PR DESCRIPTION
## Summary

- `plugin_version` and `input_features` default to `None`, `feature_names` to `()`. These are the values the engine already passes when a field does not apply (join hook, feature-group match, root step, module not shipped as an installed distribution), so the defaults encode existing meaning rather than a new sentinel.
- `hook`, `feature_group_class`, `feature_group_version` and `compute_framework_name` stay required. They identify what the hook call is about, and a forgotten one still fails at construction and under mypy at every production construction site.
- Field declaration order is unchanged, so `repr()`, `asdict()` and `astuple()` output for existing callers is identical.
- No core-side test factory. The plain constructor is the short form, `dataclasses.replace()` covers overrides, and test builders belong in test support packages.
- The extender docs gain the short construction form for unit-testing an extender's `__call__` under `activate()`, as a runnable fence.

## Tests

- New `TestHookContextKeywordDefaults`: the short form constructs with the three defaults, each identity field independently raises `TypeError` when omitted, `dataclasses.fields()` reports exactly those four fields without a default, and every other field defaults to `None` (feature_names to `()`), which is what the docs promise.
- Existing production call sites are untouched; they keep passing every field explicitly.
- tox green.

Note: `feat/hook-context-output-schema` (#1295) edits the same field block. Whichever lands second should re-run the extender tests after merging.

Closes #1308
