### PR TITLE
fix: extract dtype from PyArrow tables in IcebergFramework

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -146,46 +146,54 @@ class IcebergFramework(ComputeFramework):
         return set(data.schema.names)
 
     def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
-        if IcebergTable is None or not isinstance(data, IcebergTable):
+        if IcebergTable is not None and isinstance(data, IcebergTable):
+            schema = data.schema()
+            if column_name not in set(schema.column_names):
+                return None
+            field = schema.find_field(column_name)
+            if field is None:
+                return None
+            return str(field.field_type)
+        if pa is not None and isinstance(data, pa.Table):
+            if column_name in data.schema.names:
+                return str(data.schema.field(column_name).type)
             return None
-        schema = data.schema()
-        if column_name not in set(schema.column_names):
-            return None
-        field = schema.find_field(column_name)
-        if field is None:
-            return None
-        return str(field.field_type)
+        return None
 
     def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
-        if IcebergTable is None or not isinstance(data, IcebergTable):
+        if IcebergTable is not None and isinstance(data, IcebergTable):
+            schema = data.schema()
+            if column_name not in set(schema.column_names):
+                return None
+            field = schema.find_field(column_name)
+            if field is None:
+                return None
+            field_type = field.field_type
+            if isinstance(field_type, IntegerType):
+                return DataType.INT32
+            if isinstance(field_type, LongType):
+                return DataType.INT64
+            if isinstance(field_type, FloatType):
+                return DataType.FLOAT
+            if isinstance(field_type, DoubleType):
+                return DataType.DOUBLE
+            if isinstance(field_type, BooleanType):
+                return DataType.BOOLEAN
+            if isinstance(field_type, StringType):
+                return DataType.STRING
+            if isinstance(field_type, BinaryType):
+                return DataType.BINARY
+            if isinstance(field_type, DateType):
+                return DataType.DATE
+            if isinstance(field_type, (TimestampType, TimestamptzType)):
+                return DataType.TIMESTAMP_MICROS
+            if isinstance(field_type, DecimalType):
+                return DataType.DECIMAL
             return None
-        schema = data.schema()
-        if column_name not in set(schema.column_names):
-            return None
-        field = schema.find_field(column_name)
-        if field is None:
-            return None
-        field_type = field.field_type
-        if isinstance(field_type, IntegerType):
-            return DataType.INT32
-        if isinstance(field_type, LongType):
-            return DataType.INT64
-        if isinstance(field_type, FloatType):
-            return DataType.FLOAT
-        if isinstance(field_type, DoubleType):
-            return DataType.DOUBLE
-        if isinstance(field_type, BooleanType):
-            return DataType.BOOLEAN
-        if isinstance(field_type, StringType):
-            return DataType.STRING
-        if isinstance(field_type, BinaryType):
-            return DataType.BINARY
-        if isinstance(field_type, DateType):
-            return DataType.DATE
-        if isinstance(field_type, (TimestampType, TimestamptzType)):
-            return DataType.TIMESTAMP_MICROS
-        if isinstance(field_type, DecimalType):
-            return DataType.DECIMAL
+        if pa is not None and isinstance(data, pa.Table):
+            if column_name not in data.schema.names:
+                return None
+            return DataType.from_arrow_type_safe(data.schema.field(column_name).type)
         return None
 
     def _output_schema(self, data: Any) -> OutputSchema | None:

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -291,6 +291,59 @@ class TestIcebergDtypeExtraction(DtypeExtractionTestMixin):
 @pytest.mark.skipif(
     pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
 )
+class TestIcebergDtypeExtractionPyArrow(DtypeExtractionTestMixin):
+    """Pin _extract_column_dtype for the post-transform PyArrow shape, not just a native IcebergTable."""
+
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return IcebergFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    @pytest.fixture
+    def dtype_sample_data(self) -> Any:
+        return pa.table({"int_col": [1, 2, 3], "str_col": ["a", "b", "c"], "float_col": [1.0, 2.0, 3.0]})
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
+class TestIcebergDataTypeValidatorPyArrow(DataTypeValidatorFrameworkTestMixin):
+    """Pin DataTypeValidator enforcement for the post-transform PyArrow shape, where from_arrow is the identity."""
+
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return IcebergFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    def from_arrow(self, table: Any) -> Any:
+        return table
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
+def test_extract_column_dtype_pyarrow_table_returns_arrow_type_string() -> None:
+    framework = IcebergFramework()
+    assert framework._extract_column_dtype(pa.table({"a": [1]}), "a") == "int64"
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
+def test_extract_column_dtype_pyarrow_table_missing_column_returns_none() -> None:
+    framework = IcebergFramework()
+    assert framework._extract_column_dtype(pa.table({"a": [1]}), "unknown") is None
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
+def test_extract_column_data_type_pyarrow_table_returns_int64() -> None:
+    framework = IcebergFramework()
+    assert framework._extract_column_data_type(pa.table({"a": [1]}), "a") is DataType.INT64
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
 class TestIcebergEmptyResult(EmptyResultFrameworkTestMixin):
     """Test IcebergFramework schema detection via shared mixin, covering both branches.
 


### PR DESCRIPTION
`IcebergFramework` accepts both native Iceberg tables and the post-transform PyArrow table shape, but dtype extraction only handled the Iceberg-table case, returning `None` for the PyArrow one.

This silently skipped `DataTypeValidator` enforcement of a feature's declared `data_type` for that shape (the resolver always returned `None`, which the validator treats as "skip this column"), and skipped filter dtype-compatibility validation for FeatureGroups that opt into row-level filtering.

`_extract_column_dtype` and `_extract_column_data_type` now also handle a `pa.Table`, mirroring `PyArrowTable`'s existing implementation. Iceberg-table behavior is unchanged.

Closes #1299
