### PR TITLE
test: route MlodaTestRunner and tests through public run() instead of _batch_run

### DIFF
--- a/tests/test_core/test_abstract_plugins/test_multi_column_auto_resolution.py
+++ b/tests/test_core/test_abstract_plugins/test_multi_column_auto_resolution.py
@@ -265,8 +265,7 @@ def test_multi_column_auto_resolution_with_chaining() -> None:
         {PandasDataFrame},
         plugin_collector=plugin_collector,
     )
-    api._batch_run()
-    results = api.get_result()
+    results = api.run()
 
     # Verify results
     # The mloda returns separate DataFrames per feature group

--- a/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
+++ b/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
@@ -176,8 +176,7 @@ class TestSubColumnDependencyResolution:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         assert len(results) > 0, "Should return at least one result DataFrame"
 

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -80,7 +80,7 @@ class MlodaTestRunner:
         Run mloda with the given configuration.
 
         This is the recommended method for most integration tests.
-        Uses mloda instance + _batch_run() for full access to results and artifacts.
+        Uses mloda instance + run() for full access to results and artifacts.
 
         Args:
             features: The feature set to compute
@@ -112,9 +112,11 @@ class MlodaTestRunner:
             plugin_collector=plugin_collector,
             strict_type_enforcement=strict_type_enforcement,
         )
-        api._batch_run(parallelization_modes, flight_server, function_extender)
-
-        results = api.get_result()
+        results = api.run(
+            parallelization_modes=parallelization_modes,
+            flight_server=flight_server,
+            function_extender=function_extender,
+        )
         artifacts = api.get_artifacts()
 
         if cleanup_flight_server:

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_complex_encoding_chaining.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_complex_encoding_chaining.py
@@ -94,8 +94,7 @@ class TestComplexEncodingChaining:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         artifacts1 = api1.get_artifacts()
 
         # Verify all complex features were created
@@ -177,8 +176,7 @@ class TestComplexEncodingChaining:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
         artifacts2 = api2.get_artifacts()
 
         # Verify results are identical (indicating artifact reuse)

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_encoding_feature_group_integration.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_encoding_feature_group_integration.py
@@ -60,8 +60,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         artifacts1 = api1.get_artifacts()
 
         # Verify encoding feature was created
@@ -90,8 +89,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
         artifacts2 = api2.get_artifacts()
 
         # Verify results are identical (indicating artifact reuse)
@@ -129,8 +127,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         artifacts1 = api1.get_artifacts()
 
         # Verify encoding feature was created
@@ -176,8 +173,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         artifacts1 = api1.get_artifacts()
 
         # Verify specific columns were created
@@ -211,8 +207,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
 
         # Verify full encoding creates all columns
         assert len(results2) == 1
@@ -270,8 +265,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
         artifacts = api.get_artifacts()
 
         # Verify results
