### PR TITLE
fix: resolve runtime artifacts across every Options instance in a FeatureSet

### DIFF
--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -131,7 +131,10 @@ for fold_data in folds:
 ```
 
 When `artifacts` is not provided (the default), the artifact mode from
-`prepare()` is used.
+`prepare()` is used. Baking an artifact into `Options` at prepare time and also
+supplying it via `run(artifacts=...)` for the same feature are mutually
+exclusive: resolving a runtime artifact when the key is already present in
+`Options.group` raises, rather than silently picking one over the other.
 
 #### Testing Artifacts
 

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -57,21 +57,25 @@ class FeatureSet:
 
         for feature_name in self.get_all_names():
             if feature_name in runtime_artifacts:
+                # Dedupe by identity, not equality: Options.__eq__/__hash__ is group-content-based,
+                # so distinct instances with equal groups must not collapse into one.
+                distinct_options = {id(feature.options): feature.options for feature in self.features}.values()
+
+                for options in distinct_options:
+                    if feature_name in options.group:
+                        raise ValueError(
+                            f"Artifact '{feature_name}' is already stored in Options.group from a previous "
+                            "save; supply it either via Options at prepare time or via run(artifacts=...), "
+                            "not both."
+                        )
+
+                # Write to context (never group, to avoid mutating any Feature's hash) on every
+                # distinct Options instance, since get_singular_option_from_options may read any of them.
+                for options in distinct_options:
+                    options.context[feature_name] = runtime_artifacts[feature_name]
+
                 self.artifact_to_load = feature_name
                 self.artifact_to_save = None
-                # self.options is commonly the same object a member Feature's `.options`
-                # aliases (set by add() on first insert, or shared directly by the caller
-                # across multiple features). Options.set() defaults a brand-new key to
-                # `group`, but group is what Options.__hash__/__eq__ (and therefore
-                # Feature.__hash__) is based on -- writing the artifact there silently
-                # changes the hash of any Feature(s) still referencing this Options
-                # object, corrupting `self.features` set membership for any Feature
-                # already inserted (#1236). `context` is excluded from hashing and is
-                # still checked by Options.get()/__getitem__, so store it there instead;
-                # write directly (rather than via add_to_context(), which raises on a
-                # differing existing value) so re-resolving across repeated run() calls
-                # with a different artifact each time keeps working.
-                self.options.context[feature_name] = runtime_artifacts[feature_name]
                 return
 
         self.artifact_to_load = None

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -66,11 +66,14 @@ class FeatureSet:
                         raise ValueError(
                             f"Artifact '{feature_name}' is already stored in Options.group from a previous "
                             "save; supply it either via Options at prepare time or via run(artifacts=...), "
-                            "not both."
+                            f"not both (feature set anchored on '{self.get_name_of_one_feature()}')."
                         )
 
                 # Write to context (never group, to avoid mutating any Feature's hash) on every
                 # distinct Options instance, since get_singular_option_from_options may read any of them.
+                # A raw dict write, not add_to_context(): its value-equality check crashes on
+                # non-boolean-comparable artifacts (e.g. numpy arrays) and would block re-resolving
+                # a different artifact across repeated run() calls.
                 for options in distinct_options:
                     options.context[feature_name] = runtime_artifacts[feature_name]
 

--- a/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
+++ b/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
@@ -1,6 +1,7 @@
 """Pin BaseArtifact.custom_loader to key off artifact_to_load, not name_of_one_feature (always the
 alphabetically smallest feature name, independent of which feature the artifact is stored under)."""
 
+import numpy as np
 import pytest
 
 from mloda.provider import BaseArtifact, FeatureSet
@@ -127,14 +128,25 @@ class TestFeatureSetResolveArtifactForRuntimeRejectsGroupCollision:
     must not silently coexist with a runtime override written into context: Options.get() checks
     group before context, so the stale group value would shadow the fresh runtime value forever."""
 
-    def test_raises_when_runtime_override_collides_with_group_baked_artifact(self) -> None:
-        options = Options({"z_col": "stored_value"})
-        feature = Feature("z_col", options)
+    def test_raises_when_second_feature_has_group_baked_artifact(self) -> None:
+        """The colliding key belongs to the second-added feature's Options, a distinct object
+        from self.options (aliased to the first-added feature), proving the check covers every
+        distinct instance in the set rather than only self.options."""
+        clean_options = Options({})
+        colliding_options = Options({"z_col": "stored_value"})
+        a_col = Feature("a_col", clean_options)
+        z_col = Feature("z_col", colliding_options)
         features = FeatureSet()
-        features.add(feature)
+        features.add(a_col)
+        features.add(z_col)
 
-        with pytest.raises(ValueError, match="(?i)artifact"):
+        with pytest.raises(ValueError, match="already stored in Options.group"):
             features.resolve_artifact_for_runtime({"z_col": "new_runtime_value"})
+
+        assert clean_options.context == {}
+        assert "z_col" not in colliding_options.context
+        assert features.artifact_to_load is None
+        assert features.artifact_to_save is None
 
 
 class TestFeatureSetResolveArtifactForRuntimeVisibleAcrossDistinctOptionsInstances:
@@ -156,3 +168,27 @@ class TestFeatureSetResolveArtifactForRuntimeVisibleAcrossDistinctOptionsInstanc
 
         assert options_a.context.get("z_col") == "runtime_value"
         assert options_z.context.get("z_col") == "runtime_value"
+        assert BaseArtifact.load(fs) == "runtime_value"
+
+    def test_runtime_numpy_array_lands_on_both_instances_and_re_resolves(self) -> None:
+        """A raw dict write (not add_to_context()) is required because numpy arrays are not
+        boolean-comparable; this also confirms a second resolve with a different array succeeds."""
+        options_a = Options({})
+        options_z = Options({})
+        a_col = Feature("a_col", options_a)
+        z_col = Feature("z_col", options_z)
+        fs = FeatureSet()
+        fs.add(a_col)
+        fs.add(z_col)
+
+        first_array = np.array([1, 2, 3])
+        fs.resolve_artifact_for_runtime({"z_col": first_array})
+
+        assert np.array_equal(options_a.context["z_col"], first_array)
+        assert np.array_equal(options_z.context["z_col"], first_array)
+
+        second_array = np.array([4, 5, 6])
+        fs.resolve_artifact_for_runtime({"z_col": second_array})
+
+        assert np.array_equal(options_a.context["z_col"], second_array)
+        assert np.array_equal(options_z.context["z_col"], second_array)

--- a/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
+++ b/tests/test_core/test_artifacts/test_base_artifact_custom_loader.py
@@ -1,6 +1,8 @@
 """Pin BaseArtifact.custom_loader to key off artifact_to_load, not name_of_one_feature (always the
 alphabetically smallest feature name, independent of which feature the artifact is stored under)."""
 
+import pytest
+
 from mloda.provider import BaseArtifact, FeatureSet
 from mloda.user import Feature, Options
 
@@ -118,3 +120,39 @@ class TestFeatureSetResolveArtifactForRuntimeDoesNotMutateFeatureHash:
         features.resolve_artifact_for_runtime({"z_col": "runtime_value"})
 
         assert shared_options["z_col"] == "runtime_value"
+
+
+class TestFeatureSetResolveArtifactForRuntimeRejectsGroupCollision:
+    """A stored artifact key baked into Options.group (the documented "load via Options" pattern)
+    must not silently coexist with a runtime override written into context: Options.get() checks
+    group before context, so the stale group value would shadow the fresh runtime value forever."""
+
+    def test_raises_when_runtime_override_collides_with_group_baked_artifact(self) -> None:
+        options = Options({"z_col": "stored_value"})
+        feature = Feature("z_col", options)
+        features = FeatureSet()
+        features.add(feature)
+
+        with pytest.raises(ValueError, match="(?i)artifact"):
+            features.resolve_artifact_for_runtime({"z_col": "new_runtime_value"})
+
+
+class TestFeatureSetResolveArtifactForRuntimeVisibleAcrossDistinctOptionsInstances:
+    """resolve_artifact_for_runtime() writes only onto self.options (aliased to whichever Feature
+    was added first). When a FeatureSet holds two value-equal but distinct Options instances, the
+    runtime value must land on both, since get_singular_option_from_options reads an arbitrary
+    feature from a set."""
+
+    def test_runtime_value_lands_on_both_distinct_options_instances(self) -> None:
+        options_a = Options({})
+        options_z = Options({})
+        a_col = Feature("a_col", options_a)
+        z_col = Feature("z_col", options_z)
+        fs = FeatureSet()
+        fs.add(a_col)
+        fs.add(z_col)
+
+        fs.resolve_artifact_for_runtime({"z_col": "runtime_value"})
+
+        assert options_a.context.get("z_col") == "runtime_value"
+        assert options_z.context.get("z_col") == "runtime_value"


### PR DESCRIPTION
## Summary

While this PR was in flight, #1236 (the original bug: `resolve_artifact_for_runtime` corrupting Feature hashes by writing into `Options.group`) was independently fixed and merged in #1331. This PR now covers what that fix left open, plus #1343.

`FeatureSet.resolve_artifact_for_runtime` writes the resolved runtime artifact value into `Options.context`. Two problems remained after #1331:

1. It wrote only onto `self.options`, aliased to whichever feature was added first. `BaseArtifact.get_singular_option_from_options` reads an arbitrary feature from the set, so a `FeatureSet` holding two distinct-but-value-equal `Options` instances could resolve the artifact onto one and never find it on the other (#1343).
2. If the artifact key already existed in `Options.group` (baked in via the documented prepare-time "load via Options" pattern) and a runtime override was then supplied for the same feature, the key ended up present in both `.group` and `.context`. `Options.get()` checks `.group` first, so the stale group value silently shadowed the fresh runtime value forever.

## Fix

Write the resolved value into every distinct `Options` instance referenced by the `FeatureSet`'s features (deduplicated by identity, since `Options` equality is group-content-based and would otherwise collapse distinct instances). Raise a clear error naming the conflict when the artifact key is already present in `Options.group`, instead of silently shadowing it.

## Tests

Regression coverage for: the artifact landing on every distinct `Options` instance (including a realistic `BaseArtifact.load` call), the group-collision error firing when the collision is on a non-aliased instance, atomicity of that raise (nothing partially mutated), and non-boolean-comparable artifact values (numpy arrays) across repeated resolves.

Closes #1343