### PR TITLE
fix: raise on missing filter parameters in Iceberg filter engine

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_filter_engine.py
@@ -7,7 +7,6 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_type_semantics
 try:
     from pyiceberg.table import Table as IcebergTable
     from pyiceberg.expressions import (
-        GreaterThan,
         LessThan,
         GreaterThanOrEqual,
         LessThanOrEqual,
@@ -17,7 +16,6 @@ try:
     )
 except ImportError:
     IcebergTable: Optional[type[Any]] = None  # type: ignore[no-redef]
-    GreaterThan: Optional[type[Any]] = None  # type: ignore[no-redef]
     LessThan: Optional[type[Any]] = None  # type: ignore[no-redef]
     GreaterThanOrEqual: Optional[type[Any]] = None  # type: ignore[no-redef]
     LessThanOrEqual: Optional[type[Any]] = None  # type: ignore[no-redef]
@@ -96,9 +94,7 @@ class IcebergFilterEngine(BaseFilterEngine):
     @classmethod
     def _build_iceberg_expression(cls, filter_feature: SingleFilter) -> Any:
         """Build an Iceberg filter expression from a SingleFilter."""
-        if any(
-            expr is None for expr in [EqualTo, GreaterThan, LessThan, GreaterThanOrEqual, LessThanOrEqual, Reference]
-        ):
+        if any(expr is None for expr in [EqualTo, And, LessThan, GreaterThanOrEqual, LessThanOrEqual, Reference]):
             return None
 
         column_name = str(filter_feature.filter_feature.name)
@@ -106,48 +102,51 @@ class IcebergFilterEngine(BaseFilterEngine):
 
         if filter_type == "equal":
             value = cls._extract_parameter_value(filter_feature, "value")
-            return EqualTo(Reference(column_name), value) if value is not None else None
+            if value is None:
+                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
+            return EqualTo(Reference(column_name), value)
 
         elif filter_type == "min":
             value = cls._extract_parameter_value(filter_feature, "value")
-            return GreaterThanOrEqual(Reference(column_name), value) if value is not None else None
+            if value is None:
+                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
+            return GreaterThanOrEqual(Reference(column_name), value)
 
         elif filter_type == "max":
-            # Handle both simple and complex max parameters
-            if cls._has_parameter(filter_feature, "max"):
-                _, max_param, is_max_exclusive = cls.get_min_max_operator(filter_feature)
-                if max_param is not None:
-                    if is_max_exclusive:
-                        return LessThan(Reference(column_name), max_param)
-                    return LessThanOrEqual(Reference(column_name), max_param)
-            else:
+            has_max = cls._has_parameter(filter_feature, "max")
+            has_value = cls._extract_parameter_value(filter_feature, "value") is not None
+
+            if has_max:
+                min_param, max_param, is_max_exclusive = cls.get_min_max_operator(filter_feature)
+                if min_param is not None:
+                    raise ValueError(
+                        f"Filter parameter {filter_feature.parameter} not supported as max filter: "
+                        f"{filter_feature.name}"
+                    )
+                if is_max_exclusive is True:
+                    return LessThan(Reference(column_name), max_param)
+                return LessThanOrEqual(Reference(column_name), max_param)
+            elif has_value:
                 value = cls._extract_parameter_value(filter_feature, "value")
-                return LessThanOrEqual(Reference(column_name), value) if value is not None else None
+                return LessThanOrEqual(Reference(column_name), value)
+            else:
+                raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
 
         elif filter_type == "range":
             min_param, max_param, is_max_exclusive = cls.get_min_max_operator(filter_feature)
-            expressions: list[Any] = []
+            if min_param is None or max_param is None:
+                raise ValueError(f"Filter parameter {filter_feature.parameter} not supported")
 
-            if min_param is not None:
-                expressions.append(GreaterThanOrEqual(Reference(column_name), min_param))
-
-            if max_param is not None:
-                if is_max_exclusive:
-                    expressions.append(LessThan(Reference(column_name), max_param))
-                else:
-                    expressions.append(LessThanOrEqual(Reference(column_name), max_param))
-
-            if len(expressions) == 1:
-                return expressions[0]
-            elif len(expressions) == 2 and And is not None:
-                return And(expressions[0], expressions[1])
-
-            return None
+            expr_min = GreaterThanOrEqual(Reference(column_name), min_param)
+            expr_max: Any
+            if is_max_exclusive is True:
+                expr_max = LessThan(Reference(column_name), max_param)
+            else:
+                expr_max = LessThanOrEqual(Reference(column_name), max_param)
+            return And(expr_min, expr_max)
 
         else:
             raise NotImplementedError(f"Unsupported Iceberg filter type: {filter_type!r}")
