### PR TITLE
fix: include discriminators in Link equality and hash

### DIFF
--- a/mloda/core/abstract_plugins/components/link.py
+++ b/mloda/core/abstract_plugins/components/link.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from typing import Any, ClassVar, Literal, Optional
 
 
+from mloda.core.abstract_plugins.components.hashable_dict import _deep_hashable
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.validators.link_validator import LinkValidator
 
@@ -95,18 +96,6 @@ class JoinSpec:
 
     def __hash__(self) -> int:
         return hash((self.feature_group, self.index))
-
-
-def _freeze_discriminator(discriminator: Optional[dict[str, Any]]) -> Optional[tuple[tuple[str, Any], ...]]:
-    """Return a hashable, order-independent representation of a discriminator dict.
-
-    Discriminators are optional ``{key: value}`` dicts; dicts are unhashable, so this
-    normalizes them (sorted by key) into a tuple that can participate in ``__hash__``
-    while comparing equal regardless of insertion order.
-    """
-    if discriminator is None:
-        return None
-    return tuple(sorted(discriminator.items()))
 
 
 def _get_index_from_feature_group(
@@ -624,7 +613,7 @@ class Link:
                 self.left_index,
                 self.right_index,
                 self.asof_config,
-                _freeze_discriminator(self.left_discriminator),
-                _freeze_discriminator(self.right_discriminator),
+                _deep_hashable(self.left_discriminator),
+                _deep_hashable(self.right_discriminator),
             )
         )

--- a/mloda/core/abstract_plugins/components/link.py
+++ b/mloda/core/abstract_plugins/components/link.py
@@ -97,6 +97,18 @@ class JoinSpec:
         return hash((self.feature_group, self.index))
 
 
+def _freeze_discriminator(discriminator: Optional[dict[str, Any]]) -> Optional[tuple[tuple[str, Any], ...]]:
+    """Return a hashable, order-independent representation of a discriminator dict.
+
+    Discriminators are optional ``{key: value}`` dicts; dicts are unhashable, so this
+    normalizes them (sorted by key) into a tuple that can participate in ``__hash__``
+    while comparing equal regardless of insertion order.
+    """
+    if discriminator is None:
+        return None
+    return tuple(sorted(discriminator.items()))
+
+
 def _get_index_from_feature_group(
     feature_group: type[Any],
     index_position: int,
@@ -599,6 +611,8 @@ class Link:
             and self.left_index == other.left_index
             and self.right_index == other.right_index
             and self.asof_config == other.asof_config
+            and self.left_discriminator == other.left_discriminator
+            and self.right_discriminator == other.right_discriminator
         )
 
     def __hash__(self) -> int:
@@ -610,5 +624,7 @@ class Link:
                 self.left_index,
                 self.right_index,
                 self.asof_config,
+                _freeze_discriminator(self.left_discriminator),
+                _freeze_discriminator(self.right_discriminator),
             )
         )

--- a/tests/test_core/test_setup/test_link_discriminator_eq_hash.py
+++ b/tests/test_core/test_setup/test_link_discriminator_eq_hash.py
@@ -130,3 +130,26 @@ class TestLinkDiscriminatorEqHash:
         )
         assert link_with != link_without
         assert len({link_with, link_without}) == 2
+
+    def test_list_valued_discriminator_is_hashable(self) -> None:
+        """A discriminator holding a list value (a valid Options value, e.g. file_paths) must not
+        raise on hash(); Link.__hash__ has to normalize it instead of hashing it directly."""
+        link_1 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"file_paths": ["a.csv", "b.csv"]},
+        )
+        link_2 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"file_paths": ["a.csv", "b.csv"]},
+        )
+        link_3 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"file_paths": ["a.csv", "c.csv"]},
+        )
+        assert link_1 == link_2
+        assert hash(link_1) == hash(link_2)
+        assert link_1 != link_3
+        assert len({link_1, link_2, link_3}) == 2

