### PR TITLE
chore(deps): bump mkdocs-material to 9.7.7

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1373,7 +1373,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.6"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1388,9 +1388,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `mkdocs-material` 9.7.6 -> 9.7.7 in `uv.lock`, fixing GHSA-xvg9-69gf-fjrf / CVE-2026-73295 (DOM XSS in the `search.suggest` feature via the `q` query parameter).
- Closes Dependabot alert #58.
- `mkdocs-material` is a transitive dependency of `mkdocs-jupyter` (docs extra only); it is not shipped in the published `mloda` package. The docs site itself uses the `readthedocs` theme, not Material, and `search.suggest` is not enabled, so the site was not exploitable regardless of version. Bumping anyway since a patch is available and the change is a single-line, isolated lockfile diff (no other packages moved).

## Test plan
- [x] `uv lock --upgrade-package mkdocs-material` produced an isolated diff (only `mkdocs-material` version/hashes changed)
- [x] Confirmed `mkdocs-material` is not part of tox's tested extras (`test,pandas,polars,duckdb,iceberg,sklearn,text-cleaning`), so this does not affect the pytest/mypy/bandit gate
- [ ] CI (tox) passes on this branch