-
-        return None
 
     @classmethod
     def _extract_parameter_value(cls, filter_feature: SingleFilter, param_name: str) -> Any:

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
@@ -136,6 +136,76 @@ class TestIcebergFilterEngine:
         with pytest.raises(NotImplementedError):
             IcebergFilterEngine._build_iceberg_expression(single_filter)
 
+    def test_build_iceberg_expression_equal_missing_value_raises(self) -> None:
+        """EQUAL with no value must raise ValueError, not silently return None."""
+        feature = Feature("age")
+        filter_type = FilterType.EQUAL
+        parameter = {"invalid": 30}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="Filter parameter 'value' not found"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_min_missing_value_raises(self) -> None:
+        """MIN with no value must raise ValueError, not silently return None."""
+        feature = Feature("age")
+        filter_type = FilterType.MIN
+        parameter = {"invalid": 30}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="Filter parameter 'value' not found"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_max_missing_value_raises(self) -> None:
+        """MAX with neither value nor max must raise ValueError, matching the base engine's message."""
+        feature = Feature("age")
+        filter_type = FilterType.MAX
+        parameter = {"invalid": 30}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="No valid filter parameter found"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_max_with_min_raises(self) -> None:
+        """MAX with both min and max present must raise ValueError instead of silently dropping min."""
+        feature = Feature("age")
+        filter_type = FilterType.MAX
+        parameter = {"min": 25, "max": 50}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="not supported as max filter"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_range_missing_both_raises(self) -> None:
+        """RANGE with neither min nor max must raise ValueError, not silently return None."""
+        feature = Feature("age")
+        filter_type = FilterType.RANGE
+        parameter = {"invalid": 30}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="not supported"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_range_missing_max_raises(self) -> None:
+        """RANGE requires both bounds; a min-only range must raise ValueError."""
+        feature = Feature("age")
+        filter_type = FilterType.RANGE
+        parameter = {"min": 25}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="not supported"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
+    def test_build_iceberg_expression_range_missing_min_raises(self) -> None:
+        """RANGE requires both bounds; a max-only range must raise ValueError."""
+        feature = Feature("age")
+        filter_type = FilterType.RANGE
+        parameter = {"max": 50}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        with pytest.raises(ValueError, match="not supported"):
+            IcebergFilterEngine._build_iceberg_expression(single_filter)
+
     def test_extract_parameter_value(self) -> None:
         """Test extracting parameter values."""
         feature = Feature("age")
@@ -242,6 +312,17 @@ class TestIcebergFilterEngine:
         mock_feature_set.filters = [category_filter]
 
         with pytest.raises(NotImplementedError):
+            IcebergFilterEngine.apply_filters(mock_iceberg_table, mock_feature_set)
+
+        # An unfiltered scan would indicate the filter was silently dropped instead of raising.
+        mock_iceberg_table.scan.assert_not_called()
+
+    def test_apply_filters_equal_missing_value_raises(self, mock_iceberg_table: Mock, mock_feature_set: Mock) -> None:
+        """apply_filters must not silently drop a missing-value filter and return the unfiltered table."""
+        age_filter = SingleFilter(Feature("age"), FilterType.EQUAL, {"invalid": 30})
+        mock_feature_set.filters = [age_filter]
+
+        with pytest.raises(ValueError, match="Filter parameter 'value' not found"):
             IcebergFilterEngine.apply_filters(mock_iceberg_table, mock_feature_set)
 
         # An unfiltered scan would indicate the filter was silently dropped instead of raising.


### PR DESCRIPTION
## Summary

`IcebergFilterEngine._build_iceberg_expression` returned `None` for a supported filter type (equal, min, max, range) when a required value or bound was missing, and `apply_filters` silently dropped that filter, returning the unfiltered table instead of raising. Every other filter engine in the codebase (pandas, pyarrow, polars, spark, sql, python_dict) raises `ValueError` for the equivalent missing-parameter case, so this brings Iceberg in line.

## Changes

- `equal` and `min`: raise `ValueError` when `value` is missing, instead of returning `None`.
- `max`: restructured to a three-way split (has max bound, has simple value, neither) mirroring `BaseFilterEngine.do_max_filter`. Raises when neither parameter is present, and now also raises when a `min` bound is supplied alongside `max` (previously silently dropped the min and filtered on max alone).
- `range`: now requires both `min` and `max` to be present, matching every other engine's `do_range_filter`. A one-sided range previously built a partial, single-bound expression instead of raising; no caller in this codebase relies on that.

## Tests

Added coverage in `test_iceberg_filter_engine.py` for each missing-parameter case across all four filter types, plus the max-with-min case and an `apply_filters`-level check that a missing-value filter raises rather than falling through to an unfiltered scan.

Closes #1261