@@ -300,8 +294,7 @@ class TestEncodingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api_string._batch_run()
-        results_string = api_string.get_result()
+        results_string = api_string.run()
 
         # Verify string-based results match configuration-based results
         assert len(results_string) == 1

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_simple_chaining_demo.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_simple_chaining_demo.py
@@ -53,8 +53,7 @@ class TestSimpleChaining:
         # L→R: category__onehot_encoded~0__standard_scaled
         onehot_feature = Feature("category__onehot_encoded~0__standard_scaled")
         api1 = mloda([onehot_feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         df1 = results1[0]
 
         print("Columns after OneHot encoding:")

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_feature_group_integration.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_feature_group_integration.py
@@ -359,8 +359,7 @@ class TestSklearnPipelineFeatureGroupIntegration:
         feature1 = Feature("income__sklearn_pipeline_scaling", Options(feature_options))
 
         api1 = mloda([feature1], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         artifacts1 = api1.get_artifacts()
 
         # Verify we got results and artifacts
@@ -392,8 +391,7 @@ class TestSklearnPipelineFeatureGroupIntegration:
         feature2 = Feature("income__sklearn_pipeline_scaling", Options(combined_options))
 
         api2 = mloda([feature2], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
         artifacts2 = api2.get_artifacts()
 
         # Verify results are identical (indicating artifact reuse)

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_scaling_feature_group/test_scaling_feature_group_integration.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_scaling_feature_group/test_scaling_feature_group_integration.py
@@ -59,8 +59,7 @@ class TestScalingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
         artifacts1 = api1.get_artifacts()
 
         # Verify scaling feature was created
@@ -90,8 +89,7 @@ class TestScalingFeatureGroupIntegration:
             {PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
         artifacts2 = api2.get_artifacts()
 
         # Verify results are identical (indicating artifact reuse)

--- a/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_artifact_integration.py
+++ b/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_artifact_integration.py
@@ -61,8 +61,7 @@ class TestForecastingArtifactIntegration:
         )
 
         # Run the mloda to generate forecasts and save the artifact
-        api._batch_run()
-        results1 = api.get_result()
+        results1 = api.run()
 
         # Get the saved artifacts
         artifacts = api.get_artifacts()
@@ -84,8 +83,7 @@ class TestForecastingArtifactIntegration:
         )
 
         # Run the mloda to generate forecasts using the loaded artifact
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
 
         # Verify that both runs produced results with the same feature
         assert feature_name in results1[0].columns, f"{feature_name} not found in first run results"

--- a/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_modernization.py
+++ b/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_modernization.py
@@ -65,8 +65,7 @@ class TestForecastingModernization:
             plugin_collector=plugin_collector,
         )
 
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Verify that the feature was created successfully
         assert len(results) == 1
@@ -101,8 +100,7 @@ class TestForecastingModernization:
             plugin_collector=plugin_collector,
         )
 
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Verify that the feature was created successfully
         assert len(results) == 1
@@ -137,12 +135,10 @@ class TestForecastingModernization:
 
         # Run both approaches
         api1 = mloda([string_feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
 
         api2 = mloda([config_feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
 
         # Both should produce results with their respective feature names
         assert "sales__linear_forecast_7day" in results1[0].columns
@@ -174,7 +170,7 @@ class TestForecastingModernization:
                 ),
             )
             api = mloda([feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-            api._batch_run()
+            api.run()
 
         # Test invalid time unit
         with pytest.raises(Exception):  # Should fail during validation
@@ -190,7 +186,7 @@ class TestForecastingModernization:
                 ),
             )
             api = mloda([feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-            api._batch_run()
+            api.run()
 
         # Test invalid horizon (negative)
         with pytest.raises(Exception):  # Should fail during validation
@@ -206,7 +202,7 @@ class TestForecastingModernization:
                 ),
             )
             api = mloda([feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-            api._batch_run()
+            api.run()
 
     def test_multiple_algorithms_configuration_based(self) -> None:
         """Test multiple forecasting algorithms using configuration-based approach."""
@@ -235,8 +231,7 @@ class TestForecastingModernization:
 
         # Run the mloda with multiple features
         api = mloda(features, {PandasDataFrame}, plugin_collector=plugin_collector)
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Verify all features were created
         assert len(results) == 1
@@ -280,8 +275,7 @@ class TestForecastingModernization:
 
         # Run the mloda with both features
         api = mloda([feature1, feature2], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Both features should be processed together (same Feature Group resolution)
         assert len(results) == 1

--- a/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_geo_distance_modernization.py
+++ b/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_geo_distance_modernization.py
@@ -71,8 +71,7 @@ class TestGeoDistanceModernization:
             plugin_collector=plugin_collector,
         )
 
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Verify that all features were created successfully
         assert len(results) == 1
@@ -133,8 +132,7 @@ class TestGeoDistanceModernization:
             plugin_collector=plugin_collector,
         )
 
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Verify that all features were created successfully
         assert len(results) == 1
@@ -173,12 +171,10 @@ class TestGeoDistanceModernization:
 
         # Run both approaches
         api1 = mloda([string_feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api1._batch_run()
-        results1 = api1.get_result()
+        results1 = api1.run()
 
         api2 = mloda([config_feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api2._batch_run()
-        results2 = api2.get_result()
+        results2 = api2.run()
 
         # Both should produce results with their respective feature names
         assert "point_a&point_b__euclidean_distance" in results1[0].columns
@@ -213,7 +209,7 @@ class TestGeoDistanceModernization:
                 ),
             )
             api = mloda([feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-            api._batch_run()
+            api.run()
 
         # Test invalid number of source features (only 1 instead of 2)
         with pytest.raises(Exception):  # Should fail during validation
@@ -227,7 +223,7 @@ class TestGeoDistanceModernization:
                 ),
             )
             api = mloda([feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-            api._batch_run()
+            api.run()
 
         # Test invalid number of source features (3 instead of 2)
         with pytest.raises(Exception):  # Should fail during validation
@@ -241,7 +237,7 @@ class TestGeoDistanceModernization:
                 ),
             )
             api = mloda([feature], {PandasDataFrame}, plugin_collector=plugin_collector)
-            api._batch_run()
+            api.run()
 
     def test_multiple_distance_types_configuration_based(self) -> None:
         """Test multiple distance types using configuration-based approach."""
@@ -278,8 +274,7 @@ class TestGeoDistanceModernization:
 
         # Run the mloda with multiple features
         api = mloda(features, {PandasDataFrame}, plugin_collector=plugin_collector)
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Verify all features were created
         assert len(results) == 1
@@ -322,8 +317,7 @@ class TestGeoDistanceModernization:
 
         # Run the mloda with both features
         api = mloda([feature1, feature2], {PandasDataFrame}, plugin_collector=plugin_collector)
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # Both features should be processed together (same Feature Group resolution)
         assert len(results) == 1
@@ -406,8 +400,7 @@ class TestGeoDistanceModernization:
 
         # Run the mloda with mixed features
         api = mloda(features, {PandasDataFrame}, plugin_collector=plugin_collector)
-        api._batch_run()
-        results = api.get_result()
+        results = api.run()
 
         # All features should be processed successfully
         assert len(results) == 1


### PR DESCRIPTION
## What and why

MlodaTestRunner and about forty tests drove a session through the private mlodaAPI._batch_run(...) and then read get_result() / get_artifacts() directly. The public mlodaAPI.run(...) already does exactly that (calls _batch_run, stores the runner, returns the results), so these callers now use the public entry point instead. Going through run() means the tests exercise the same path real users do.

## Changes

- MlodaTestRunner.run_api now calls api.run(parallelization_modes=..., flight_server=..., function_extender=...) and uses its return value directly, dropping the redundant get_result() call.
- All other direct _batch_run(...) calls in tests/ (about forty call sites across ten files) are replaced with run(...), keeping their get_artifacts() calls where present.
- Two call sites in tests/test_core/test_api/ are intentionally left calling _batch_run() directly, since they unit-test that private method's own contract rather than using it to drive a session: one asserts its return type (an ExecutionOrchestrator, which run() does not return), the other asserts its fallback behavior when no run_context is passed (a branch run() always bypasses by building one explicitly).

## Testing

tox passes with the expected skip count unchanged.