### PR TITLE
fix: preserve feature identity when loading artifacts

### DIFF
--- a/mloda/core/abstract_plugins/components/base_artifact.py
+++ b/mloda/core/abstract_plugins/components/base_artifact.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from copy import copy
 from typing import Any, Optional, final
 
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -92,6 +93,11 @@ class BaseArtifact(ABC):
         If features carry different Options (e.g. due to context-based
         partitioning), saving and loading a single artifact per feature set
         is ambiguous. Raises ValueError when Options differ across features.
+
+        A runtime artifact is exposed through a temporary Options copy so
+        existing custom loaders can read it by ``artifact_to_load`` without
+        adding execution state to the shared Options that determine Feature
+        equality and hashing.
         """
 
         _options = None
@@ -108,6 +114,13 @@ class BaseArtifact(ABC):
 
         if _options is None:
             return None
+
+        if features.artifact_to_load is not None and features.runtime_artifact_to_load is not None:
+            # Options.__copy__ gives the overlay its own group/context dictionaries while
+            # preserving opaque option values and provenance metadata by reference/value.
+            isolated_options = copy(_options)
+            isolated_options.set(features.artifact_to_load, features.runtime_artifact_to_load)
+            return isolated_options
 
         return _options
 

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -24,6 +24,10 @@ class FeatureSet:
         self.name_of_one_feature: Optional[FeatureName] = None
         self.artifact_to_save: Optional[str] = None
         self.artifact_to_load: Optional[str] = None
+        # Runtime artifact payloads are execution state, not feature configuration. Keeping the
+        # value separate prevents an artifact from changing Options.group and invalidating the
+        # hashes of Feature objects already stored in ``features``.
+        self.runtime_artifact_to_load: Optional[Any] = None
         self.save_artifact: Optional[Any] = None
         self.filter_engine: type[BaseFilterEngine] = BaseFilterEngine
         self.mask_engine: type[BaseMaskEngine] | None = None
@@ -37,6 +41,7 @@ class FeatureSet:
     def add_artifact_name(self) -> None:
         FeatureSetValidator.validate_options_initialized(self.options, "add_artifact_name")
         assert self.options is not None  # Type narrowing for mypy
+        self.runtime_artifact_to_load = None
 
         for feature_name in self.get_all_names():
             if feature_name in self.options.keys():
@@ -50,7 +55,9 @@ class FeatureSet:
 
         Called at step execution time on the deep-copied FeatureSet when
         artifacts are passed to run(). This enables switching between save
-        and load modes across run() calls without re-preparing.
+        and load modes across run() calls without re-preparing. The selected
+        payload is kept as execution state instead of being written to shared
+        feature Options, whose group values define Feature identity.
         """
         FeatureSetValidator.validate_options_initialized(self.options, "resolve_artifact_for_runtime")
         assert self.options is not None
@@ -59,11 +66,12 @@ class FeatureSet:
             if feature_name in runtime_artifacts:
                 self.artifact_to_load = feature_name
                 self.artifact_to_save = None
-                self.options.set(feature_name, runtime_artifacts[feature_name])
+                self.runtime_artifact_to_load = runtime_artifacts[feature_name]
                 return
 
         self.artifact_to_load = None
         self.artifact_to_save = self.get_name_of_one_feature()
+        self.runtime_artifact_to_load = None
 
     def add(self, feature: Feature) -> None:
         self.features.add(feature)

--- a/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
+++ b/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
@@ -66,3 +66,22 @@ class TestFeatureSetResolveArtifactForRuntimeUsesArtifactToLoad:
         result = BaseArtifact.load(features)
 
         assert result == "runtime_value"
+
+    def test_runtime_artifact_does_not_change_feature_identity_or_group_options(self) -> None:
+        shared_options = Options(group={"model_version": "v1"}, context={"trace_id": "run-1"})
+        feature = Feature("artifact_feature", shared_options)
+        features = FeatureSet([feature])
+        feature_hash = hash(feature)
+        group_options = shared_options.group.copy()
+
+        features.resolve_artifact_for_runtime({"artifact_feature": "runtime_value"})
+
+        assert features.artifact_to_load == "artifact_feature"
+        assert features.artifact_to_save is None
+        assert feature in features.features
+        assert hash(feature) == feature_hash
+        assert shared_options.group == group_options
+        assert BaseArtifact.load(features) == "runtime_value"
+        assert feature in features.features
+        assert hash(feature) == feature_hash
+        assert shared_options.group == group_options


### PR DESCRIPTION
Closes #1236.

Keeps runtime artifact payloads outside shared feature options and gives artifact loaders an isolated options overlay. This preserves feature set membership, hashes, and group configuration.

Validation: `tox` (9,852 passed, 170 skipped, 2 xfailed; formatting, Ruff, licenses, mypy, and Bandit passed).
