### PR TITLE
fix: assign self.runner before stream_run yield loop (#1232)

### DIFF
--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -513,6 +513,12 @@ class mlodaAPI:
         run_context: RunContext,
     ) -> Generator[Any, None, None]:
         """Deferred half of ``stream_run``: iterating this is what actually drives computation."""
+        # Assign self.runner before the yield loop so that get_result()/get_artifacts()
+        # remain accessible even when the consumer exits early (break / next()).
+        # Previously this line lived after the loop, which meant an early exit left
+        # self.runner unset and both methods raised "You need to run any run function
+        # beforehand." despite teardown having completed successfully in `finally`.
+        self.runner = runner
         try:
             self._enter_runner_context(
                 runner,
@@ -526,7 +532,6 @@ class mlodaAPI:
                 yield result
         finally:
             self._exit_runner_context(runner)
-        self.runner = runner
 
     def _batch_run(
         self,

--- a/tests/test_core/test_integration/test_core/test_stream_run_early_exit.py
+++ b/tests/test_core/test_integration/test_core/test_stream_run_early_exit.py
@@ -1,0 +1,140 @@
+# mypy: disable-error-code="type-arg"
+"""Integration tests for issue #1232: stream_run loses the runner when the consumer
+exits early.
+
+Before the fix, ``self.runner`` was assigned *after* the yield loop, so a
+consumer that called ``next()`` once and stopped (or used ``break``) left
+``self.runner`` as ``None``.  That caused ``get_result()`` and
+``get_artifacts()`` to raise "You need to run any run function beforehand."
+even though the ``finally`` teardown had already run successfully.
+
+Fix: assign ``self.runner`` *before* the yield loop.
+
+Definition of done (from the issue):
+- [x] get_result()/get_artifacts() work after early consumer exit from a stream
+- [x] Test breaking out of stream_all after one item
+- [x] tox passes
+"""
+
+from typing import Any
+
+import pyarrow as pa
+
+# stream_run plans eagerly, so the EngineRunnerTest* feature groups must be
+# registered before prepare() is called.
+import tests.test_core.test_integration.test_core.test_runner_one_compute_framework  # noqa: F401
+from mloda.user import Feature, Features, ParallelizationMode, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+COMPUTE_FRAMEWORKS: set[Any] = {PyArrowTable}
+PARALLELIZATION_MODES: set[ParallelizationMode] = {ParallelizationMode.SYNC}
+
+
+def _session_with_features(feature_list: list[str]) -> mlodaAPI:
+    """Prepare a session with the given features."""
+    return mlodaAPI.prepare(
+        Features([Feature(name=f, initial_requested_data=True) for f in feature_list]),
+        compute_frameworks=COMPUTE_FRAMEWORKS,
+    )
+
+
+class TestStreamRunEarlyExitRunnerAssignment:
+    """stream_run must set session.runner even when the consumer exits early."""
+
+    def test_runner_set_after_single_next_call(self) -> None:
+        """session.runner must not be None after a single next() call."""
+        session = _session_with_features(["EngineRunnerTest1"])
+        gen = session.stream_run(parallelization_modes=PARALLELIZATION_MODES)
+
+        first = next(gen)  # consume only the first (and only) item
+
+        assert session.runner is not None, (
+            "session.runner must be set even when the consumer calls next() once "
+            "and does not exhaust the generator (issue #1232)"
+        )
+        assert isinstance(first, pa.Table)
+
+    def test_runner_set_after_break_from_multi_feature_stream(self) -> None:
+        """session.runner must not be None after breaking out of a multi-feature stream."""
+        session = _session_with_features(["EngineRunnerTest1", "EngineRunnerTest2"])
+        gen = session.stream_run(parallelization_modes=PARALLELIZATION_MODES)
+
+        for _result in gen:
+            break  # exit after the very first yielded result
+
+        assert session.runner is not None, (
+            "session.runner must be set after breaking out of stream_run early (issue #1232)"
+        )
+
+    def test_get_artifacts_does_not_raise_after_early_exit(self) -> None:
+        """get_artifacts() must not raise the 'run function beforehand' error after early exit."""
+        session = _session_with_features(["EngineRunnerTest1", "EngineRunnerTest2"])
+        gen = session.stream_run(parallelization_modes=PARALLELIZATION_MODES)
+        next(gen)  # early exit
+
+        # Should not raise ValueError("You need to run any run function beforehand.")
+        artifacts = session.get_artifacts()
+        assert isinstance(artifacts, dict)
+
+    def test_get_artifacts_does_not_raise_after_break_from_stream_all(self) -> None:
+        """Breaking out of stream_all() must not prevent get_artifacts() from working.
+
+        stream_all() wraps stream_run() via ResultStream, so the fix applies here too.
+        """
+        stream = mlodaAPI.stream_all(
+            Features(
+                [
+                    Feature(name="EngineRunnerTest1", initial_requested_data=True),
+                    Feature(name="EngineRunnerTest2", initial_requested_data=True),
+                ]
+            ),
+            compute_frameworks=COMPUTE_FRAMEWORKS,
+            parallelization_modes=PARALLELIZATION_MODES,
+        )
+
+        for _result in stream:
+            break  # exit after one item
+
+        # The underlying session is not exposed by ResultStream, so we verify
+        # indirectly that the generator's finally block ran without error
+        # (i.e. no exception was raised by early exit teardown).
+        # The primary assertion is that breaking does NOT raise an unhandled exception.
+
+    def test_runner_set_before_first_yield(self) -> None:
+        """session.runner must be set even before the generator produces its first value.
+
+        This verifies the assignment happens before the loop, not in the finally block.
+        """
+        session = _session_with_features(["EngineRunnerTest1"])
+        gen = session.stream_run(parallelization_modes=PARALLELIZATION_MODES)
+
+        # Advance to the point where the first value is about to be yielded.
+        # After next() returns, self.runner must already be set.
+        _first = next(gen)
+
+        # runner is set — we don't need to exhaust the generator
+        assert session.runner is not None
+
+        # Clean up the generator properly
+        gen.close()
+
+
+class TestStreamRunFullExitStillWorks:
+    """Regression: full iteration must still work after the fix."""
+
+    def test_full_iteration_runner_set(self) -> None:
+        """Exhausting the generator fully must still leave session.runner set."""
+        session = _session_with_features(["EngineRunnerTest1"])
+        results = list(session.stream_run(parallelization_modes=PARALLELIZATION_MODES))
+
+        assert session.runner is not None
+        assert len(results) == 1
+        assert isinstance(results[0], pa.Table)
+
+    def test_full_iteration_get_artifacts_works(self) -> None:
+        """get_artifacts() after full iteration must not raise."""
+        session = _session_with_features(["EngineRunnerTest1"])
+        list(session.stream_run(parallelization_modes=PARALLELIZATION_MODES))
+
+        artifacts = session.get_artifacts()
+        assert isinstance(artifacts, dict)

--- a/tests/test_core/test_integration/test_core/test_stream_run_early_exit.py
+++ b/tests/test_core/test_integration/test_core/test_stream_run_early_exit.py
@@ -77,9 +77,12 @@ class TestStreamRunEarlyExitRunnerAssignment:
         assert isinstance(artifacts, dict)
 
     def test_get_artifacts_does_not_raise_after_break_from_stream_all(self) -> None:
-        """Breaking out of stream_all() must not prevent get_artifacts() from working.
+        """Breaking out of stream_all() must not raise when the stream is closed afterward.
 
-        stream_all() wraps stream_run() via ResultStream, so the fix applies here too.
+        ResultStream does not expose the underlying session, so get_artifacts() cannot be
+        reached through this API. This instead verifies the concrete guarantee stream_all
+        depends on: closing the stream after an early break must drive the generator's
+        ``finally`` teardown (``_exit_runner_context``) without raising.
         """
         stream = mlodaAPI.stream_all(
             Features(
@@ -95,10 +98,7 @@ class TestStreamRunEarlyExitRunnerAssignment:
         for _result in stream:
             break  # exit after one item
 
-        # The underlying session is not exposed by ResultStream, so we verify
-        # indirectly that the generator's finally block ran without error
-        # (i.e. no exception was raised by early exit teardown).
-        # The primary assertion is that breaking does NOT raise an unhandled exception.
+        stream.close()  # drives the generator's finally teardown; must not raise
 
     def test_runner_set_before_first_yield(self) -> None:
         """session.runner must be set even before the generator produces its first value.
@@ -112,7 +112,7 @@ class TestStreamRunEarlyExitRunnerAssignment:
         # After next() returns, self.runner must already be set.
         _first = next(gen)
 
-        # runner is set — we don't need to exhaust the generator
+        # runner is set (no need to exhaust the generator)
         assert session.runner is not None
 
         # Clean up the generator properly


### PR DESCRIPTION
## Summary

Rebase of #1270 (by @Maqbool61) onto current `main`. The original PR went stale: `stream_run` was split into `stream_run` + `_stream_run_results` by #1278/#1288 after #1270 was opened, so the original diff no longer applied. This carries the original fix commit forward (rebased onto the new structure) and adds one follow-up commit.

`_stream_run_results` assigned `self.runner = runner` *after* the yield loop, so any consumer that exited early (a `break`, a single `next()` call, or `.close()`) left `self.runner` as `None`. Both `get_result()` and `get_artifacts()` check `if self.runner is None` first, so they raised:

```
ValueError: You need to run any run function beforehand.
```

even though the `finally` block had already torn down cleanly.

## Fix

Move `self.runner = runner` to *before* the `try` in `_stream_run_results`, so the assignment survives any early consumer exit.

## Follow-up commit

`test_get_artifacts_does_not_raise_after_break_from_stream_all` couldn't actually call `get_artifacts()` (`ResultStream` doesn't expose the underlying session), so it had no real assertion. Replaced the bare `break` with an explicit `stream.close()`, which verifies the concrete guarantee `stream_all()` depends on: the generator's `finally` teardown runs cleanly on early exit.

Fixes #1232

Original contribution by @Maqbool61 in #1270.