### PR TITLE
refactor: adopt _extract_single_source_feature in time_window and forecasting

### DIFF
--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -406,11 +406,10 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
         algorithm, horizon, time_unit = cls._extract_forecast_params(feature)
         if algorithm is None or horizon is None or time_unit is None:
             raise ValueError(f"Could not extract forecasting parameters from: {feature.name}")
-        return algorithm, horizon, time_unit, source_features[0]
+        return algorithm, horizon, time_unit, cls._extract_single_source_feature(feature)
 
     @classmethod
     def _has_valid_forecast_suffix(cls, feature_name: str) -> bool:

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -219,13 +219,12 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
         window_function, window_size, time_unit = cls._extract_time_window_params(feature)
 
         if window_function is None or window_size is None or time_unit is None:
             raise ValueError(f"Could not extract time window parameters from: {feature.name}")
 
-        return window_function, window_size, time_unit, source_features[0]
+        return window_function, window_size, time_unit, cls._extract_single_source_feature(feature)
 
     @classmethod
     def parse_time_window_prefix(cls, feature_name: str) -> tuple[str, int, str]:


### PR DESCRIPTION
## Summary

Depends on #1324 (adds `FeatureChainParserMixin._extract_single_source_feature`); based on that branch, targets it instead of `main`, and should merge after it.

`time_window/base.py` and `forecasting/base.py` both declare `MIN_IN_FEATURES = MAX_IN_FEATURES = 1` but resolved their source feature via `_extract_source_features(feature)[0]`, an unguarded index that raises a bare `IndexError` instead of a clear error when the resolved list is empty. Both now use `_extract_single_source_feature`, which enforces the arity and raises `ValueError`.

Closes #1325

## Test plan

- [x] `tests/test_plugins/feature_group/experimental/test_time_window_feature_group` and `test_forecasting` pass (89 tests)
- [x] ruff format/check clean