### PR TITLE
perf: read output schema in one pass per framework

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
+from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_merge_engine import DuckDBMergeEngine
 from mloda.user import FeatureName, ParallelizationMode
@@ -147,6 +148,16 @@ class DuckDBFramework(ComputeFramework):
         if type_str.startswith("DECIMAL"):
             return DataType.DECIMAL
         return None
+
+    def _output_schema(self, data: Any) -> OutputSchema | None:
+        """Read columns/types once and zip them; never index into columns per name."""
+        if isinstance(data, dict):
+            return super()._output_schema(data)
+        columns = data.columns
+        if not columns:
+            return None
+        types = data.types
+        return tuple((name, str(dtype)) for name, dtype in sorted(zip(columns, types), key=lambda pair: pair[0]))
 
     @classmethod
     def duckdb_relation(cls) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -150,14 +150,21 @@ class DuckDBFramework(ComputeFramework):
         return None
 
     def _output_schema(self, data: Any) -> OutputSchema | None:
-        """Read columns/types once and zip them; never index into columns per name."""
+        """Read columns/types once and zip them; never index into columns per name.
+
+        Duplicate column names (e.g. an un-aliased join) collapse to one entry, first
+        occurrence wins.
+        """
         if isinstance(data, dict):
             return super()._output_schema(data)
         columns = data.columns
         if not columns:
             return None
         types = data.types
-        return tuple((name, str(dtype)) for name, dtype in sorted(zip(columns, types), key=lambda pair: pair[0]))
+        seen: dict[str, str] = {}
+        for name, dtype in zip(columns, types):
+            seen.setdefault(name, str(dtype))
+        return tuple((name, seen[name]) for name in sorted(seen, key=str))
 
     @classmethod
     def duckdb_relation(cls) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
+from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.user import FeatureName
 from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame
 from mloda.provider import BaseMergeEngine, BaseMaskEngine
@@ -64,6 +65,13 @@ class PolarsLazyDataFrame(PolarsDataFrame):
         if column_name not in schema.names():
             return None
         return PolarsDataFrame._polars_type_to_data_type(schema[column_name])
+
+    def _output_schema(self, data: Any) -> OutputSchema | None:
+        """Read collect_schema() once and build the sorted (name, dtype) pairs from it directly."""
+        schema = data.collect_schema()
+        if not schema:
+            return None
+        return tuple((name, str(dtype)) for name, dtype in sorted(schema.items(), key=lambda pair: pair[0]))
 
     @classmethod
     def pl_lazy_frame(cls) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
@@ -67,7 +67,13 @@ class PolarsLazyDataFrame(PolarsDataFrame):
         return PolarsDataFrame._polars_type_to_data_type(schema[column_name])
 
     def _output_schema(self, data: Any) -> OutputSchema | None:
