### PR TITLE
fix: log once per class when HookContext.feature_group_version degrades

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -264,7 +264,7 @@ its declaration is read. Both apply identically to a run, so a scope that rescue
 ### Shared helper
 
 The annotate tier is a single shared helper,
-`safe_field(read, fallback, catching=(Exception,), field="")` in
+`safe_field(read, fallback, catching=(Exception,), field="", warn_once_for=None)` in
 `mloda.core.abstract_plugins.components.utils`: it calls the `read` thunk and
 returns `fallback` if the read raises one of `catching`, so a catalog function or
 info field reaches for one helper instead of re-deriving a `try/except`.
@@ -280,7 +280,9 @@ Logging is opt-in via `field`: the labelled `get_feature_group_docs` reads warn 
 swallow, where a raise does mean a broken plugin. The unlabelled guards stay silent
 because degrading there is by design (source introspection of `type()`-built
 classes, an availability probe without its optional backend, Iceberg's deliberate
-`NotImplementedError` from `merge_engine()`).
+`NotImplementedError` from `merge_engine()`). A hot call site can also pass
+`warn_once_for` (a key, typically the plugin class) to dedup that WARNING to once
+per key instead of once per call.
 
 `get_compute_framework_docs` uses the default broad `catching` (any failure
 degrades the field), while the narrower named guards `_safe_version` (in

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -51,30 +51,23 @@ def safe_exc_str(exc: BaseException) -> str:
         return type(exc).__name__
 
 
-# Keys already warned via warn_once_for. Weak-referenceable keys (the common case: a class) live in the
-# WeakSet, so a key is never pinned past its natural lifetime, consistent with
-# _class_source_hash_cache's rationale in base_feature_group_version.py; keys that cannot be weakly
-# referenced fall back to a plain set.
+# Weakly held so a warn_once_for key (typically a class) isn't pinned past its lifetime; non-weakly-referenceable
+# keys fall back to a plain set.
 _warn_once_for_weak: "weakref.WeakSet[Any]" = weakref.WeakSet()
 _warn_once_for_strong: set[object] = set()
 
 
 def _warn_once_for_seen(key: object) -> bool:
-    """True if `key` was already recorded by a prior warn_once_for call; otherwise records it and returns False.
-
-    Total: any failure probing or recording `key` (a plugin-owned __hash__/__eq__/weakref hook can raise)
-    degrades to "not seen", matching safe_exc_str/is_match_abort's never-break-the-safety-net idiom.
-    """
+    """True if `key` was already seen, else records it. Never raises: a bad hash/weakref hook degrades to False."""
     try:
-        # type(key).__weakrefoffset__, not hasattr(key, "__weakref__"): the latter resolves through key's
-        # MRO when key is a class, testing instances-of-key, not key itself.
+        # __weakrefoffset__, not hasattr(key, "__weakref__"): the latter tests instances-of-key, not key itself.
         registry: "weakref.WeakSet[Any] | set[object]" = (
             _warn_once_for_weak if getattr(type(key), "__weakrefoffset__", 0) else _warn_once_for_strong
         )
         if key in registry:
             return True
         registry.add(key)
-    except Exception:  # noqa: BLE001  (checking/recording the key is plugin-owned and must not escape)
+    except Exception:  # noqa: BLE001  (plugin-owned key, must not escape)
         return False
     return False
 

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable, TypeVar
 
 import logging
+import weakref
 
 logger = logging.getLogger(__name__)
 
@@ -50,21 +51,40 @@ def safe_exc_str(exc: BaseException) -> str:
         return type(exc).__name__
 
 
+# Keys already warned via warn_once_for. Weak-referenceable keys (the common case: a class) live in the
+# WeakKeyDictionary, so a key is never pinned past its natural lifetime, consistent with
+# _class_source_hash_cache's rationale in base_feature_group_version.py; keys that cannot be weakly
+# referenced fall back to a plain dict.
+_warn_once_for_weak: "weakref.WeakKeyDictionary[Any, None]" = weakref.WeakKeyDictionary()
+_warn_once_for_strong: dict[object, None] = {}
+
+
+def _warn_once_for_seen(key: object) -> bool:
+    """True if `key` was already recorded by a prior warn_once_for call; otherwise records it and returns False."""
+    registry: Any = _warn_once_for_weak if hasattr(key, "__weakref__") else _warn_once_for_strong
+    if key in registry:
+        return True
+    registry[key] = None
+    return False
+
+
 def safe_field(
     read: Callable[[], T],
     fallback: T,
     catching: tuple[type[Exception], ...] = (Exception,),
     field: str = "",
+    warn_once_for: object | None = None,
 ) -> T:
     """Annotate tier: degrade a single unreadable field to a fallback instead of failing the whole discovery call.
 
     A labelled read (non-empty `field`) warns on swallow; an unlabelled read degrades silently, because degrading
-    there is expected.
+    there is expected. `warn_once_for` dedups that WARNING per key, so a hot call site warns only on the key's
+    first swallow.
     """
     try:
         return read()
     except catching as exc:
-        if field:
+        if field and (warn_once_for is None or not _warn_once_for_seen(warn_once_for)):
             # str(exc), not exc: a retained log record must not pin the traceback, its frames and the plugin class.
             logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, safe_exc_str(exc))
         return fallback

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -52,19 +52,30 @@ def safe_exc_str(exc: BaseException) -> str:
 
 
 # Keys already warned via warn_once_for. Weak-referenceable keys (the common case: a class) live in the
