### PR TITLE
fix: log once per class when plugin_docs version() degrades

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -277,12 +277,13 @@ also reject a non-str return, so a wrong type degrades too instead of sinking th
 call at the filter.
 
 Logging is opt-in via `field`: the labelled `get_feature_group_docs` reads warn on
-swallow, where a raise does mean a broken plugin. The unlabelled guards stay silent
-because degrading there is by design (source introspection of `type()`-built
-classes, an availability probe without its optional backend, Iceberg's deliberate
-`NotImplementedError` from `merge_engine()`). A hot call site can also pass
-`warn_once_for` (a key, typically the plugin class) to dedup that WARNING to once
-per key instead of once per call.
+swallow, where a raise does mean a broken plugin (`_safe_version` included, via
+`warn_once_for` so a broken class warns once, not once per catalog walk). The
+unlabelled guards stay silent because degrading there is by design (the source-hash
+read in `accessible_plugins.py`, an availability probe without its optional backend,
+Iceberg's deliberate `NotImplementedError` from `merge_engine()`). A hot call site
+can also pass `warn_once_for` (a key, typically the plugin class) to dedup that
+WARNING to once per key instead of once per call.
 
 `get_compute_framework_docs` uses the default broad `catching` (any failure
 degrades the field), while the narrower named guards `_safe_version` (in

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -51,8 +51,20 @@ def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
 
 
 def _safe_version(fg_class: type[FeatureGroup]) -> str:
-    """Return the feature group version or "unavailable" if source introspection fails or version() is not a str."""
-    return safe_field(lambda: as_str(fg_class.version()), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
+    """Return the feature group version or "unavailable" if source introspection fails or version() is not a str.
+
+    Warns once per class (via warn_once_for) when it degrades.
+    """
+    cls_name = fg_class.__name__
+    return safe_field(
+        lambda: as_str(fg_class.version()),
+        "unavailable",
+        catching=SOURCE_INTROSPECTION_ERRORS,
+        field=f"{cls_name}.version",
+        # Shares this dedup key with compute_framework.py's _build_hook_context version read;
+        # only whichever call site hits first per class actually warns for it in a process.
+        warn_once_for=fg_class,
+    )
 
 
 def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -618,28 +618,6 @@ class TestGetFeatureGroupDocsContractViolations:
             del _DocsVersionNonStrUnfilteredFG
             gc.collect()
 
-    def test_version_degradation_stays_silent(self, caplog: pytest.LogCaptureFixture) -> None:
-        """_safe_version is unlabelled by design, so a degraded version read logs nothing."""
-
-        class _DocsVersionSilentFG(FeatureGroup):
-            """Test double whose version() returns an int."""
-
-            @classmethod
-            def version(cls) -> Any:
-                return 42
-
-        try:
-            with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
-                by_name = {fg.name: fg for fg in get_feature_group_docs()}
-
-            assert by_name["_DocsVersionSilentFG"].version == "unavailable"
-
-            messages = [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER]
-            assert messages == [], f"An unlabelled version degradation must be silent, got {messages}"
-        finally:
-            del _DocsVersionSilentFG
-            gc.collect()
-
 
 class TestDegradedReadLogging:
     """Feature-group reads are labelled, so they warn. Compute-framework reads are not, so they stay silent.
@@ -675,6 +653,70 @@ class TestDegradedReadLogging:
             assert "boom" in matching[0], "Warning must carry the swallowed exception message"
         finally:
             del _DocsWarnBoomFG
+            gc.collect()
+
+    def test_version_raising_logs_exactly_one_warning_across_repeated_calls(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A version() that raises degrades once; warn_once_for dedups the WARNING across repeated doc calls."""
+
+        class _DocsVersionRaisesFG(FeatureGroup):
+            """Test double whose version() classmethod raises OSError."""
+
+            @classmethod
+            def version(cls) -> str:
+                raise OSError("boom")
+
+        try:
+            with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+                first = {fg.name: fg for fg in get_feature_group_docs()}
+                second = {fg.name: fg for fg in get_feature_group_docs()}
+
+            assert "_DocsVersionRaisesFG" in first, "A raising version() must not drop the class from the catalog"
+            assert first["_DocsVersionRaisesFG"].version == "unavailable"
+            assert "_DocsVersionRaisesFG" in second, "The class must stay in the catalog on the second call too"
+            assert second["_DocsVersionRaisesFG"].version == "unavailable"
+
+            warnings = [
+                record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.WARNING
+                and record.name == SAFE_FIELD_LOGGER
+                and "_DocsVersionRaisesFG.version" in record.getMessage()
+            ]
+            assert len(warnings) == 1, f"Expected exactly one WARNING across both calls, got {warnings}"
+            assert "boom" in warnings[0], "Warning must carry the swallowed exception message"
+        finally:
+            del _DocsVersionRaisesFG
+            gc.collect()
+
+    def test_version_degradation_logs_warning_naming_class_and_field(self, caplog: pytest.LogCaptureFixture) -> None:
+        """_safe_version is labelled, so a degraded version read (non-str return) logs a WARNING."""
+
+        class _DocsVersionWarnFG(FeatureGroup):
+            """Test double whose version() returns an int."""
+
+            @classmethod
+            def version(cls) -> Any:
+                return 42
+
+        try:
+            with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+                by_name = {fg.name: fg for fg in get_feature_group_docs()}
+
+            assert by_name["_DocsVersionWarnFG"].version == "unavailable"
+
+            messages = [
+                record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
+            ]
+            matching = [msg for msg in messages if "_DocsVersionWarnFG.version" in msg]
+            assert len(matching) == 1, (
+                f"Expected exactly one WARNING naming '_DocsVersionWarnFG.version', got {messages}"
+            )
+        finally:
+            del _DocsVersionWarnFG
             gc.collect()
 
     def test_degraded_compute_framework_read_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary

\`_safe_version\` in \`plugin_docs.py\` read a FeatureGroup's \`version()\` through \`safe_field\` with no \`field\` label, so a broken \`version()\` degraded to \`"unavailable"\` with zero log trace on the docs/catalog enumeration path (\`get_feature_group_docs\`).

The same silent-fallback problem was already fixed on the extender/HookContext path (\`ComputeFramework._build_hook_context\`), which labels the read and passes \`warn_once_for\` so a broken class warns once instead of flooding the log. This applies the identical fix to \`plugin_docs.py\`'s \`_safe_version\`, since \`get_feature_group_docs\` iterates the whole plugin registry per call.

## Changes

- \`_safe_version\` now passes \`field=f"{cls_name}.version"\` (matching this file's own labelling convention) and \`warn_once_for=fg_class\`.
- The narrow \`catching=SOURCE_INTROSPECTION_ERRORS\` guard is unchanged.
- Tests cover a FeatureGroup whose \`version()\` raises during doc enumeration, asserting the log record and that the warning dedups across repeated calls.
- Doc update to keep the "labelled vs unlabelled reads" description in \`discover-plugins.md\` accurate.

Closes #1333