### PR TITLE
fix: populate RunResult runner field

### DIFF
--- a/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
+++ b/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
@@ -347,6 +347,7 @@ class TestEndToEndIntegration:
         run_result = MlodaTestRunner.run_api(features, parallelization_modes=modes, flight_server=flight_server)
 
         assert len(run_result.results) == 1
+        assert run_result.runner is not None
         result = run_result.results[0]
         assert "TypedFeatureSource" in result.column_names
         assert result.to_pydict()["TypedFeatureSource"] == [25, 30, 35]

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -122,7 +122,10 @@ class MlodaTestRunner:
         if cleanup_flight_server:
             MlodaTestRunner.assert_flight_server_clean(parallelization_modes, flight_server)
 
-        return RunResult(results=results, artifacts=artifacts)
+        return RunResult(results=results,
+                        artifacts=artifacts,
+                        runner=api.runner,
+                    )
 
     @staticmethod
     def run_api_simple(

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -122,10 +122,11 @@ class MlodaTestRunner:
         if cleanup_flight_server:
             MlodaTestRunner.assert_flight_server_clean(parallelization_modes, flight_server)
 
-        return RunResult(results=results,
-                        artifacts=artifacts,
-                        runner=api.runner,
-                    )
+        return RunResult(
+            results=results,
+            artifacts=artifacts,
+            runner=api.runner,
+        )
 
     @staticmethod
     def run_api_simple(


### PR DESCRIPTION
fix: populate RunResult runner field

## Summary

Populate `RunResult.runner` in `MlodaTestRunner.run_api` using the runner created by the API.

Added a test to verify that `RunResult.runner` is populated correctly.

## Related issue

Closes #1312

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [ ] `tox` passes locally
- [x] Tests added or updated for the change
- [ ] Documentation updated where relevant
- [x] PR title follows Conventional Commits