### PR TITLE
fix: stop multiprocessing workers from outliving a killed parent

### DIFF
--- a/mloda/core/runtime/worker/multiprocessing_worker.py
+++ b/mloda/core/runtime/worker/multiprocessing_worker.py
@@ -142,6 +142,12 @@ def worker(
         try:
             command = command_queue.get(block=False)
         except Empty:
+            # Lets an orphaned worker exit on its own if its parent dies (e.g. SIGKILL).
+            # Only checked here at poll time, so a command already in progress runs to
+            # completion before this loop is reached again (best-effort, not preemptive).
+            parent = multiprocessing.parent_process()
+            if parent is not None and not parent.is_alive():
+                break
             time.sleep(0.01)
             continue
 

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -47,7 +47,10 @@ class WorkerManager:
         result_queue: multiprocessing.Queue[Any] = ctx.Queue()
 
         worker_index = len(self.process_register)
-        process = ctx.Process(target=target, args=(command_queue, result_queue, *args, worker_index))
+        # daemon=True so this process is reaped automatically if the parent exits without
+        # calling join_all(); as a side effect, code running inside a worker cannot itself
+        # spawn multiprocessing children (Python raises on that).
+        process = ctx.Process(target=target, args=(command_queue, result_queue, *args, worker_index), daemon=True)
 
         self.process_register[cfw_uuid] = (process, command_queue, result_queue)
         self.result_queues_collection.add(result_queue)

--- a/tests/test_core/test_runtime/test_multiprocessing_worker.py
+++ b/tests/test_core/test_runtime/test_multiprocessing_worker.py
@@ -7,6 +7,8 @@ from typing import Any
 from unittest.mock import Mock
 from uuid import uuid4
 
+import pytest
+
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.abstract_plugins.run_context import RunContext
 from mloda.core.core.cfw_manager import CfwManager
@@ -85,3 +87,26 @@ class TestWorkerReportsChildBootstrapExceptionThroughTheErrorChannel:
         # exactly like the existing except block at the bottom of the while-True loop does.
         stopped_command = command_queue.get(timeout=2)
         assert stopped_command == "STOP"
+
+
+class TestWorkerExitsWhenTheParentProcessIsNoLongerAlive:
+    """worker() exits its command loop once parent_process() reports the parent as dead, even without a STOP."""
+
+    @pytest.mark.timeout(5)
+    def test_worker_returns_without_a_stop_command_when_parent_is_dead(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _FakeDeadParent:
+            def is_alive(self) -> bool:
+                return False
+
+        monkeypatch.setattr(multiprocessing, "parent_process", lambda: _FakeDeadParent())
+
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+
+        # No STOP is queued; the dead-parent check alone must end the loop.
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), worker_index=0)

--- a/tests/test_core/test_runtime/test_worker_manager.py
+++ b/tests/test_core/test_runtime/test_worker_manager.py
@@ -153,6 +153,26 @@ class TestWorkerManagerProcessCreation:
 
         mock_process.start.assert_called_once()
 
+    def test_create_worker_process_passes_daemon_true(self) -> None:
+        """Worker processes must be daemonic so they are reaped if the parent interpreter exits."""
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+        target_func = Mock()
+        args = ("arg1", "arg2")
+
+        mock_process = Mock()
+        mock_ctx = Mock()
+        mock_ctx.Process.return_value = mock_process
+        mock_ctx.Queue.return_value = Mock()
+
+        with patch(
+            "mloda.core.runtime.worker_manager.mp_spawn_context",
+            return_value=mock_ctx,
+        ):
+            manager.create_worker_process(cfw_uuid, target_func, args)
+
+        assert mock_ctx.Process.call_args.kwargs.get("daemon") is True
+
 
 class TestWorkerManagerProcessRetrieval:
     """Test retrieving existing process information."""

