### PR TITLE
fix: check artifact_to_load/artifact_to_save with is None instead of truthiness

### DIFF
--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -45,10 +45,10 @@ class BaseExampleArtifactFeature(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        if features.artifact_to_save:
+        if features.artifact_to_save is not None:
             features.save_artifact = "BasicArtifact"
 
-        if features.artifact_to_load:
+        if features.artifact_to_load is not None:
             result = cls.load_artifact(features)
             print(f"{result} is the loaded artifact.")
 
@@ -154,7 +154,7 @@ class MySklearnFeatureGroup(FeatureGroup):
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         # Save multiple artifacts with unique keys
-        if features.artifact_to_save:
+        if features.artifact_to_save is not None:
             SklearnArtifact.save_sklearn_artifact(
                 features, 
                 "my_transformer", 
@@ -162,7 +162,7 @@ class MySklearnFeatureGroup(FeatureGroup):
             )
         
         # Load specific artifact by key
-        if features.artifact_to_load:
+        if features.artifact_to_load is not None:
             artifact_data = SklearnArtifact.load_sklearn_artifact(features, "my_transformer")
             fitted_model = artifact_data["fitted_transformer"]
 ```

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -336,7 +336,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
 
             # Check if we have a trained model in the artifact
             model_artifact = None
-            if features.artifact_to_load:
+            if features.artifact_to_load is not None:
                 model_artifact = cls.load_artifact(features)
                 if model_artifact is None:
                     raise ValueError("No artifact to load although it was requested.")
@@ -358,7 +358,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
                 )
 
                 # Save the updated artifact if needed
-                if features.artifact_to_save and updated_artifact and not features.artifact_to_load:
+                if features.artifact_to_save is not None and updated_artifact and features.artifact_to_load is None:
                     features.save_artifact = updated_artifact
 
                 # Store the results for later addition (main forecast + confidence bounds)
@@ -378,7 +378,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
                 )
 
                 # Save the updated artifact if needed
-                if features.artifact_to_save and updated_artifact and not features.artifact_to_load:
+                if features.artifact_to_save is not None and updated_artifact and features.artifact_to_load is None:
                     features.save_artifact = updated_artifact
 
                 # Store the result for later addition

--- a/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
@@ -254,7 +254,7 @@ class SklearnArtifact(BaseArtifact):
         Returns:
             The artifact data if found, None otherwise
         """
-        if features.artifact_to_load:
+        if features.artifact_to_load is not None:
             artifacts = cls.custom_loader(features)
             if artifacts and artifact_key in artifacts:
                 return artifacts[artifact_key]  # type: ignore
@@ -273,7 +273,7 @@ class SklearnArtifact(BaseArtifact):
             artifact_key: The unique key for this artifact
             artifact_data: The artifact data to save
         """
-        if features.artifact_to_save:
+        if features.artifact_to_save is not None:
             # Support multiple artifacts by using a dictionary
             if not isinstance(features.save_artifact, dict):
                 features.save_artifact = {}

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_sklearn_artifact.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_sklearn_artifact.py
@@ -15,6 +15,35 @@ from mloda.user import Options
 class TestSklearnArtifact:
     """Test cases for SklearnArtifact."""
 
+    def test_empty_string_artifact_to_save_proceeds(self) -> None:
+        """artifact_to_save="" must not be silently treated as unset."""
+        features = FeatureSet()
+        features.artifact_to_save = ""
+        SklearnArtifact.save_sklearn_artifact(features, "my_key", {"data": 1})
+        assert features.save_artifact == {"my_key": {"data": 1}}
+
+    def test_none_artifact_to_save_skips(self) -> None:
+        """artifact_to_save=None still skips (no change in behaviour)."""
+        features = FeatureSet()
+        assert features.artifact_to_save is None
+        SklearnArtifact.save_sklearn_artifact(features, "my_key", {"data": 1})
+        assert features.save_artifact is None
+
+    def test_empty_string_artifact_to_load_attempts_load(self) -> None:
+        """artifact_to_load="" must enter the load branch, not silently return None."""
+        features = FeatureSet()
+        features.artifact_to_load = ""
+        with patch.object(SklearnArtifact, "custom_loader", return_value=None):
+            with pytest.raises(ValueError, match="Artifact not found"):
+                SklearnArtifact.load_sklearn_artifact(features, "my_key")
+
+    def test_none_artifact_to_load_returns_none(self) -> None:
+        """artifact_to_load=None still returns None (no change in behaviour)."""
+        features = FeatureSet()
+        assert features.artifact_to_load is None
+        result = SklearnArtifact.load_sklearn_artifact(features, "my_key")
+        assert result is None
+
     def test_serialize_deserialize_artifact(self) -> None:
         """Test serialization and deserialization of sklearn artifacts."""
         # Skip test if sklearn/joblib not available


### PR DESCRIPTION
Closes #1306

## Problem
`artifact_to_load` and `artifact_to_save` are `Optional[str]`, but several call sites used truthiness checks. A genuinely-set empty-string artifact key was silently treated as unset:

- `SklearnArtifact` skip loading/saving when the key is `""`
- `ForecastingFeatureGroup` skipped loading and saving under the same condition
- `docs/docs/in_depth/artifacts.md` taught the same buggy pattern

## Fix
Replace truthiness checks with explicit `is None` / `is not None` checks at the five call sites and update the four matching doc examples. This aligns the plugins with the framework-level `BaseArtifact`, which already uses `is None`.

## Tests
- `test_empty_string_artifact_to_save_proceeds`: `""` key now saves; previously skipped silently
- `test_empty_string_artifact_to_load_attempts_load`: `""` key now enters the load path and raises a clear error when the artifact is absent; previously returned `None`
- `test_none_artifact_to_save_skips` / `test_none_artifact_to_load_returns_none`: none-key behaviour unchanged

Note: the tox gate ran on `tox -e python314` (10076 passed); the one failing test (`test_worker_parent_death.py`) is a pre-existing flake unrelated to this change and passes in isolation. ruff format/check, mypy --strict, and bandit all pass.