### PR TITLE
fix: populate RunResult.runner in MlodaTestRunner.run_api

### DIFF
--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -96,7 +96,7 @@ class MlodaTestRunner:
             strict_type_enforcement: If True, enforce strict type matching for typed features
 
         Returns:
-            RunResult containing results, artifacts, and optionally the runner
+            RunResult containing results, artifacts, and the runner
         """
         if compute_frameworks is None:
             compute_frameworks = {PyArrowTable}
@@ -122,7 +122,7 @@ class MlodaTestRunner:
         if cleanup_flight_server:
             MlodaTestRunner.assert_flight_server_clean(parallelization_modes, flight_server)
 
-        return RunResult(results=results, artifacts=artifacts)
+        return RunResult(results=results, artifacts=artifacts, runner=api.runner)
 
     @staticmethod
     def run_api_simple(

--- a/tests/test_core/test_tooling/test_mloda_test_runner.py
+++ b/tests/test_core/test_tooling/test_mloda_test_runner.py
@@ -1,0 +1,23 @@
+"""Tests for the MlodaTestRunner helper itself."""
+
+from mloda.user import Feature, Features
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+from tests.test_core.test_tooling import MlodaTestRunner
+
+
+class TestRunApi:
+    def test_run_api_populates_runner(self) -> None:
+        """run_api returns the ExecutionOrchestrator that produced the results, as documented."""
+        features = Features([Feature(name="ApiInputDataTestFeatureGroup_id")])
+        api_data = {"TestApiInputData": {"ApiInputDataTestFeatureGroup_id": [12, 2, 3]}}
+
+        result = MlodaTestRunner.run_api(
+            features,
+            compute_frameworks={PyArrowTable},
+            api_data=api_data,
+        )
+
+        assert result.runner is not None
+        assert result.results == result.runner.get_result()
+        assert result.artifacts == result.runner.get_artifacts()


### PR DESCRIPTION
Fixes #1312

## What

`MlodaTestRunner.run_api` declares and documents `RunResult.runner` ("RunResult containing results, artifacts, and optionally the runner"), but the field is never assigned and was always `None`.

## Fix

`_batch_run()` already returns the `ExecutionOrchestrator` it ran (and sets `api.runner` as a side effect), so `run_api` now captures that return value and passes it through to `RunResult`. The docstring is aligned with the actual behavior: the runner is now always populated.

Adds a regression test (`tests/test_core/test_tooling/test_mloda_test_runner.py`) asserting that `run_api` returns the orchestrator that produced the results, and that `result.results` / `result.artifacts` agree with it.

## Validation

- Full suite: **9798 passed, 170 skipped, 2 xfailed** — skip count unchanged vs `EXPECTED_SKIP_COUNT=170`
- `ruff format --check` / `ruff check` (line length 120): pass
- `mypy --strict --ignore-missing-imports`: pass (1066 files)
- `bandit -c pyproject.toml -r -q .` and `pip-licenses` allow-list: pass