### PR TITLE
feat: add single-source extraction accessor to FeatureChainParserMixin

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -134,8 +134,10 @@ class FeatureChainParser:
     ) -> tuple[str | None, str | None]:
         """Legacy adapter over ``parse_name``: returns ``(operation_config, source_feature)``.
 
-        Public API (mloda_plugins call sites and documented examples), so the tuple stays
-        byte-for-byte identical to today, including the captureless fabrication and the ValueError.
+        Public API, so the tuple stays byte-for-byte identical to today: ``(None, None)`` on no
+        match; otherwise ``source_feature`` is always populated, and ``operation_config`` is
+        ``None`` for a captureless or non-participating-capture pattern (a match with nothing
+        before the separator still raises, as before).
         """
         parsed = cls.parse_name(feature_name, prefix_patterns, pattern)
         if not parsed.matched:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -622,11 +622,28 @@ class FeatureChainParserMixin:
         return [f.name for f in in_features_set]
 
     @classmethod
+    def _extract_single_source_feature(cls, feature: Feature) -> str:
+        """Single-source counterpart to ``_extract_source_features``; always enforces exactly one result.
+
+        Raises:
+            ValueError: if the resolved source count is not exactly one
+        """
+        source_features = cls._extract_source_features(feature)
+        reason = cls._in_feature_count_reason(feature.name, len(source_features))
+        if reason is not None:
+            raise ValueError(reason)
+        if len(source_features) != 1:
+            raise ValueError(
+                f"Feature '{feature.name}' resolved {len(source_features)} source feature(s), expected exactly 1"
+            )
+        return source_features[0]
+
+    @classmethod
     def _extract_operation_and_source_feature(
         cls, feature: Feature, extract_fn: Callable[[Feature], Any], label: str
     ) -> tuple[Any, str]:
         """
-        Extract an operation parameter and the primary source feature name from a feature.
+        Extract the primary source feature name and an operation parameter from a feature.
 
         Args:
             feature: The feature to extract parameters from
@@ -637,13 +654,13 @@ class FeatureChainParserMixin:
             Tuple of (operation_value, source_feature_name)
 
         Raises:
-            ValueError: If the operation value cannot be extracted
+            ValueError: if the source count isn't exactly one, or the operation can't be extracted
         """
-        source_features = cls._extract_source_features(feature)
+        source_feature = cls._extract_single_source_feature(feature)
         operation = extract_fn(feature)
         if operation is None:
             raise ValueError(f"Could not extract {label} from: {feature.name}")