--- a/tests/test_core/test_setup/test_link_discriminator_eq_hash.py
+++ b/tests/test_core/test_setup/test_link_discriminator_eq_hash.py
@@ -1,0 +1,132 @@
+"""
+Tests that Link equality/hash incorporate the left/right discriminators.
+
+Two links that differ only by their discriminators identify different join nodes
+(e.g. the same FeatureGroup class reading two different CSV files) and must not
+collapse into one another in a ``set``/``dict``.
+
+See Also:
+    - GitHub Issue #1235: Link equality/hash ignore discriminators
+"""
+
+from typing import Any, Optional
+
+from mloda.provider import FeatureGroup
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+
+
+# ============================================================================
+# Mock Feature Group for Testing (mirrors test_link_on_methods.py pattern)
+# ============================================================================
+class DiscriminatorFG(FeatureGroup):
+    """Mock feature group with a single index column 'id'."""
+
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+        return None
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("id",))]
+
+
+# ============================================================================
+# eq / hash incorporate discriminators
+# ============================================================================
+class TestLinkDiscriminatorEqHash:
+    def test_different_right_discriminator_not_equal(self) -> None:
+        """Two links identical except for right_discriminator must NOT be equal."""
+        link_b = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "b.csv"},
+        )
+        link_c = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "c.csv"},
+        )
+        assert link_b != link_c
+
+    def test_different_left_discriminator_not_equal(self) -> None:
+        """Two links identical except for left_discriminator must NOT be equal."""
+        link_a = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "z.csv"},
+        )
+        link_b = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "b.csv"},
+            right_discriminator={"r": "z.csv"},
+        )
+        assert link_a != link_b
+
+    def test_discriminator_differing_links_both_survive_in_set(self) -> None:
+        """Links differing only by discriminator must both persist in a set."""
+        link_b = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "b.csv"},
+        )
+        link_c = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "c.csv"},
+        )
+        assert len({link_b, link_c}) == 2
+
+    def test_identical_discriminators_equal_with_equal_hash(self) -> None:
+        """Two truly-identical links remain equal and hash equal (eq/hash contract)."""
+        link_1 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "b.csv"},
+        )
+        link_2 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+            right_discriminator={"r": "b.csv"},
+        )
+        assert link_1 == link_2
+        assert hash(link_1) == hash(link_2)
+        assert len({link_1, link_2}) == 1
+
+    def test_discriminator_hash_is_order_independent(self) -> None:
+        """A multi-key discriminator hashes equal regardless of insertion order."""
+        link_1 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"reader": "a.csv", "region": "us"},
+        )
+        link_2 = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"region": "us", "reader": "a.csv"},
+        )
+        assert link_1 == link_2
+        assert hash(link_1) == hash(link_2)
+
+    def test_discriminator_vs_none_not_equal(self) -> None:
+        """A link with a discriminator is not equal to one without it."""
+        link_with = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+            left_discriminator={"r": "a.csv"},
+        )
+        link_without = Link.inner(
+            JoinSpec(DiscriminatorFG, "id"),
+            JoinSpec(DiscriminatorFG, "id"),
+        )
+        assert link_with != link_without
+        assert len({link_with, link_without}) == 2


### PR DESCRIPTION
## Summary
`Link.__eq__` / `__hash__` ignored `left_discriminator` / `right_discriminator`, so two links differing only by discriminator compared equal and collapsed in a `set[Link]` — silently dropping a join.

## Related issue
Closes #1235

## Changes
- Add `_freeze_discriminator` to normalize the optional dict into a hashable, key-sorted (order-independent) tuple.
- Include both discriminators in `__eq__` and `__hash__`, preserving the `a == b ⇒ hash(a) == hash(b)` contract.
- Add `tests/test_core/test_setup/test_link_discriminator_eq_hash.py` proving discriminator-differing links persist in a `set` (len == 2) and identical links still collapse (len == 1, equal hash).

## Testing
`tests/test_core/test_setup/` + `test_prepare/`: 1180 passed, 2 xfailed. New discriminator tests + existing asof eq/hash tests: 20 passed. `ruff format --check` and `mypy` on `link.py` pass. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)