### PR TITLE
fix: stop flight server and manager processes from outliving a killed parent

### DIFF
--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -1,3 +1,5 @@
+import functools
+from collections.abc import Callable, Iterable
 from multiprocessing.managers import BaseManager
 from typing import Any, Optional
 from uuid import UUID
@@ -7,6 +9,7 @@ from mloda.core.abstract_plugins.components.error_utils import internal_invarian
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.abstract_plugins.run_context import RunContext
+from mloda.core.runtime.parent_death_watchdog import start_parent_death_watchdog
 
 import logging
 
@@ -14,8 +17,20 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _watchdog_then_initializer(initializer: Callable[..., object] | None, initargs: Iterable[Any]) -> None:
+    start_parent_death_watchdog()
+    if initializer is not None:
+        initializer(*initargs)
+
+
 class MyManager(BaseManager):
-    pass
+    def start(self, initializer: Callable[..., object] | None = None, initargs: Iterable[Any] = ()) -> None:
+        # BaseManager._run_server() runs initializer inside the freshly spawned manager server
+        # process, so the watchdog must always run there; a caller-supplied initializer is
+        # chained after it rather than replaced. A module-level function plus functools.partial
+        # is used, not a closure, because BaseManager.start() pickles the initializer to send it
+        # to the spawned server process, and closures are not picklable.
+        super().start(functools.partial(_watchdog_then_initializer, initializer, initargs), ())
 
 
 class CfwManager:

--- a/mloda/core/runtime/flight/runner_flight_server.py
+++ b/mloda/core/runtime/flight/runner_flight_server.py
@@ -10,7 +10,8 @@ import logging
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
 from mloda.core.runtime.flight.flight_server import FlightServer, create_location, _require_pyarrow_flight
-from mloda.core.runtime.mp_context import mp_spawn_context
+from mloda.core.runtime.mp_context import mp_spawn_context, spawn_daemon_process
+from mloda.core.runtime.parent_death_watchdog import start_parent_death_watchdog
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,7 @@ class ParallelRunnerFlightServer:
         self.queue: Any
 
     def start_flight_server(self, location: Any, location_queue: Any) -> None:
+        start_parent_death_watchdog()
         flight_server = FlightServer(location=location)
         location_queue.put(flight_server.location)
         flight_server.serve()
@@ -36,10 +38,7 @@ class ParallelRunnerFlightServer:
             location = create_location()
             ctx = mp_spawn_context()
             location_queue: multiprocessing.Queue[Any] = ctx.Queue()
-            self.flight_server_process = ctx.Process(
-                target=self.start_flight_server,
-                args=(location, location_queue),
-            )
+            self.flight_server_process = spawn_daemon_process(ctx, self.start_flight_server, (location, location_queue))
             self.flight_server_process.start()
             try:
                 self.location = self.wait_for_flight_server_location(location_queue)

--- a/mloda/core/runtime/mp_context.py
+++ b/mloda/core/runtime/mp_context.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import multiprocessing
 from multiprocessing.context import SpawnContext
+from multiprocessing.process import BaseProcess
+from typing import Any, Callable
 
 
 def mp_spawn_context() -> SpawnContext:
@@ -15,3 +17,9 @@ def mp_spawn_context() -> SpawnContext:
     interpreter for each child and avoids this entire class of bug.
     """
     return multiprocessing.get_context("spawn")
+
+
+def spawn_daemon_process(ctx: SpawnContext, target: Callable[..., None], args: tuple[Any, ...] = ()) -> BaseProcess:
+    """Creates ctx.Process(target, args, daemon=True): reaped automatically if the parent exits
+    cleanly without an explicit join/terminate on this process."""
+    return ctx.Process(target=target, args=args, daemon=True)

--- a/mloda/core/runtime/parent_death_watchdog.py
+++ b/mloda/core/runtime/parent_death_watchdog.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+import threading
+
+
+def start_parent_death_watchdog() -> None:
+    """Starts a daemon thread that exits this process once its real parent process is gone."""
+
+    def _watch() -> None:
+        parent = multiprocessing.parent_process()
+        if parent is None:
+            return
+        parent.join()
+        os._exit(0)
+
+    threading.Thread(target=_watch, daemon=True).start()

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -9,7 +9,7 @@ from multiprocessing.process import BaseProcess
 from typing import Any, Callable, Optional
 from uuid import UUID
 
-from mloda.core.runtime.mp_context import mp_spawn_context
+from mloda.core.runtime.mp_context import mp_spawn_context, spawn_daemon_process
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +47,9 @@ class WorkerManager:
         result_queue: multiprocessing.Queue[Any] = ctx.Queue()
 
         worker_index = len(self.process_register)
-        # daemon=True so this process is reaped automatically if the parent exits without
-        # calling join_all(); as a side effect, code running inside a worker cannot itself
+        # As a side effect of daemon=True, code running inside a worker cannot itself
         # spawn multiprocessing children (Python raises on that).
-        process = ctx.Process(target=target, args=(command_queue, result_queue, *args, worker_index), daemon=True)
+        process = spawn_daemon_process(ctx, target, (command_queue, result_queue, *args, worker_index))
 
         self.process_register[cfw_uuid] = (process, command_queue, result_queue)
         self.result_queues_collection.add(result_queue)

--- a/tests/test_core/test_core/test_cfw_manager.py
+++ b/tests/test_core/test_core/test_cfw_manager.py
@@ -1,12 +1,15 @@
 """Tests for CfwManager RunContext get/set round-trip and merge-relation cycles."""
 
+from multiprocessing.managers import BaseManager
+from typing import Any
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
 
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.abstract_plugins.run_context import RunContext
-from mloda.core.core.cfw_manager import CfwManager
+from mloda.core.core.cfw_manager import CfwManager, MyManager
 
 
 def _module_level_bootstrap() -> None:
@@ -81,3 +84,54 @@ class TestCfwManagerFindLeftmostCycleDetection:
         assert cfw_register.find_leftmost(uuid_c, cls_name) == uuid_a
         assert cfw_register.find_leftmost(uuid_b, cls_name) == uuid_a
         assert cfw_register.find_leftmost(uuid_a, cls_name) == uuid_a
+
+
+class TestMyManagerStartAlwaysChainsTheParentDeathWatchdog:
+    """MyManager.start() must always run the watchdog in the manager server process, and if the
+    caller also supplied an initializer, chain it after the watchdog rather than replacing it."""
+
+    def test_start_with_no_initializer_still_invokes_the_watchdog(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_super_start(self: BaseManager, initializer: Any = None, initargs: Any = ()) -> None:
+            captured["initializer"] = initializer
+            captured["initargs"] = initargs
+
+        monkeypatch.setattr(BaseManager, "start", fake_super_start)
+
+        watchdog_mock = Mock()
+        monkeypatch.setattr("mloda.core.core.cfw_manager.start_parent_death_watchdog", watchdog_mock)
+
+        MyManager().start()
+
+        # Invoke whatever MyManager.start() actually handed to super().start(), simulating
+        # BaseManager._run_server() calling it inside the freshly spawned manager process.
+        captured["initializer"](*captured["initargs"])
+
+        watchdog_mock.assert_called_once()
+
+    def test_start_with_an_explicit_initializer_chains_it_after_the_watchdog(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_super_start(self: BaseManager, initializer: Any = None, initargs: Any = ()) -> None:
+            captured["initializer"] = initializer
+            captured["initargs"] = initargs
+
+        monkeypatch.setattr(BaseManager, "start", fake_super_start)
+
+        watchdog_mock = Mock()
+        monkeypatch.setattr("mloda.core.core.cfw_manager.start_parent_death_watchdog", watchdog_mock)
+
+        caller_calls: list[tuple[Any, ...]] = []
+
+        def my_initializer(*args: Any) -> None:
+            caller_calls.append(args)
+
+        MyManager().start(initializer=my_initializer, initargs=("a", "b"))
+
+        captured["initializer"](*captured["initargs"])
+
+        watchdog_mock.assert_called_once()
+        assert caller_calls == [("a", "b")]

--- a/tests/test_core/test_runtime/test_flight_server_error_messages.py
+++ b/tests/test_core/test_runtime/test_flight_server_error_messages.py
@@ -21,7 +21,7 @@ class TestFlightServerProcessLocation:
                 return None
 
         class InlineProcess:
-            def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
+            def __init__(self, target: Any, args: tuple[Any, ...], **kwargs: Any) -> None:
                 self.target = target
                 self.args = args
                 self.started = False
@@ -53,7 +53,7 @@ class TestFlightServerProcessLocation:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         class DeadProcess:
-            def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
+            def __init__(self, target: Any, args: tuple[Any, ...], **kwargs: Any) -> None:
                 self.target = target
                 self.args = args
                 self.exitcode: int | None = None
@@ -94,6 +94,52 @@ class TestFlightServerProcessLocation:
         assert "1" in str(exc_info.value)
         assert server.flight_server_process is None
         assert server.location is None
+
+
+class TestFlightServerProcessDaemon:
+    """The flight server child process must be daemon=True: a caller that never calls
+    end_flight_server_process() on the success path would otherwise hang at clean
+    interpreter exit, mirroring the sibling fix in WorkerManager.create_worker_process."""
+
+    def test_start_flight_server_process_creates_process_with_daemon_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        published_location = "grpc://127.0.0.1:39124"
+
+        class BoundFlightServer:
+            def __init__(self, location: str) -> None:
+                self.location = published_location
+
+            def serve(self) -> None:
+                return None
+
+        class RecordingProcess:
+            def __init__(self, target: Any, args: tuple[Any, ...], **kwargs: Any) -> None:
+                self.target = target
+                self.args = args
+                self.daemon = kwargs.get("daemon")
+
+            def start(self) -> None:
+                self.target(*self.args)
+
+        monkeypatch.setattr(
+            "mloda.core.runtime.flight.runner_flight_server.create_location", lambda: "grpc://127.0.0.1:0"
+        )
+        monkeypatch.setattr("mloda.core.runtime.flight.runner_flight_server.FlightServer", BoundFlightServer)
+
+        class FakeCtx:
+            Process = RecordingProcess
+            Queue: Any = staticmethod(multiprocessing.Queue)
+
+        monkeypatch.setattr(
+            "mloda.core.runtime.flight.runner_flight_server.mp_spawn_context",
+            lambda: FakeCtx(),
+        )
+
+        server = ParallelRunnerFlightServer()
+        server.start_flight_server_process()
+
+        assert server.flight_server_process.daemon is True
 
 
 class TestFlightServerLocationNoneError:

--- a/tests/test_core/test_runtime/test_flight_server_parent_death.py
+++ b/tests/test_core/test_runtime/test_flight_server_parent_death.py
@@ -1,0 +1,86 @@
+"""The Flight server process spawned by ParallelRunnerFlightServer must exit once the real OS
+process that spawned it is killed, instead of surviving as a reparented orphan.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from pathlib import Path
+
+import pytest
+
+from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
+from mloda.core.runtime.mp_context import mp_spawn_context
+
+
+def _flight_server_is_gone(pid: int) -> bool:
+    """A reparented child can sit as an unreaped zombie, which still answers os.kill(pid, 0);
+    /proc state distinguishes that from actually running."""
+    stat_path = Path(f"/proc/{pid}/stat")
+    if not stat_path.exists():
+        return True
+    return stat_path.read_text().rsplit(")", 1)[1].split()[0] == "Z"
+
+
+def _fake_parent_main(pid_file: str) -> None:
+    server = ParallelRunnerFlightServer()
+    server.start_flight_server_process()
+
+    with open(pid_file, "w") as pid_handle:
+        pid_handle.write(str(server.flight_server_process.pid))
+
+    # Non-daemonic (it has its own child); if the test process dies uncleanly,
+    # multiprocessing's exit handling would join this for the full sleep duration.
+    time.sleep(20)
+
+
+class TestFlightServerProcessDoesNotOutliveASigkilledParent:
+    @pytest.mark.timeout(45)
+    def test_real_flight_server_process_exits_after_its_real_parent_process_is_sigkilled(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "flight_server.pid"
+        ctx = mp_spawn_context()
+        fake_parent = ctx.Process(target=_fake_parent_main, args=(str(pid_file),))
+        fake_parent.start()
+
+        flight_server_pid: int | None = None
+        flight_server_gone = False
+        try:
+            deadline = time.time() + 15.0
+            while time.time() < deadline and flight_server_pid is None:
+                if pid_file.exists():
+                    content = pid_file.read_text().strip()
+                    if content:
+                        flight_server_pid = int(content)
+                        break
+                time.sleep(0.05)
+            assert flight_server_pid is not None, (
+                f"fake parent process never reported the flight server's pid "
+                f"(fake_parent.exitcode={fake_parent.exitcode})"
+            )
+
+            assert fake_parent.pid is not None, "fake parent process has no pid"
+            fake_parent_pid = fake_parent.pid
+            os.kill(fake_parent_pid, signal.SIGKILL)
+            fake_parent.join(timeout=5)
+            assert not fake_parent.is_alive(), "fake parent process survived SIGKILL"
+
+            deadline = time.time() + 10.0
+            while time.time() < deadline:
+                if _flight_server_is_gone(flight_server_pid):
+                    flight_server_gone = True
+                    break
+                time.sleep(0.1)
+
+            assert flight_server_gone, "flight server process outlived its SIGKILLed parent process"
+        finally:
+            # Never leak either process, even if an assertion above failed.
+            if fake_parent.is_alive():
+                fake_parent.kill()
+                fake_parent.join(timeout=5)
+            if flight_server_pid is not None and not flight_server_gone:
+                try:
+                    os.kill(flight_server_pid, signal.SIGKILL)
+                except OSError:
+                    pass

--- a/tests/test_core/test_runtime/test_parent_death_watchdog.py
+++ b/tests/test_core/test_runtime/test_parent_death_watchdog.py
@@ -1,0 +1,49 @@
+"""start_parent_death_watchdog() must os._exit() once the real parent process's join() returns,
+and must do nothing when there is no parent process to watch.
+"""
+
+import multiprocessing
+import os
+import time
+from unittest.mock import Mock
+
+import pytest
+
+from mloda.core.runtime.parent_death_watchdog import start_parent_death_watchdog
+
+
+class TestWatchdogExitsOnceTheParentProcessJoinReturns:
+    """A background thread waits on parent_process().join(); once that returns, the process must exit."""
+
+    @pytest.mark.timeout(5)
+    def test_os_exit_is_called_once_the_fake_parent_join_returns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_parent = Mock()
+        fake_parent.join.return_value = None
+        monkeypatch.setattr(multiprocessing, "parent_process", lambda: fake_parent)
+        fake_exit = Mock()
+        monkeypatch.setattr(os, "_exit", fake_exit)
+
+        start_parent_death_watchdog()
+
+        deadline = time.time() + 3.0
+        while time.time() < deadline and not fake_exit.called:
+            time.sleep(0.02)
+
+        fake_exit.assert_called_once_with(0)
+
+
+class TestWatchdogDoesNothingWithoutARealParentProcess:
+    """When multiprocessing.parent_process() is None, the watchdog must never call os._exit."""
+
+    @pytest.mark.timeout(5)
+    def test_os_exit_is_never_called_when_there_is_no_parent_process(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(multiprocessing, "parent_process", lambda: None)
+        fake_exit = Mock()
+        monkeypatch.setattr(os, "_exit", fake_exit)
+
+        start_parent_death_watchdog()
+
+        # Give the background thread a moment to call os._exit, if it were going to.
+        time.sleep(0.3)
+
+        fake_exit.assert_not_called()


### PR DESCRIPTION
## Summary

A prior fix stopped `MultiprocessingWorker` processes from outliving an abruptly-killed parent. Two other long-lived child processes had the same problem: `ParallelRunnerFlightServer`'s flight server process, and the `multiprocessing.managers.BaseManager` process used by the compute framework manager. Both survived indefinitely after the parent was SIGKILLed, reparented to init, with the flight server (holding uploaded Arrow results) the main contributor to the resulting RSS leak.

## Change

Adds a small watchdog helper (`parent_death_watchdog.py`) that starts a daemon thread joining `multiprocessing.parent_process()` and exits the process once that returns, which works even on SIGKILL since it relies on an OS-level pipe closing, not on the parent running any cleanup code.

- `ParallelRunnerFlightServer.start_flight_server()` starts the watchdog before serving. The flight server process is also now `daemon=True`, so a caller that never explicitly tears it down doesn't hang interpreter exit.
- `MyManager.start()` (the `BaseManager` subclass backing the compute framework manager) always installs the watchdog inside the spawned manager server process, chaining any caller-supplied initializer after it rather than replacing it.

## Testing

- A real end-to-end test SIGKILLs a process holding a flight server and asserts the flight server process exits.
- Unit tests cover the watchdog itself and the manager's initializer wiring/chaining.
- Full test suite, ruff, mypy --strict, and bandit all pass.

Closes #1323