-# WeakKeyDictionary, so a key is never pinned past its natural lifetime, consistent with
+# WeakSet, so a key is never pinned past its natural lifetime, consistent with
 # _class_source_hash_cache's rationale in base_feature_group_version.py; keys that cannot be weakly
-# referenced fall back to a plain dict.
-_warn_once_for_weak: "weakref.WeakKeyDictionary[Any, None]" = weakref.WeakKeyDictionary()
-_warn_once_for_strong: dict[object, None] = {}
+# referenced fall back to a plain set.
+_warn_once_for_weak: "weakref.WeakSet[Any]" = weakref.WeakSet()
+_warn_once_for_strong: set[object] = set()
 
 
 def _warn_once_for_seen(key: object) -> bool:
-    """True if `key` was already recorded by a prior warn_once_for call; otherwise records it and returns False."""
-    registry: Any = _warn_once_for_weak if hasattr(key, "__weakref__") else _warn_once_for_strong
-    if key in registry:
-        return True
-    registry[key] = None
+    """True if `key` was already recorded by a prior warn_once_for call; otherwise records it and returns False.
+
+    Total: any failure probing or recording `key` (a plugin-owned __hash__/__eq__/weakref hook can raise)
+    degrades to "not seen", matching safe_exc_str/is_match_abort's never-break-the-safety-net idiom.
+    """
+    try:
+        # type(key).__weakrefoffset__, not hasattr(key, "__weakref__"): the latter resolves through key's
+        # MRO when key is a class, testing instances-of-key, not key itself.
+        registry: "weakref.WeakSet[Any] | set[object]" = (
+            _warn_once_for_weak if getattr(type(key), "__weakrefoffset__", 0) else _warn_once_for_strong
+        )
+        if key in registry:
+            return True
+        registry.add(key)
+    except Exception:  # noqa: BLE001  (checking/recording the key is plugin-owned and must not escape)
+        return False
     return False
 
 

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -792,6 +792,8 @@ class ComputeFramework(ABC):
         # feature_group is a class in production; normalize since test doubles may pass an instance.
         feature_group_cls: Any = feature_group if isinstance(feature_group, type) else type(feature_group)
 
+        feature_group_class = f"{feature_group_cls.__module__}.{feature_group_cls.__qualname__}"
+
         feature_names: tuple[str, ...] = ()
         input_features: frozenset[str] | None = None
         if isinstance(features, FeatureSet):