-        return operation, source_features[0]
+        return operation, source_feature
 
     @classmethod
     def _resolve_operation(

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -406,11 +406,10 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
         algorithm, horizon, time_unit = cls._extract_forecast_params(feature)
         if algorithm is None or horizon is None or time_unit is None:
             raise ValueError(f"Could not extract forecasting parameters from: {feature.name}")
-        return algorithm, horizon, time_unit, source_features[0]
+        return algorithm, horizon, time_unit, cls._extract_single_source_feature(feature)
 
     @classmethod
     def _has_valid_forecast_suffix(cls, feature_name: str) -> bool:

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -219,13 +219,12 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
         window_function, window_size, time_unit = cls._extract_time_window_params(feature)
 
         if window_function is None or window_size is None or time_unit is None:
             raise ValueError(f"Could not extract time window parameters from: {feature.name}")
 
-        return window_function, window_size, time_unit, source_features[0]
+        return window_function, window_size, time_unit, cls._extract_single_source_feature(feature)
 
     @classmethod
     def parse_time_window_prefix(cls, feature_name: str) -> tuple[str, int, str]:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -126,6 +126,80 @@ class MockFeatureGroupWithValidationHook(FeatureChainParserMixin):
         return operation_config != "reject_me"
 
 
+class MockFeatureGroupSingleInFeatureCustomReason(FeatureChainParserMixin):
+    """Mock single-source Feature group overriding _in_feature_count_reason with custom wording."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_test$"
+    MIN_IN_FEATURES = 1
+    MAX_IN_FEATURES = 1
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+    @classmethod
+    def _in_feature_count_reason(cls, feature_name: str | FeatureName, count: int) -> Optional[str]:
+        """Custom arity wording that must win over the mixin's generic MIN/MAX message."""
+        if count != 1:
+            return f"{cls.__name__} needs exactly one input column; got {count}."
+        return None
+
+
+class MockFeatureGroupZeroSources(FeatureChainParserMixin):
+    """Mock Feature group whose _extract_source_features always resolves to zero sources."""
+
+    MIN_IN_FEATURES = 1
+    MAX_IN_FEATURES = 1
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+    @classmethod
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
+        return []
+
+
+class MockFeatureGroupNoMaxDeclared(FeatureChainParserMixin):
+    """Mock Feature group leaving MIN/MAX_IN_FEATURES at their class defaults (1 / unbounded)."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_test$"
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+
+class MockFeatureGroupMinZero(FeatureChainParserMixin):
+    """Mock Feature group with MIN_IN_FEATURES=0, whose _extract_source_features always resolves to zero sources."""
+
+    MIN_IN_FEATURES = 0
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+    @classmethod
+    def _extract_source_features(cls, feature: Feature) -> list[str]:
+        return []
+
+
 class TestFeatureChainParserMixinInputFeatures:
     """Tests for input_features() method."""
 
@@ -691,3 +765,101 @@ class TestFeatureChainParserMixinExtractSourceFeatures:
         result = MockFeatureGroupCustomSeparator._extract_source_features(feature)
 
         assert result == ["feat1", "feat2", "feat3"]
+
+
+class TestFeatureChainParserMixinExtractSingleSourceFeature:
+    """Tests for _extract_single_source_feature() classmethod."""
+
+    def test_extract_single_source_feature_string_based(self) -> None:
+        """A feature name that string-parses to exactly one source returns that source."""
+        feature = Feature(
+            name="source_feature__op1_test",
+            options=Options(context={"operation": "op1"}),
+        )
+
+        result = MockFeatureGroupSingleInFeature._extract_single_source_feature(feature)
+
+        assert result == "source_feature"
+
+    def test_extract_single_source_feature_config_based_fallback(self) -> None:
+        """A non-parsing name falls back to the single in_features option value."""
+        feature = Feature(
+            name="simple_name",
+            options=Options(context={DefaultOptionKeys.in_features: ["feature_a"], "operation": "op1"}),
+        )
+
+        result = MockFeatureGroupSingleInFeature._extract_single_source_feature(feature)
+
+        assert result == "feature_a"
+
+    def test_extract_single_source_feature_raises_generic_message_for_zero_sources(self) -> None:
+        """Zero resolved sources raise the generic MIN_IN_FEATURES-based message."""
+        feature = Feature(name="simple_name", options=Options(context={"operation": "op1"}))
+
+        with pytest.raises(ValueError) as exc_info:
+            MockFeatureGroupZeroSources._extract_single_source_feature(feature)
+
+        assert "at least 1 in_feature" in str(exc_info.value)
+
+    def test_extract_single_source_feature_raises_generic_message_for_too_many_sources(self) -> None:
+        """Two resolved sources against MAX_IN_FEATURES=1 raise the generic MAX-based message."""
+        feature = Feature(
+            name="simple_name",
+            options=Options(context={DefaultOptionKeys.in_features: ["feature_a", "feature_b"], "operation": "op1"}),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            MockFeatureGroupSingleInFeature._extract_single_source_feature(feature)
+
+        assert "at most 1 in_feature" in str(exc_info.value)
+
+    def test_extract_single_source_feature_raises_custom_message_when_overridden(self) -> None:
+        """A subclass override of _in_feature_count_reason wins over the generic wording."""
+        feature = Feature(
+            name="simple_name",
+            options=Options(context={DefaultOptionKeys.in_features: ["feature_a", "feature_b"], "operation": "op1"}),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            MockFeatureGroupSingleInFeatureCustomReason._extract_single_source_feature(feature)
+
+        assert (
+            str(exc_info.value) == "MockFeatureGroupSingleInFeatureCustomReason needs exactly one input column; got 2."
+        )
+
+    def test_extract_single_source_feature_raises_for_two_sources_when_max_unbounded(self) -> None:
+        """An unbounded MAX_IN_FEATURES must still reject 2 resolved sources, not silently pick one."""
+        feature = Feature(
+            name="simple_name",
+            options=Options(context={DefaultOptionKeys.in_features: ["feature_a", "feature_b"], "operation": "op1"}),
+        )
+
+        with pytest.raises(ValueError):
+            MockFeatureGroupNoMaxDeclared._extract_single_source_feature(feature)
+
+    def test_extract_single_source_feature_raises_value_error_not_index_error_when_min_zero(self) -> None:
+        """MIN_IN_FEATURES=0 leaves the reason hook silent at zero sources; must still raise ValueError."""
+        feature = Feature(name="simple_name", options=Options(context={"operation": "op1"}))
+
+        with pytest.raises(ValueError):
+            MockFeatureGroupMinZero._extract_single_source_feature(feature)
+
+
+def _constant_operation_extractor(_feature: Feature) -> str:
+    """An extract_fn stand-in that always resolves to a fixed, non-None operation value."""
+    return "op1"
+
+
+class TestFeatureChainParserMixinExtractOperationAndSourceFeature:
+    """Regression tests for _extract_operation_and_source_feature()."""
+
+    def test_raises_value_error_not_index_error_for_zero_sources(self) -> None:
+        """Zero resolved sources with a non-None operation must raise ValueError, not IndexError."""
+        feature = Feature(name="simple_name", options=Options(context={"operation": "op1"}))
+
+        with pytest.raises(ValueError) as exc_info:
+            MockFeatureGroupZeroSources._extract_operation_and_source_feature(
+                feature, _constant_operation_extractor, "operation"
+            )
+
+        assert "at least 1 in_feature" in str(exc_info.value)


### PR DESCRIPTION
## Summary

A feature-group family that wants exactly one source column currently has to re-implement the whole name-or-options read from `FeatureChainParserMixin` just to get its own arity-error wording, because the mixin's existing helpers hard-code the generic MIN/MAX-based message.

This adds `FeatureChainParserMixin._extract_single_source_feature`, which reuses the existing `_extract_source_features` and the already-overridable `_in_feature_count_reason` hook: a family gets exactly-one-source extraction with its own error wording by overriding a single hook, no extra mixin or MRO ordering needed.

- `_extract_single_source_feature` returns the sole source feature, or raises (using a family's own `_in_feature_count_reason` wording when overridden, else a generic message) when the resolved count isn't exactly one.
- `_extract_operation_and_source_feature` now uses it instead of indexing `_extract_source_features(...)[0]` directly, replacing a latent unguarded `IndexError` with a clear `ValueError`.
- `FeatureChainParser.parse_feature_name`'s docstring now documents its return contract precisely: `(None, None)` on no match, otherwise `source_feature` is always populated while `operation_config` is `None` only when the pattern's positional capture yields no value (captureless, or an optional capture that didn't participate); a matched pattern with nothing before the separator raises instead of returning. No behavior change, since that function's tuple is pinned public API.

Closes #1080

## Test plan

- [x] New unit tests for `_extract_single_source_feature` (string-based and options-fallback sourcing, generic and custom arity messages, unbounded-MAX and MIN-zero edge cases)
- [x] Regression test confirming `_extract_operation_and_source_feature` raises `ValueError`, not `IndexError`, for zero resolved sources
- [x] Full `tox` run green (tests, ruff, mypy --strict, license check, bandit)