--- a/tests/test_core/test_runtime/test_worker_parent_death.py
+++ b/tests/test_core/test_runtime/test_worker_parent_death.py
@@ -1,0 +1,108 @@
+"""A worker spawned via WorkerManager must exit once the real OS process that spawned it is killed."""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.abstract_plugins.run_context import RunContext
+from mloda.core.runtime.mp_context import mp_spawn_context
+from mloda.core.runtime.worker.multiprocessing_worker import worker
+from mloda.core.runtime.worker_manager import WorkerManager
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+class _FakeCfwManager:
+    """Plain, picklable stand-in for CfwManager; Mock objects do not reliably pickle across spawn."""
+
+    def get_location(self) -> str:
+        return "grpc://localhost:9999"
+
+    def get_run_context(self) -> RunContext:
+        return RunContext()
+
+
+def _worker_is_gone(pid: int) -> bool:
+    """A reparented child can sit as an unreaped zombie, which still answers os.kill(pid, 0);
+    /proc state distinguishes that from actually running."""
+    stat_path = Path(f"/proc/{pid}/stat")
+    if not stat_path.exists():
+        return True
+    return stat_path.read_text().rsplit(")", 1)[1].split()[0] == "Z"
+
+
+def _fake_parent_main(pid_file: str) -> None:
+    """Spawns a real worker() child via WorkerManager, writes its pid to pid_file, then blocks for SIGKILL."""
+    manager = WorkerManager()
+    cfw_register = _FakeCfwManager()
+    cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+
+    process, _, _ = manager.create_worker_process(
+        cfw_uuid=uuid4(),
+        target=worker,
+        args=(cfw_register, cfw, uuid4()),
+    )
+
+    with open(pid_file, "w") as pid_handle:
+        pid_handle.write(str(process.pid))
+
+    # Non-daemonic (it has its own child); if the test process dies uncleanly,
+    # multiprocessing's exit handling would join this for the full sleep duration.
+    time.sleep(20)
+
+
+class TestWorkerProcessDoesNotOutliveASigkilledParent:
+    """A worker spawned via WorkerManager.create_worker_process must exit once its parent dies."""
+
+    @pytest.mark.timeout(30)
+    def test_real_worker_process_exits_after_its_real_parent_process_is_sigkilled(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "worker.pid"
+        ctx = mp_spawn_context()
+        fake_parent = ctx.Process(target=_fake_parent_main, args=(str(pid_file),))
+        fake_parent.start()
+
+        worker_pid: int | None = None
+        worker_gone = False
+        try:
+            deadline = time.time() + 5.0
+            while time.time() < deadline and worker_pid is None:
+                if pid_file.exists():
+                    content = pid_file.read_text().strip()
+                    if content:
+                        worker_pid = int(content)
+                        break
+                time.sleep(0.05)
+            assert worker_pid is not None, (
+                f"fake parent process never reported the worker's pid (fake_parent.exitcode={fake_parent.exitcode})"
+            )
+
+            assert fake_parent.pid is not None, "fake parent process has no pid"
+            fake_parent_pid = fake_parent.pid
+            os.kill(fake_parent_pid, signal.SIGKILL)
+            fake_parent.join(timeout=5)
+            assert not fake_parent.is_alive(), "fake parent process survived SIGKILL"
+
+            deadline = time.time() + 10.0
+            while time.time() < deadline:
+                if _worker_is_gone(worker_pid):
+                    worker_gone = True
+                    break
+                time.sleep(0.1)
+
+            assert worker_gone, "worker process outlived its SIGKILLed parent process"
+        finally:
+            # Never leak either process, even if an assertion above failed.
+            if fake_parent.is_alive():
+                fake_parent.kill()
+                fake_parent.join(timeout=5)
+            if worker_pid is not None and not worker_gone:
+                try:
+                    os.kill(worker_pid, signal.SIGKILL)
+                except OSError:
+                    pass


### PR DESCRIPTION
## Summary

`MultiprocessingWorker` processes polled their command queue in an unbounded loop with no check on whether their parent process was still alive. If the parent was killed abruptly (SIGKILL), the worker was reparented to init and kept running indefinitely, holding its full memory.

Workers now exit their command loop once `multiprocessing.parent_process()` reports the parent as no longer alive, checked each time the command queue is found empty. Worker processes are also created as daemons, so they are reaped automatically on the normal and exception exit paths too, not only via an explicit stop signal.

This check happens at poll time: a worker in the middle of executing a command finishes that command before it can notice a dead parent. That matches the reported symptom (idle workers spinning forever) without introducing a preemptive kill mid-computation.

## Testing

Added a real-process integration test that spawns a worker via `WorkerManager`, SIGKILLs its parent, and asserts the worker exits on its own within a bounded time, plus unit tests for the loop's parent-liveness check and for `daemon=True` being passed through.

Closes #1292