### PR TITLE
fix: populate RunResult.runner in MlodaTestRunner.run_api

### DIFF
--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -44,7 +44,7 @@ class RunResult:
 
     results: list[Any] = field(default_factory=list)
     artifacts: dict[str, Any] = field(default_factory=dict)
-    runner: Optional[ExecutionOrchestrator] = None
+    runner: Optional[ExecutionOrchestrator] = None  # already torn down; only get_result()/get_artifacts() are safe
 
 
 class MlodaTestRunner:
@@ -96,7 +96,7 @@ class MlodaTestRunner:
             strict_type_enforcement: If True, enforce strict type matching for typed features
 
         Returns:
-            RunResult containing results, artifacts, and optionally the runner
+            RunResult containing results, artifacts, and the runner
         """
         if compute_frameworks is None:
             compute_frameworks = {PyArrowTable}

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -122,7 +122,7 @@ class MlodaTestRunner:
         if cleanup_flight_server:
             MlodaTestRunner.assert_flight_server_clean(parallelization_modes, flight_server)
 
-        return RunResult(results=results, artifacts=artifacts)
+        return RunResult(results=results, artifacts=artifacts, runner=api.runner)
 
     @staticmethod
     def run_api_simple(

--- a/tests/test_core/test_tooling/test_mloda_test_runner.py
+++ b/tests/test_core/test_tooling/test_mloda_test_runner.py
@@ -8,11 +8,9 @@ from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.user import Feature
 from mloda.user import Features
-from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
-from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
-from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_ALL
+from tests.test_core.test_tooling import MlodaTestRunner
 
 
 class RunnerFieldRootFeature(FeatureGroup):
@@ -25,17 +23,14 @@ class RunnerFieldRootFeature(FeatureGroup):
         return {cls.get_class_name(): [1]}
 
 
-@PARALLELIZATION_MODES_ALL
-class TestRunApiRunnerField:
-    def test_run_api_populates_runner(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
-        features = Features([Feature(name=RunnerFieldRootFeature.get_class_name())])
+def test_run_api_populates_runner() -> None:
+    features = Features([Feature(name=RunnerFieldRootFeature.get_class_name())])
 
-        result = MlodaTestRunner.run_api(
-            features,
-            compute_frameworks={PyArrowTable},
-            parallelization_modes=modes,
-            flight_server=flight_server,
-            plugin_collector=PluginCollector.enabled_feature_groups({RunnerFieldRootFeature}),
-        )
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PyArrowTable},
+        plugin_collector=PluginCollector.enabled_feature_groups({RunnerFieldRootFeature}),
+    )
 
-        assert isinstance(result.runner, ExecutionOrchestrator)
+    assert result.runner is not None
+    assert result.runner.get_artifacts() is result.artifacts

--- a/tests/test_core/test_tooling/test_mloda_test_runner.py
+++ b/tests/test_core/test_tooling/test_mloda_test_runner.py
@@ -1,0 +1,41 @@
+"""MlodaTestRunner.run_api must populate RunResult.runner with the ExecutionOrchestrator."""
+
+from typing import Any, Optional
+
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import Features
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_ALL
+
+
+class RunnerFieldRootFeature(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [1]}
+
+
+@PARALLELIZATION_MODES_ALL
+class TestRunApiRunnerField:
+    def test_run_api_populates_runner(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+        features = Features([Feature(name=RunnerFieldRootFeature.get_class_name())])
+
+        result = MlodaTestRunner.run_api(
+            features,
+            compute_frameworks={PyArrowTable},
+            parallelization_modes=modes,
+            flight_server=flight_server,
+            plugin_collector=PluginCollector.enabled_feature_groups({RunnerFieldRootFeature}),
+        )
+
+        assert isinstance(result.runner, ExecutionOrchestrator)


### PR DESCRIPTION
## What

`MlodaTestRunner.run_api`'s docstring promises a `RunResult` containing "results, artifacts, and the runner", but the `runner` field was never set, it was always `None`.

`mlodaAPI.run(...)` already sets `self.runner` (an `ExecutionOrchestrator`) as a side effect, so `run_api` now copies it onto the `RunResult` it returns instead of leaving it unset.

## Why

Fixes the mismatch between the documented and actual return value, so `RunResult.runner` is a usable field instead of dead weight.

## Changes

- `run_api` now returns `RunResult(..., runner=api.runner)`.
- Docstring updated (the field is unconditionally populated now, not optional).
- Noted on the field that the runner is already torn down by the time callers see it, so only `get_result()`/`get_artifacts()` are safe to call on it.
- Added a regression test asserting the returned runner is the one that actually produced the result.

Closes #1312