-        """Read collect_schema() once and build the sorted (name, dtype) pairs from it directly."""
+        """Read collect_schema() once and build the sorted (name, dtype) pairs from it directly.
+
+        The dict interchange shape reaches this method before transform() normalizes it, so it
+        must be handled before collect_schema() is called.
+        """
+        if isinstance(data, dict):
+            return super()._output_schema(data)
         schema = data.collect_schema()
         if not schema:
             return None

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -9,6 +9,8 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 )
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.components.utils import safe_field
+from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_filter_engine import (
@@ -123,6 +125,34 @@ class PythonDictFramework(ComputeFramework):
                 return DataType.DECIMAL
             return None
         return None
+
+    def _output_schema(self, data: Any) -> OutputSchema | None:
+        """Row-wise list[dict] resolves every column's dtype in a single pass over rows;
+        other shapes (columnar dict included) delegate to the base implementation."""
+        if not (isinstance(data, list) and data and isinstance(data[0], dict)):
+            return super()._output_schema(data)
+
+        names = self._extract_column_names(data)
+        if not names:
+            return None
+
+        dtypes: dict[str, str | None] = dict.fromkeys(names)
+        unresolved = set(names)
+        for row in data:
+            if not unresolved:
+                break
+            for name in list(unresolved):
+
+                def _read(row: Any = row, name: str = name) -> str | None:
+                    value = row.get(name)
+                    return None if value is None else type(value).__name__
+
+                dtype = safe_field(_read, None)
+                if dtype is not None:
+                    dtypes[name] = dtype
+                    unresolved.discard(name)
+
+        return tuple((name, dtypes[name]) for name in sorted(names, key=str))
 
     @staticmethod
     def _validate_columnar_dict(data: dict[str, Any]) -> None:

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import decimal
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_merge_engine import (
@@ -10,7 +12,6 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.utils import safe_field
-from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_filter_engine import (
@@ -23,6 +24,9 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
     rows_to_columnar,
     validate_columnar_dict,
 )
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.hook_context import OutputSchema
 
 
 class PythonDictFramework(ComputeFramework):

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -126,6 +126,11 @@ class PythonDictFramework(ComputeFramework):
             return None
         return None
 
+    @staticmethod
+    def _row_dtypes(row: Any, names: tuple[str, ...]) -> dict[str, str]:
+        """Non-None dtypes for ``names`` read off a single row; a name absent from the result stays unresolved."""
+        return {name: type(value).__name__ for name in names if (value := row.get(name)) is not None}
+
     def _output_schema(self, data: Any) -> OutputSchema | None:
         """Row-wise list[dict] resolves every column's dtype in a single pass over rows;
         other shapes (columnar dict included) delegate to the base implementation."""
@@ -141,18 +146,31 @@ class PythonDictFramework(ComputeFramework):
         for row in data:
             if not unresolved:
                 break
-            for name in list(unresolved):
+            pending = tuple(unresolved)
 
-                def _read(row: Any = row, name: str = name) -> str | None:
-                    value = row.get(name)
-                    return None if value is None else type(value).__name__
+            def _read_row(row: Any = row, pending: tuple[str, ...] = pending) -> dict[str, str] | None:
+                return self._row_dtypes(row, pending)
 
-                dtype = safe_field(_read, None)
-                if dtype is not None:
-                    dtypes[name] = dtype
-                    unresolved.discard(name)
+            # One safe_field call per row (not per cell): a hostile column must not force a
+            # per-cell try/except for every column that would otherwise resolve cheaply.
+            resolved = safe_field(_read_row, None)
+            if resolved is None:
+                # The batch read raised; isolate the hostile column(s) so a single bad column
+                # does not also degrade this row's otherwise-readable columns.
+                resolved = {}
+                for name in pending:
 
-        return tuple((name, dtypes[name]) for name in sorted(names, key=str))
+                    def _read_cell(row: Any = row, name: str = name) -> dict[str, str] | None:
+                        return self._row_dtypes(row, (name,))
+
+                    cell_result = safe_field(_read_cell, None)
+                    if cell_result is not None:
+                        resolved.update(cell_result)
+            for name, dtype in resolved.items():
+                dtypes[name] = dtype
+                unresolved.discard(name)
+
+        return tuple((str(name), dtypes[name]) for name in sorted(names, key=str))
 
     @staticmethod
     def _validate_columnar_dict(data: dict[str, Any]) -> None:

--- a/tests/test_plugins/compute_framework/test_output_schema_hook.py
+++ b/tests/test_plugins/compute_framework/test_output_schema_hook.py
@@ -82,6 +82,11 @@ class TestPythonDictRowWiseOutputSchemaSinglePass:
         rows = [{"b": "x", "a": 1}, {"b": "y", "a": 2}]
         assert PythonDictFramework()._output_schema(rows) == (("a", "int"), ("b", "str"))
 
+    def test_non_string_keys_are_stringified(self) -> None:
+        """MINOR: the row-wise branch's final tuple emits (name, ...) instead of (str(name), ...),
+        so a non-str key (e.g. int 1) leaks through unstringified, unlike the base class."""
+        assert PythonDictFramework()._output_schema([{1: "x", "a": 2}]) == (("1", "str"), ("a", "int"))
+
 
 @pytest.mark.skipif(pa is None, reason="PyArrow is not installed. Skipping this test.")
 class TestPyArrowOutputSchema:
@@ -131,6 +136,29 @@ class TestBaseComputeFrameworkOutputSchemaRaises:
     def test_raises_not_implemented_error(self) -> None:
         with pytest.raises(NotImplementedError):
             ComputeFramework()._output_schema([1, 2])
+
+
+class _RaisingColumnADtypeFramework(ComputeFramework):
+    """Names come back fixed as {"a", "b"}; dtype extraction raises for "a" but works for "b"."""
+
+    def _extract_column_names(self, data: Any) -> set[str]:
+        return {"a", "b"}
+
+    def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
+        if column_name == "a":
+            raise RuntimeError("cannot read dtype for column 'a'")
+        return "int"
+
+
+class TestBaseComputeFrameworkGenericLoopDegradesColumnToNone:
+    """Coverage restoration: exercises ComputeFramework._output_schema's generic per-column
+    safe_field loop directly, independent of PythonDictFramework's own single-pass override.
+    This loop still runs for every framework that does not override _output_schema."""
+
+    def test_raising_extract_column_dtype_degrades_only_that_column(self) -> None:
+        fw = _RaisingColumnADtypeFramework()
+        # A non-dict-shaped sentinel so this hits the generic loop, not the dict shortcut.
+        assert fw._output_schema(object()) == (("a", None), ("b", "int"))
 
 
 class _ContextCapturingExtender(Extender):
@@ -245,12 +273,15 @@ class TestDtypeFailureDegradesColumnToNone:
         extender = _ContextCapturingExtender()
         cfw = _build_framework({extender})
 
-        cfw.run_calculate_feature(_RowWiseOutputSchemaFeatureGroup, feature_set)
+        result = cfw.run_calculate_feature(_RowWiseOutputSchemaFeatureGroup, feature_set)
 
         captured = extender.captured
         assert captured is not None
         assert captured.output_schema == (("a", None), ("b", "str"))
         assert captured.status == "success"
+        # dict.__eq__ does not invoke the overridden get/__getitem__, so this equality check is
+        # unaffected by the poisoned column and confirms the schema-read failure did not corrupt data.
+        assert result == [{"b": "x", "a": 1}, {"b": "y", "a": 2}]
 
 
 class TestValidateHooksOutputSchema:
@@ -311,6 +342,19 @@ class TestPolarsLazyOutputSchemaStaysLazy:
         assert call_count == 1
 
 
+@pytest.mark.skipif(pl is None, reason="Polars is not installed. Skipping this test.")
+class TestPolarsLazyDictInterchangeOutputSchema(DictInterchangeOutputSchemaTestMixin):
+    """Test PolarsLazyDataFrame._output_schema on the dict interchange shape using shared mixin.
+
+    BLOCKER: _output_schema calls data.collect_schema() unconditionally, with no isinstance(data, dict)
+    guard, but the dict interchange shape reaches this method before transform() normalizes it.
+    """
+
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return PolarsLazyDataFrame()
+
+
 class _IndexForbiddenList(list[str]):
     """Stand-in for data.columns whose .index() raises, since the builtin list type itself
     cannot be monkeypatched."""
@@ -351,6 +395,38 @@ class TestDuckDBOutputSchemaStaysLazy:
 
         assert DuckDBFramework()._output_schema(relation) == (("a", "DOUBLE"), ("b", "BIGINT"), ("c", "VARCHAR"))
 
+    def test_output_schema_reads_columns_and_types_properties_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stronger perf regression than test_output_schema_does_not_call_list_index: counts total
+        reads of columns/types instead of only forbidding .index(), catching any once-per-column read."""
+        conn = duckdb.connect()
+        arrow_table = pa.Table.from_pydict({"c": ["x"], "b": [1], "a": [1.5]})
+        relation = DuckdbRelation.from_arrow(conn, arrow_table)
+
+        original_get_columns = cast(property, DuckdbRelation.__dict__["columns"]).fget
+        original_get_types = cast(property, DuckdbRelation.__dict__["types"]).fget
+        assert original_get_columns is not None
+        assert original_get_types is not None
+
+        columns_read_count = 0
+        types_read_count = 0
+
+        def _counting_columns(self: Any) -> Any:
+            nonlocal columns_read_count
+            columns_read_count += 1
+            return original_get_columns(self)
+
+        def _counting_types(self: Any) -> Any:
+            nonlocal types_read_count
+            types_read_count += 1
+            return original_get_types(self)
+
+        monkeypatch.setattr(DuckdbRelation, "columns", property(_counting_columns))
+        monkeypatch.setattr(DuckdbRelation, "types", property(_counting_types))
+
+        assert DuckDBFramework()._output_schema(relation) == (("a", "DOUBLE"), ("b", "BIGINT"), ("c", "VARCHAR"))
+        assert columns_read_count == 1
+        assert types_read_count == 1
+
     def test_validate_output_feature_hook_does_not_call_dunder_len(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Regression at the hook-dispatch level: VALIDATE_OUTPUT_FEATURE must read output_schema
         without materializing the relation, not just when _output_schema is unit-tested directly."""
@@ -374,6 +450,22 @@ class TestDuckDBOutputSchemaStaysLazy:
         captured = extender.captured
         assert captured is not None
         assert captured.output_schema == (("a", "BIGINT"), ("b", "VARCHAR"))
+
+
+@pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB/PyArrow is not installed.")
+class TestDuckDBOutputSchemaDuplicateColumns:
+    """MAJOR: zip(data.columns, data.types) no longer dedupes duplicate column names the way the
+    old _extract_column_names = set(data.columns) path did; duplicates leak through as-is."""
+
+    def test_duplicate_column_names_collapse_to_one_entry(self) -> None:
+        conn = duckdb.connect()
+        relation = DuckdbRelation(conn, conn.sql("select 1 as a, 2 as b, 3 as a"))
+
+        result = DuckDBFramework()._output_schema(relation)
+
+        assert result is not None
+        a_entries = [pair for pair in result if pair[0] == "a"]
+        assert len(a_entries) == 1
 
 
 class _PandasOutputSchemaFeatureGroup(FeatureGroup):

--- a/tests/test_plugins/compute_framework/test_output_schema_hook.py
+++ b/tests/test_plugins/compute_framework/test_output_schema_hook.py
@@ -5,7 +5,7 @@ are never materialized to build the schema.
 
 import sqlite3
 import types
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -65,6 +65,22 @@ class TestPythonDictOutputSchema:
     def test_non_native_shape_yields_none(self) -> None:
         fw = PythonDictFramework()
         assert fw._output_schema([1, 2, 3]) is None
+
+
+class TestPythonDictRowWiseOutputSchemaSinglePass:
+    """Perf regression: the row-wise list[dict] shape must resolve dtypes in a single pass
+    over the rows, not by rebuilding a full per-column values list for every column."""
+
+    def test_output_schema_does_not_call_column_values_for_list_input(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise_if_list(data: Any, column_name: str) -> list[Any]:
+            if isinstance(data, list):
+                raise AssertionError("_column_values must not be called by _output_schema for row-wise list input")
+            return data.get(column_name, [])  # type: ignore[no-any-return]
+
+        monkeypatch.setattr(PythonDictFramework, "_column_values", staticmethod(_raise_if_list))
+
+        rows = [{"b": "x", "a": 1}, {"b": "y", "a": 2}]
+        assert PythonDictFramework()._output_schema(rows) == (("a", "int"), ("b", "str"))
 
 
 @pytest.mark.skipif(pa is None, reason="PyArrow is not installed. Skipping this test.")
@@ -200,11 +216,19 @@ class TestBaseComputeFrameworkOutputSchemaEndToEnd:
         assert captured.status == "success"
 
 
-class _RaisingDtypeFramework(PythonDictFramework):
-    """PythonDictFramework whose _extract_column_dtype always raises, to exercise output_schema degradation."""
+class _HostileColumnARow(dict[str, Any]):
+    """Access to column 'a' always raises; 'b' stays readable. Poisons row access directly
+    since single-pass _output_schema no longer calls _extract_column_dtype for this shape."""
 
-    def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
-        raise RuntimeError("dtype boom")
+    def get(self, key: Any, default: Any = None) -> Any:
+        if key == "a":
+            raise RuntimeError("corrupted row: cannot read column 'a'")
+        return super().get(key, default)
+
+    def __getitem__(self, key: Any) -> Any:
+        if key == "a":
+            raise RuntimeError("corrupted row: cannot read column 'a'")
+        return super().__getitem__(key)
 
 
 class _RowWiseOutputSchemaFeatureGroup(FeatureGroup):
@@ -212,23 +236,20 @@ class _RowWiseOutputSchemaFeatureGroup(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return [{"b": "x", "a": 1}, {"b": "y", "a": 2}]
+        return [_HostileColumnARow(b="x", a=1), _HostileColumnARow(b="y", a=2)]
 
 
 class TestDtypeFailureDegradesColumnToNone:
     def test_dtype_raising_degrades_only_that_columns_dtype(self) -> None:
         feature_set = _build_feature_set()
         extender = _ContextCapturingExtender()
-        cfw = _RaisingDtypeFramework(
-            mode=ParallelizationMode.SYNC, children_if_root=frozenset(), function_extender={extender}
-        )
+        cfw = _build_framework({extender})
 
-        result = cfw.run_calculate_feature(_RowWiseOutputSchemaFeatureGroup, feature_set)
+        cfw.run_calculate_feature(_RowWiseOutputSchemaFeatureGroup, feature_set)
 
-        assert result == [{"b": "x", "a": 1}, {"b": "y", "a": 2}]
         captured = extender.captured
         assert captured is not None
-        assert captured.output_schema == (("a", None), ("b", None))
+        assert captured.output_schema == (("a", None), ("b", "str"))
         assert captured.status == "success"
 
 
@@ -272,6 +293,31 @@ class TestPolarsLazyOutputSchemaStaysLazy:
 
         assert PolarsLazyDataFrame()._output_schema(lazy_frame) == (("a", "Int64"), ("b", "String"))
 
+    def test_output_schema_calls_collect_schema_at_most_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Perf regression: collect_schema() must run once total, not once per column."""
+        call_count = 0
+        original_collect_schema = pl.LazyFrame.collect_schema
+
+        def _counting_collect_schema(self: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            return original_collect_schema(self, *args, **kwargs)
+
+        monkeypatch.setattr(pl.LazyFrame, "collect_schema", _counting_collect_schema)
+
+        lazy_frame = pl.LazyFrame({"c": ["x"], "b": [1], "a": [1.5]})
+
+        assert PolarsLazyDataFrame()._output_schema(lazy_frame) == (("a", "Float64"), ("b", "Int64"), ("c", "String"))
+        assert call_count == 1
+
+
+class _IndexForbiddenList(list[str]):
+    """Stand-in for data.columns whose .index() raises, since the builtin list type itself
+    cannot be monkeypatched."""
+
+    def index(self, *args: Any, **kwargs: Any) -> int:
+        raise AssertionError("list.index must not be called by _output_schema")
+
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB/PyArrow is not installed.")
 class TestDuckDBOutputSchemaStaysLazy:
@@ -288,6 +334,22 @@ class TestDuckDBOutputSchemaStaysLazy:
         monkeypatch.setattr(DuckdbRelation, "__len__", _raise_if_called)
 
         assert DuckDBFramework()._output_schema(relation) == (("a", "BIGINT"), ("b", "VARCHAR"))
+
+    def test_output_schema_does_not_call_list_index(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Perf regression: data.columns.index(name) is O(columns) per call, quadratic overall."""
+        conn = duckdb.connect()
+        arrow_table = pa.Table.from_pydict({"c": ["x"], "b": [1], "a": [1.5]})
+        relation = DuckdbRelation.from_arrow(conn, arrow_table)
+
+        original_get_columns = cast(property, DuckdbRelation.__dict__["columns"]).fget
+        assert original_get_columns is not None
+
+        def _index_forbidden_columns(self: Any) -> Any:
+            return _IndexForbiddenList(original_get_columns(self))
+
+        monkeypatch.setattr(DuckdbRelation, "columns", property(_index_forbidden_columns))
+
+        assert DuckDBFramework()._output_schema(relation) == (("a", "DOUBLE"), ("b", "BIGINT"), ("c", "VARCHAR"))
 
     def test_validate_output_feature_hook_does_not_call_dunder_len(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Regression at the hook-dispatch level: VALIDATE_OUTPUT_FEATURE must read output_schema


### PR DESCRIPTION
## Summary

`ComputeFramework._output_schema` builds `HookContext.output_schema` by calling `_extract_column_dtype` once per column, so frameworks whose dtype read re-derives the whole schema pay one schema read per column on every `calculate_feature` call that has an extender registered.

- `PolarsLazyDataFrame` now reads `collect_schema()` once instead of once per column.
- `DuckDBFramework` now zips `columns`/`types` once instead of a linear `.index()` lookup per column, and dedupes duplicate column names (e.g. from an un-aliased join) rather than emitting repeated entries.
- `PythonDictFramework` resolves the row-wise `list[dict]` shape in a single pass over rows (batched per row, falling back to per-column isolation only if a row's read raises), instead of rebuilding a full per-column values list for every column.

`SqliteFramework._output_schema` already used this pattern for its relation shape and served as the template.

## Testing

Added and adapted coverage in `tests/test_plugins/compute_framework/test_output_schema_hook.py`: single-read regression tests per framework (mirroring the existing laziness tests), the dict interchange shape for polars, duplicate-column handling for duckdb, non-string key stringification for the row-wise python_dict shape, and restored per-column degradation coverage for both the generic base-class loop and the row-wise single-pass path.

Full `tox` passes (tests, ruff format/check, mypy strict, bandit, license check).

Closes #1297