@@ -800,8 +802,13 @@ class ComputeFramework(ABC):
 
         return HookContext(
             hook=hook,
-            feature_group_class=f"{feature_group_cls.__module__}.{feature_group_cls.__qualname__}",
-            feature_group_version=safe_field(lambda: as_str(feature_group_cls.version()), "unavailable"),
+            feature_group_class=feature_group_class,
+            feature_group_version=safe_field(
+                lambda: as_str(feature_group_cls.version()),
+                "unavailable",
+                field=f"{feature_group_class}.version",
+                warn_once_for=feature_group_cls,
+            ),
             plugin_version=resolve_plugin_version(feature_group_cls.__module__),
             feature_names=feature_names,
             input_features=input_features,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
+from mloda.core.abstract_plugins.components import utils
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
@@ -37,18 +38,31 @@ def _clear_warned_unregistered() -> None:
         warned.clear()
 
 
+def _clear_warn_once_for_registries() -> None:
+    """Clear safe_field's warn_once_for dedup registries if the implementation provides them."""
+    weak_registry = getattr(utils, "_warn_once_for_weak", None)
+    if weak_registry is not None:
+        weak_registry.clear()
+    strong_registry = getattr(utils, "_warn_once_for_strong", None)
+    if strong_registry is not None:
+        strong_registry.clear()
+
+
 @pytest.fixture(autouse=True)
 def restore_default_plugin_registry() -> Any:
     """Snapshot and restore the default plugin registry around every test.
 
-    Also clears the warn-mode dedup set so warn-mode tests stay independent.
+    Also clears the warn-mode dedup set and safe_field's warn_once_for registries so
+    warn-mode tests and once-per-process WARNING dedup tests stay independent.
     """
     registry = PluginRegistry.default()
     snapshot = registry.snapshot()
     _clear_warned_unregistered()
+    _clear_warn_once_for_registries()
     yield
     registry.restore(snapshot)
     _clear_warned_unregistered()
+    _clear_warn_once_for_registries()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
@@ -240,3 +240,72 @@ class TestSafeFieldFieldLabelKeepsExistingBehavior:
                 safe_field(raises, "fallback", catching=(OSError, TypeError), field="version")
 
         assert _warning_messages(caplog) == [], "A propagated exception is not a swallowed read, so it must not warn"
+
+
+class TestSafeFieldWarnOnceFor:
+    """warn_once_for dedups the WARNING per key, so a hot call site warns only on the key's first swallow."""
+
+    def test_first_call_with_warn_once_for_warns_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        key = object()
+
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable", field="description", warn_once_for=key)
+
+        assert result == "unavailable"
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, f"Expected exactly one WARNING, got {messages}"
+
+    def test_second_call_with_same_warn_once_for_does_not_warn_again(self, caplog: pytest.LogCaptureFixture) -> None:
+        key = object()
+
+        def raises_first() -> str:
+            raise RuntimeError("boom")
+
+        def raises_second() -> str:
+            raise KeyError("missing")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            safe_field(raises_first, "unavailable", field="description", warn_once_for=key)
+            # Different field label and different exception type: still the same warn_once_for key.
+            safe_field(raises_second, "unavailable", field="other_field", warn_once_for=key)
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, (
+            f"A second swallow with the same warn_once_for key must not warn again, got {messages}"
+        )
+
+    def test_different_warn_once_for_still_warns_on_its_own_first_occurrence(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        key_a = object()
+        key_b = object()
+
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            safe_field(raises, "unavailable", field="description", warn_once_for=key_a)
+            safe_field(raises, "unavailable", field="description", warn_once_for=key_b)
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 2, (
+            f"A different warn_once_for key must still warn on its own first occurrence, got {messages}"
+        )
+
+    def test_without_warn_once_for_repeated_swallows_still_warn_every_time(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No regression: omitting warn_once_for keeps today's every-call-warns behavior."""
+
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            safe_field(raises, "unavailable", field="description")
+            safe_field(raises, "unavailable", field="description")
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 2, f"Expected two WARNINGs (no dedup without warn_once_for), got {messages}"

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -113,6 +113,10 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/utils.py", "get_all_subclasses"): (
         "real edge, collided verdict: it raises nothing itself; the set.add / set.update names do"
     ),
+    ("mloda/core/abstract_plugins/components/utils.py", "safe_field"): (
+        "real edge, collided verdict: it raises nothing itself; warn_once_for's own try/except degrades any "
+        "failure to 'not seen', and the WeakSet/set add() name collides with an unrelated raising add() elsewhere"
+    ),
     ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
     ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
     ("mloda/core/abstract_plugins/components/declaration_surface.py", "merged_declaration"): (

--- a/tests/test_plugins/extender/test_hook_context_inputs.py
+++ b/tests/test_plugins/extender/test_hook_context_inputs.py
@@ -2,7 +2,8 @@
 
 Covers root-feature-group warnings, plain-str/batched input_features declarations,
 once-per-step resolution, warning-only extenders on validate hooks, row_count's
-type-only __len__ gate, instrument's rows_out reset, and feature_group_version.
+type-only __len__ gate, instrument's rows_out reset, and feature_group_version's
+degrade-and-log-once fallback.
 """
 
 import gc
@@ -496,10 +497,10 @@ class TestInstrumentResetsRowsOutOnEntry:
         assert context.status == "error"
 
 
-class TestFeatureGroupVersionDegradesSilently:
-    """A version() that raises must degrade to 'unavailable' without a WARNING log."""
+class TestFeatureGroupVersionDegradesAndLogs:
+    """A version() that raises must degrade to 'unavailable' and log exactly one WARNING."""
 
-    def test_version_raising_degrades_without_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_version_raising_degrades_and_logs_exactly_one_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         class _VersionRaisesFeatureGroup(FeatureGroup):
             """version() classmethod raises."""
 
@@ -521,7 +522,17 @@ class TestFeatureGroupVersionDegradesSilently:
 
             assert extender.captured is not None
             assert extender.captured.feature_group_version == "unavailable"
-            assert not any("Degraded field 'feature_group_version'" in record.message for record in caplog.records)
+
+            warnings = [
+                record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.WARNING
+                and record.name == _UTILS_LOGGER
+                and ".version" in record.getMessage()
+            ]
+            assert len(warnings) == 1, f"Expected exactly one WARNING, got {warnings}"
+            assert "_VersionRaisesFeatureGroup" in warnings[0]
+            assert "RuntimeError" in warnings[0]
         finally:
             del _VersionRaisesFeatureGroup
             gc.collect()

--- a/tests/test_plugins/extender/test_hook_context_wiring.py
+++ b/tests/test_plugins/extender/test_hook_context_wiring.py
@@ -7,6 +7,7 @@ run_context/worker_index surfacing on the captured HookContext.
 
 import functools
 import gc
+import logging
 from typing import Any
 
 import pytest
@@ -18,6 +19,8 @@ from mloda.core.abstract_plugins.run_context import RunContext
 from mloda.provider import FeatureGroup
 from mloda.user import Feature, ParallelizationMode
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+SAFE_FIELD_LOGGER = "mloda.core.abstract_plugins.components.utils"
 
 
 class _CalcFeatureGroup(FeatureGroup):
@@ -245,6 +248,50 @@ class TestObservabilityFailureDoesNotBreakCalculation:
             assert extender.captured.feature_group_version == "unavailable"
         finally:
             del _VersionRaisesFeatureGroup
+            gc.collect()
+
+    def test_version_raising_logs_exactly_one_warning_across_repeated_calls(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The fallback WARNING names the feature group and exception once, not on every hot-path hook call."""
+
+        class _RepeatedVersionRaisesFeatureGroup(FeatureGroup):
+            """FeatureGroup whose version() classmethod raises; invoked twice to probe dedup."""
+
+            @classmethod
+            def version(cls) -> str:
+                raise RuntimeError("boom")
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return [{"value": i} for i in range(3)]
+
+        try:
+            feature_set = _build_feature_set()
+            extender = _ContextCapturingExtender(ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE)
+            cfw = _build_framework({extender})
+
+            with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+                cfw.run_calculate_feature(_RepeatedVersionRaisesFeatureGroup, feature_set)
+                first_captured = extender.captured
+                cfw.run_calculate_feature(_RepeatedVersionRaisesFeatureGroup, feature_set)
+                second_captured = extender.captured
+
+            assert first_captured is not None
+            assert first_captured.feature_group_version == "unavailable"
+            assert second_captured is not None
+            assert second_captured.feature_group_version == "unavailable"
+
+            warnings = [
+                record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
+            ]
+            assert len(warnings) == 1, f"Expected exactly one WARNING across both calls, got {warnings}"
+            assert "_RepeatedVersionRaisesFeatureGroup" in warnings[0]
+            assert "RuntimeError" in warnings[0]
+        finally:
+            del _RepeatedVersionRaisesFeatureGroup
             gc.collect()
 
     def test_version_returning_non_str_normalizes_to_unavailable_fallback(self) -> None:

--- a/tests/test_plugins/extender/test_hook_context_wiring.py
+++ b/tests/test_plugins/extender/test_hook_context_wiring.py
@@ -285,7 +285,9 @@ class TestObservabilityFailureDoesNotBreakCalculation:
             warnings = [
                 record.getMessage()
                 for record in caplog.records
-                if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
+                if record.levelno == logging.WARNING
+                and record.name == SAFE_FIELD_LOGGER
+                and ".version" in record.getMessage()
             ]
             assert len(warnings) == 1, f"Expected exactly one WARNING across both calls, got {warnings}"
             assert "_RepeatedVersionRaisesFeatureGroup" in warnings[0]


### PR DESCRIPTION
## Summary

`HookContext.feature_group_version` fell back to `"unavailable"` with no log record when `FeatureGroup.version()` raised, so a broken version looked identical to a working one from inside an extender.

`safe_field` gains an optional `warn_once_for` key: when a labelled read swallows an exception, the WARNING now fires only the first time a given key (typically the plugin class) is seen, so a call site on a hot path (like `_build_hook_context`, invoked on every extender hook call) can log without flooding. The key is held weakly (`WeakSet`/plain `set` fallback for non-weak-referenceable keys), so it never pins a class past its natural lifetime, and the dedup check itself cannot raise out of `safe_field`, preserving its "never fail the caller" contract even if a plugin's `__hash__` or weakref hook is broken.

`ComputeFramework._build_hook_context` now passes `field` (naming the feature group's module and class) and `warn_once_for=feature_group_cls` when reading `version()`, so a broken `version()` logs once per class instead of silently disappearing into the placeholder string.

## Changes

- `safe_field` (`mloda/core/abstract_plugins/components/utils.py`): new `warn_once_for` parameter, backed by weak/strong dedup registries.
- `ComputeFramework._build_hook_context`: wires `field`/`warn_once_for` into the `feature_group_version` read.
- Tests covering the dedup mechanism and the fallback + log record on `version()` failure.
- `docs/docs/in_depth/discover-plugins.md`: documents the new parameter.

Closes #1330