### PR TITLE
Fix resolve_artifact_for_runtime() corrupting FeatureSet membership via shared Options mutation

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -59,7 +59,19 @@ class FeatureSet:
             if feature_name in runtime_artifacts:
                 self.artifact_to_load = feature_name
                 self.artifact_to_save = None
-                self.options.set(feature_name, runtime_artifacts[feature_name])
+                # self.options is commonly the same object a member Feature's `.options`
+                # aliases (set by add() on first insert, or shared directly by the caller
+                # across multiple features). Options.set() defaults a brand-new key to
+                # `group`, but group is what Options.__hash__/__eq__ (and therefore
+                # Feature.__hash__) is based on -- writing the artifact there silently
+                # changes the hash of any Feature(s) still referencing this Options
+                # object, corrupting `self.features` set membership for any Feature
+                # already inserted (#1236). `context` is excluded from hashing and is
+                # still checked by Options.get()/__getitem__, so store it there instead;
+                # write directly (rather than via add_to_context(), which raises on a
+                # differing existing value) so re-resolving across repeated run() calls
+                # with a different artifact each time keeps working.
+                self.options.context[feature_name] = runtime_artifacts[feature_name]
                 return
 
         self.artifact_to_load = None

--- a/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
+++ b/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
@@ -66,3 +66,55 @@ class TestFeatureSetResolveArtifactForRuntimeUsesArtifactToLoad:
         result = BaseArtifact.load(features)
 
         assert result == "runtime_value"
+
+
+class TestFeatureSetResolveArtifactForRuntimeDoesNotMutateFeatureHash:
+    """resolve_artifact_for_runtime() must not change the group options (and therefore the
+    hash) of any Feature whose `.options` aliases the FeatureSet's shared Options object --
+    doing so silently corrupts `self.features` set membership (#1236)."""
+
+    def test_feature_remains_a_member_after_resolving_runtime_artifact(self) -> None:
+        feature = Feature("abc")
+        features = FeatureSet()
+        features.add(feature)
+
+        assert feature in features.features
+
+        features.resolve_artifact_for_runtime({"abc": "ART"})
+
+        assert feature in features.features
+
+    def test_feature_group_options_are_unchanged_after_resolving_runtime_artifact(self) -> None:
+        feature = Feature("abc")
+        features = FeatureSet()
+        features.add(feature)
+        hash_before = hash(feature)
+
+        features.resolve_artifact_for_runtime({"abc": "ART"})
+
+        assert "abc" not in feature.options.group
+        assert hash(feature) == hash_before
+
+    def test_shared_options_group_is_unchanged_across_features(self) -> None:
+        shared_options = Options({})
+        features = FeatureSet()
+        a_feature = Feature("a_col", shared_options)
+        z_feature = Feature("z_col", shared_options)
+        features.add(a_feature)
+        features.add(z_feature)
+
+        features.resolve_artifact_for_runtime({"z_col": "runtime_value"})
+
+        assert "z_col" not in shared_options.group
+        assert a_feature in features.features
+        assert z_feature in features.features
+
+    def test_artifact_is_still_retrievable_via_feature_options_after_fix(self) -> None:
+        shared_options = Options({})
+        features = FeatureSet()
+        features.add(Feature("a_col", shared_options))
+        features.add(Feature("z_col", shared_options))
+
+        features.resolve_artifact_for_runtime({"z_col": "runtime_value"})
+
+        assert shared_options["z_col"] == "runtime_value"


### PR DESCRIPTION
Fixes #1236

## Root cause

`FeatureSet.resolve_artifact_for_runtime()` wrote the runtime artifact into `self.options` via `Options.set()`, which defaults a brand-new key to the `group` dict. `self.options` is commonly the same object a member `Feature`'s `.options` aliases (set by `FeatureSet.add()` on first insert, or shared directly across multiple `Feature`s by the caller).

Since `Options.__hash__`/`__eq__` (and therefore `Feature.__hash__`) are computed from `group` only, writing the artifact key there silently changes the hash of every `Feature` still referencing that `Options` object *after* it was already inserted into `FeatureSet.features` (a `set`). Python's `set` looks up membership using the hash captured at insertion time, so `feature in self.features` can return `False` even though the `Feature` object is still physically present in the set.

## Fix

Write the runtime artifact into `self.options.context` instead of `self.options.group`. `context` is excluded from `Options.__hash__`/`__eq__`, so no `Feature`'s hash changes. `Options.get()`/`__getitem__`/`__contains__`/`keys()` all already check `context` in addition to `group` (this is the existing, documented split for hash-affecting vs. metadata-only option values), so `BaseArtifact.custom_loader()`'s existing `feature.options[...]`-based lookup continues to find the artifact with no changes needed there. Writing directly to the dict (rather than via `add_to_context()`, which raises on a differing existing value) keeps repeated `run()` calls with a different runtime artifact each time working, matching the prior `set()`-based behavior.

An earlier approach (`copy.copy(self.options)` before writing, to decouple the shared reference) was tried and rejected: it broke `BaseArtifact.get_singular_option_from_options()`, which reads the artifact via the member `Feature`'s own `.options`, not `FeatureSet.options` -- decoupling them made the artifact invisible again.

## Testing

- Added 4 regression tests to `tests/test_core/test_artifacts/test_base_artifact_custom_loader.py` covering: the `Feature` staying a set member after `resolve_artifact_for_runtime()`, the `Feature`'s hash staying stable, a shared `Options` object's `group` staying unchanged across multiple `Feature`s, and the artifact still being retrievable via `feature.options` after the fix.
- All 8 tests in that file pass (4 new + 4 pre-existing, including the 2 that an earlier `copy.copy()`-based attempt broke).
- Broader regression check: `tests/test_core/test_artifacts`, `tests/test_core/test_filter`, `tests/test_core/test_abstract_plugins` -- 3307 passed, 4 skipped, 0 failed.
- Artifact round-trip suites under `tests/test_plugins` (sklearn_artifact, forecasting_artifact) -- 27 passed.
- `mypy --strict --ignore-missing-imports` clean on the changed file.
- `ruff check --line-length 120` / `ruff format --check --line-length 120` on the changed file: no new findings (the pre-existing findings ruff reports on this file are identical on pristine `main`, confirmed via diff, and unrelated to this change).