### PR TITLE
chore: enable ruff UP045 and rewrite Optional annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ source .venv/bin/activate
 `tox` is the gate. It runs `pytest -n 8 --timeout=10`, then `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
 
 - **Python**: supported range is `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
-- **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
+- **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006`, `UP007`, and `UP045`.
 - **Formatting**: ruff format with line length 120.
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=170`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ source .venv/bin/activate
 `tox` is the gate. It runs `pytest -n 8 --timeout=10`, then `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
 
 - **Python**: supported range is `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
-- **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
+- **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006`, `UP007`, and `UP045`.
 - **Formatting**: ruff format with line length 120.
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=170`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.

--- a/docs/docs/examples/mloda_basics/1_ml_mloda_intro.py
+++ b/docs/docs/examples/mloda_basics/1_ml_mloda_intro.py
@@ -180,7 +180,7 @@ def _(Feature, data_access_collection, mloda):
 
 @app.cell
 def _(Feature, data_access_collection, mloda):
-    from typing import Any, Optional
+    from typing import Any
     from mloda.provider import FeatureGroup, FeatureSet
     from mloda.user import FeatureName, Options, Index, Link, JoinSpec
     from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature
@@ -189,13 +189,13 @@ def _(Feature, data_access_collection, mloda):
 
     class ReadFileFeatureJoin(ReadFileFeature):
         @classmethod
-        def index_columns(cls) -> Optional[list[Index]]:
+        def index_columns(cls) -> list[Index] | None:
             return [index]
 
     link = Link.inner(JoinSpec(ReadFileFeatureJoin, index), JoinSpec(ReadFileFeatureJoin, index))
 
     class ExampleMlLifeCycleJoin(FeatureGroup):
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             quantity = Feature(name="quantity", compute_framework="PandasDataFrame")
             product_id = Feature(name="product_id", compute_framework="PyArrowTable")
             return {product_id, quantity}

--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
@@ -185,7 +185,7 @@ def _():
     # In the following, we will just adjust a bit the CsvReader to handle a different delimiter.
     # CsvReader2 overrides load_data wholesale, returning a concrete table instead of a FileSource.
 
-    from typing import Any, Optional
+    from typing import Any
 
     from pyarrow import csv as pyarrow_csv
 
@@ -209,7 +209,7 @@ def _():
 
     class ReadFileFeature2(ReadFileFeature):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return CsvReader2()
 
         @classmethod

--- a/docs/docs/examples/mloda_basics/create_synthetic_data.py
+++ b/docs/docs/examples/mloda_basics/create_synthetic_data.py
@@ -1,7 +1,7 @@
 import sqlite3
 import numpy as np
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -12,7 +12,7 @@ from mloda.user import DataAccessCollection, Domain, Feature, Options
 
 class MlLifeCycleDataCreator(DataCreator):
     def matches(
-        self, feature_name: str, options: Options, data_access_collection: Optional[DataAccessCollection] = None
+        self, feature_name: str, options: Options, data_access_collection: DataAccessCollection | None = None
     ) -> bool:
         # This match function is only adjusted as it is part of a larger project. Else this DataCreator might be found by other
         # functionalities as well, e.g. in the testing framework. This should not be the case in a normal project.
@@ -25,7 +25,7 @@ class MlLifeCycleDataCreator(DataCreator):
 
 class OrderSyntheticDataSet(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return MlLifeCycleDataCreator({"order_id", "product_id", "quantity", "item_price", "created_at"})
 
     @classmethod
@@ -48,7 +48,7 @@ class OrderSyntheticDataSet(FeatureGroup):
 
 class PaymentSyntheticDataSet(OrderSyntheticDataSet):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return MlLifeCycleDataCreator({"payment_id", "payment_type", "payment_status", "created_at", "valid_datetime"})
 
     @classmethod
@@ -73,7 +73,7 @@ class PaymentSyntheticDataSet(OrderSyntheticDataSet):
 
 class LocationSyntheticDataSet(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return MlLifeCycleDataCreator({"transaction_id", "user_location", "merchant_location", "update_date"})
 
     @classmethod
@@ -96,7 +96,7 @@ class LocationSyntheticDataSet(FeatureGroup):
 
 class CategoricalSyntheticDataSet(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return MlLifeCycleDataCreator({"transaction_id", "user_age_group", "product_category", "transaction_type"})
 
     @classmethod

--- a/docs/docs/examples/sklearn_integration_basic.py
+++ b/docs/docs/examples/sklearn_integration_basic.py
@@ -156,7 +156,7 @@ def _(data_dict, pd):
             return data  # With this, we have access to the before and after state of a feature.
 
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator(
                 {"age", "weight", "state", "gender"}
             )  # If this feature would not load data, we would use the data given from the parameter "data".
@@ -232,7 +232,7 @@ def _(
 
     class SecondSklearnDataCreator(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"age", "weight", "state", "gender"})
 
         @classmethod

--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -36,7 +36,7 @@ from mloda.provider import FeatureGroup, FeatureSet, BaseArtifact, DataCreator, 
 
 class BaseExampleArtifactFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @staticmethod

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -33,7 +33,7 @@ from mloda.provider import BaseInputData, FeatureGroup, FeatureSet
 
 class ReadFileFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadFile()  # BaseInputData implementation
     
     @classmethod
@@ -228,7 +228,7 @@ BaseInputData and MatchData serve **different purposes** and are used in **diffe
 ```py
 class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         # BaseInputData for general data loading
         return ReadFile()
 
@@ -252,7 +252,7 @@ class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
 ```py
 class CsvProcessingFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadFile()  # BaseInputData handles file reading
 ```
 
@@ -264,7 +264,7 @@ class CsvProcessingFeature(FeatureGroup):
 ```py
 class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadFile()  # BaseInputData for data loading
 
     @classmethod
@@ -283,7 +283,7 @@ For database connection patterns, see [Framework Connection Object](framework-co
 ```py
 class SyntheticDataFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"synthetic_data"})  # BaseInputData for data creation
 ```
 

--- a/docs/docs/in_depth/plugin-loader.md
+++ b/docs/docs/in_depth/plugin-loader.md
@@ -40,10 +40,10 @@ PluginLoader.disable_auto_load("feature_group/input_data/read_files")
 PluginLoader.disable_auto_load("compute_framework")
 ```
 
-### `list_loaded_modules(plugin_category: Optional[str])`
+### `list_loaded_modules(plugin_category: str | None)`
 Lists loaded plugin modules, optionally filtered by category.
 
-### `display_plugin_graph(plugin_category: Optional[str])`
+### `display_plugin_graph(plugin_category: str | None)`
 Shows plugin dependencies as a graph.
 
 ## Example

--- a/mloda/core/abstract_plugins/components/base_artifact.py
+++ b/mloda/core/abstract_plugins/components/base_artifact.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, Optional, final
+from typing import Any, final
 
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
@@ -48,7 +48,7 @@ class BaseArtifact(ABC):
 
     @final
     @classmethod
-    def load(cls, features: FeatureSet) -> Optional[Any]:
+    def load(cls, features: FeatureSet) -> Any | None:
         """
         Loads an artifact from the given config of the feature set, when the custom_loader is not overwritten.
         If the custom_loader is overwritten, this method will call the custom_loader and return the result.
@@ -71,7 +71,7 @@ class BaseArtifact(ABC):
         return loaded_artifact
 
     @classmethod
-    def custom_loader(cls, features: FeatureSet) -> Optional[Any]:
+    def custom_loader(cls, features: FeatureSet) -> Any | None:
         """
         In the default case, it loads an artifact from the given config of the features.
 
@@ -113,7 +113,7 @@ class BaseArtifact(ABC):
 
     @final
     @classmethod
-    def save(cls, features: FeatureSet, artifact: Any) -> Optional[Any]:
+    def save(cls, features: FeatureSet, artifact: Any) -> Any | None:
         """
         The default implementation is to return the artifact, as then the framework will handle it.
 
@@ -121,7 +121,7 @@ class BaseArtifact(ABC):
         In that case, the return value would not be the artifact, but any metadata to identify this artifact.
 
         Returns:
-            Optional[Any]: The artifact or metadata identifying the artifact, depending on implementation.
+            Any | None: The artifact or metadata identifying the artifact, depending on implementation.
                            Default behavior is to return the artifact, as then the framework will handle it.
 
         """
@@ -138,7 +138,7 @@ class BaseArtifact(ABC):
         return artifact
 
     @classmethod
-    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Optional[Any]:
+    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Any | None:
         """
         Subclasses can override this method to implement custom saving logic.
 

--- a/mloda/core/abstract_plugins/components/data_types.py
+++ b/mloda/core/abstract_plugins/components/data_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import decimal
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from mloda.core.optional_dependency import loaded, require
 
@@ -116,7 +116,7 @@ class DataType(Enum):
             raise ValueError(f"Unsupported DataType: {data_type}")
 
     @classmethod
-    def _arrow_type_to_dtype_or_none(cls, arrow_type: pa.DataType) -> Optional["DataType"]:
+    def _arrow_type_to_dtype_or_none(cls, arrow_type: pa.DataType) -> DataType | None:
         pa = require("pyarrow", _PYARROW_REASON)
         if pa.types.is_int32(arrow_type):
             return cls.INT32
@@ -163,7 +163,7 @@ class DataType(Enum):
         return result
 
     @classmethod
-    def from_arrow_type_safe(cls, arrow_type: pa.DataType) -> Optional["DataType"]:
+    def from_arrow_type_safe(cls, arrow_type: pa.DataType) -> DataType | None:
         """Non-raising counterpart of from_arrow_type: returns None for unsupported types."""
         return cls._arrow_type_to_dtype_or_none(arrow_type)
 

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import copy
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
 
@@ -56,12 +56,12 @@ class Feature:
     Attributes:
         name (FeatureName): The name of the feature.
         options (Options): The options associated with the feature.
-        domain (Optional[str | Domain]): The domain of the feature.
-        compute_frameworks (Optional[Set[Type[ComputeFramework]]]): The compute frameworks supported by the feature.
-        data_type (Optional[DataType]): The data type of the feature.
+        domain (str | Domain | None): The domain of the feature.
+        compute_frameworks (set[type[ComputeFramework]] | None): The compute frameworks supported by the feature.
+        data_type (DataType | None): The data type of the feature.
         initial_requested_data (bool): Whether the data was initially requested.
-        link (Optional[Link]): The link associated with the feature.
-        index (Optional[Index]): The index associated with the feature.
+        link (Link | None): The link associated with the feature.
+        index (Index | None): The index associated with the feature.
         feature_group_scope (str | type[FeatureGroup] | None): Read by feature resolution and filter
             matching; excluded from identity.
 
@@ -104,13 +104,13 @@ class Feature:
     def __init__(
         self,
         name: str | FeatureName,
-        options: Optional[dict[str, Any] | Options] = None,
-        domain: Optional[str | Domain] = None,
-        compute_framework: Optional[str] = None,
-        data_type: Optional[DataType | str] = None,
+        options: dict[str, Any] | Options | None = None,
+        domain: str | Domain | None = None,
+        compute_framework: str | None = None,
+        data_type: DataType | str | None = None,
         initial_requested_data: bool = False,
-        link: Optional[Link] = None,
-        index: Optional[Index] = None,
+        link: Link | None = None,
+        index: Index | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
         forward_group: frozenset[str] | set[str] | list[str] | tuple[str, ...] | bool | None = None,
         forward_group_exclude: frozenset[str] | set[str] | list[str] | tuple[str, ...] | None = None,
@@ -144,7 +144,7 @@ class Feature:
                 )
 
         # Engine-stamped consumer metadata; in equality/hash via cycle-safe _child_options_key (#608).
-        self.child_options: Optional[Options] = None
+        self.child_options: Options | None = None
 
         self.initial_requested_data = initial_requested_data
 
@@ -216,7 +216,7 @@ class Feature:
     def not_typed(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> Feature:
         if options is None:
@@ -228,7 +228,7 @@ class Feature:
     def str_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> Feature:
         return cls._typed_of(name, DataType.STRING, options, feature_group)
@@ -237,7 +237,7 @@ class Feature:
     def int32_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> Feature:
         return cls._typed_of(name, DataType.INT32, options, feature_group)
@@ -246,7 +246,7 @@ class Feature:
     def int64_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.INT64, options, feature_group)
@@ -255,7 +255,7 @@ class Feature:
     def float_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.FLOAT, options, feature_group)
@@ -264,7 +264,7 @@ class Feature:
     def double_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.DOUBLE, options, feature_group)
@@ -273,7 +273,7 @@ class Feature:
     def boolean_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.BOOLEAN, options, feature_group)
@@ -282,7 +282,7 @@ class Feature:
     def binary_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.BINARY, options, feature_group)
@@ -291,7 +291,7 @@ class Feature:
     def date_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.DATE, options, feature_group)
@@ -300,7 +300,7 @@ class Feature:
     def timestamp_millis_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.TIMESTAMP_MILLIS, options, feature_group)
@@ -309,7 +309,7 @@ class Feature:
     def timestamp_micros_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.TIMESTAMP_MICROS, options, feature_group)
@@ -318,7 +318,7 @@ class Feature:
     def decimal_of(
         cls,
         name: str | FeatureName,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> "Feature":
         return cls._typed_of(name, DataType.DECIMAL, options, feature_group)
@@ -328,7 +328,7 @@ class Feature:
         cls,
         name: str | FeatureName,
         data_type: DataType,
-        options: Optional[dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
     ) -> Feature:
         if options is None:
@@ -484,7 +484,7 @@ class Feature:
         """
         return self._grouping_hash(split_keys, include_data_type=False)
 
-    def _set_domain(self, domain: Optional[str | Domain], domain_options: Optional[str | Domain]) -> None | Domain:
+    def _set_domain(self, domain: str | Domain | None, domain_options: str | Domain | None) -> None | Domain:
         if domain:
             return domain if isinstance(domain, Domain) else Domain(domain)
         elif domain_options:
@@ -492,8 +492,8 @@ class Feature:
         return None
 
     def _set_compute_framework(
-        self, compute_framework: Optional[str], compute_framework_options: Optional[str]
-    ) -> Optional[type[ComputeFramework]]:
+        self, compute_framework: str | None, compute_framework_options: str | None
+    ) -> type[ComputeFramework] | None:
         if compute_framework:
             return FeatureValidator.validate_and_resolve_compute_framework(
                 compute_framework, get_all_subclasses(ComputeFramework), "parameter"

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -447,8 +447,8 @@ class FeatureChainParser:
         cls,
         feature_name: str | FeatureName,
         options: Options,
-        property_mapping: Optional[dict[str, PropertySpec]] = None,
-        prefix_patterns: Optional[list[Any]] = None,
+        property_mapping: dict[str, PropertySpec] | None = None,
+        prefix_patterns: list[Any] | None = None,
         pattern: str = CHAIN_SEPARATOR,
         owner_name: str | None = None,
     ) -> bool:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -57,7 +57,7 @@ import inspect
 import logging
 import os
 from collections.abc import Callable
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -139,7 +139,7 @@ class FeatureChainParserMixin:
 
     IN_FEATURE_SEPARATOR: str = INPUT_SEPARATOR
     MIN_IN_FEATURES: int = 1
-    MAX_IN_FEATURES: Optional[int] = None
+    MAX_IN_FEATURES: int | None = None
     # A recognition-only pattern binds no key from the name; all values come from options (#772).
     RECOGNITION_ONLY_PATTERN: bool = False
     # An all-optional PROPERTY_MAPPING that inherits the config matcher matches any feature name with
@@ -174,7 +174,7 @@ class FeatureChainParserMixin:
         """
         return True
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """
         Parse input features from feature name or options.
 
@@ -587,10 +587,10 @@ class FeatureChainParserMixin:
         return FeatureChainParser.prefix_patterns_of(cls)
 
     @classmethod
-    def _get_property_mapping(cls) -> Optional[dict[str, PropertySpec]]:
+    def _get_property_mapping(cls) -> dict[str, PropertySpec] | None:
         """Get property mapping from class attribute."""
         if hasattr(cls, "PROPERTY_MAPPING"):
-            return cast(Optional[dict[str, PropertySpec]], cls.PROPERTY_MAPPING)
+            return cast(dict[str, PropertySpec] | None, cls.PROPERTY_MAPPING)
         return None
 
     @classmethod
@@ -667,8 +667,8 @@ class FeatureChainParserMixin:
         cls,
         feature_or_name: Any,
         options_or_key: Any,
-        config_key: Optional[str] = None,
-    ) -> Optional[str]:
+        config_key: str | None = None,
+    ) -> str | None:
         """Resolve the operation type from either a chained feature name or options.
 
         Many feature groups need to extract an operation type (e.g. aggregation type,

--- a/mloda/core/abstract_plugins/components/feature_collection.py
+++ b/mloda/core/abstract_plugins/components/feature_collection.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Generator, Optional
+from typing import Generator
 from uuid import UUID
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -20,13 +20,13 @@ class Features:
     def __init__(
         self,
         features: list[Feature | str],
-        child_options: Optional[Options] = None,
-        child_uuid: Optional[UUID] = None,
-        parent_domain: Optional[str] = None,
+        child_options: Options | None = None,
+        child_uuid: UUID | None = None,
+        parent_domain: str | None = None,
     ) -> None:
         self.collection: list[Feature] = []
-        self.child_uuid: Optional[UUID] = child_uuid
-        self.parent_domain: Optional[str] = parent_domain
+        self.child_uuid: UUID | None = child_uuid
+        self.parent_domain: str | None = parent_domain
 
         self.parent_uuids: set[UUID] = set()
 
@@ -37,7 +37,7 @@ class Features:
         self.build_feature_collection(features, child_options, child_uuid)
 
     def build_feature_collection(
-        self, features: list[Feature | str], child_options: Options, child_uuid: Optional[UUID] = None
+        self, features: list[Feature | str], child_options: Options, child_uuid: UUID | None = None
     ) -> None:
         for feature in features:
             if child_options.group == {} and child_options.context == {}:

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -15,16 +15,16 @@ if TYPE_CHECKING:
 
 
 class FeatureSet:
-    def __init__(self, features: Optional[Iterable[Feature]] = None) -> None:
+    def __init__(self, features: Iterable[Feature] | None = None) -> None:
         self.features: set[Feature] = set()
-        self.options: Optional[Options] = None
+        self.options: Options | None = None
         # This is just one uuid for easier access
-        self.any_uuid: Optional[UUID] = None
-        self.filters: Optional[set[SingleFilter]] = None
-        self.name_of_one_feature: Optional[FeatureName] = None
-        self.artifact_to_save: Optional[str] = None
-        self.artifact_to_load: Optional[str] = None
-        self.save_artifact: Optional[Any] = None
+        self.any_uuid: UUID | None = None
+        self.filters: set[SingleFilter] | None = None
+        self.name_of_one_feature: FeatureName | None = None
+        self.artifact_to_save: str | None = None
+        self.artifact_to_load: str | None = None
+        self.save_artifact: Any | None = None
         self.filter_engine: type[BaseFilterEngine] = BaseFilterEngine
         self.mask_engine: type[BaseMaskEngine] | None = None
         self.declared_input_feature_names: frozenset[str] | None = None

--- a/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional, final
+from typing import Any, final
 
 
 class BaseTransformer:
@@ -85,7 +85,7 @@ class BaseTransformer:
     @final
     @classmethod
     def transform(
-        cls, framework: type[Any], other_framework: type[Any], data: Any, framework_connection_object: Optional[Any]
+        cls, framework: type[Any], other_framework: type[Any], data: Any, framework_connection_object: Any | None
     ) -> Any:
         """Transform data from one framework to another."""
 
@@ -168,7 +168,7 @@ class BaseTransformer:
         raise NotImplementedError
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         """
         Transform data from the secondary framework to the primary framework.
 

--- a/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
@@ -1,7 +1,7 @@
 import logging
 import weakref
 from collections import deque
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
@@ -128,7 +128,7 @@ class ComputeFrameworkTransformer:
 
     def get_transformation_chain(
         self, from_framework: type[Any], to_framework: type[Any]
-    ) -> Optional[list[type[BaseTransformer]]]:
+    ) -> list[type[BaseTransformer]] | None:
         """
         Find a transformation chain between two frameworks.
 

--- a/mloda/core/abstract_plugins/components/input_data/api/api_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/api/api_input_data.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.options import Options
@@ -13,7 +12,7 @@ class ApiInputData(BaseInputData):
     """
 
     def matches(
-        self, feature_name: str, options: Options, data_access_collection: Optional[DataAccessCollection] = None
+        self, feature_name: str, options: Options, data_access_collection: DataAccessCollection | None = None
     ) -> bool:
         """
         We match the feature name with the column names given in ApiInputData.

--- a/mloda/core/abstract_plugins/components/input_data/api/api_input_data_collection.py
+++ b/mloda/core/abstract_plugins/components/input_data/api/api_input_data_collection.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
 from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData
 
@@ -11,7 +11,7 @@ class ApiInputDataCollection:
     and retrieval of API input data classes based on their names and associated column names.
     """
 
-    def __init__(self, registry: Optional[dict[str, type[BaseApiData]]] = None) -> None:
+    def __init__(self, registry: dict[str, type[BaseApiData]] | None = None) -> None:
         self._registry: dict[str, type[BaseApiData]] = registry if registry is not None else {}
 
         # Keep track of used key names to avoid misalignment

--- a/mloda/core/abstract_plugins/components/input_data/api/api_input_data_feature.py
+++ b/mloda/core/abstract_plugins/components/input_data/api/api_input_data_feature.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -128,7 +128,7 @@ class ApiInputDataFeature(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ApiInputData()
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/input_data/api/base_api_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/api/base_api_data.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, final
+from typing import Any, final
 from mloda.core.abstract_plugins.components.options import Options
 
 
@@ -18,11 +18,11 @@ class BaseApiData(ABC):
 
     Attributes:
         api_input_name (str): The name identifier for the API input.
-        feature_name (Optional[str]): The name of the feature associated with the API input.
-        options (Optional[Options]): Additional options or configurations for the API input data.
+        feature_name (str | None): The name of the feature associated with the API input.
+        options (Options | None): Additional options or configurations for the API input data.
     """
 
-    def __init__(self, api_input_name: str, feature_name: Optional[str], options: Optional[Options]) -> None:
+    def __init__(self, api_input_name: str, feature_name: str | None, options: Options | None) -> None:
         self.api_input_name = api_input_name
 
     def get_data_by_using_api_data(self, api_data: Any) -> Any:

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.property_spec import PropertySpec, is_no_default
@@ -123,7 +123,7 @@ class BaseInputData(ABC):
         return spec.default
 
     @classmethod
-    def reader_option(cls, key: str, options: Optional[Options]) -> Any:
+    def reader_option(cls, key: str, options: Options | None) -> Any:
         """The supplied value of key when present, else the declared default; NO_DEFAULT raises.
         allow_explicit_none=True reads presence as ``key in options``; options=None reads all-absent."""
         spec = cls._declared_reader_option_spec(key)
@@ -137,7 +137,7 @@ class BaseInputData(ABC):
         return spec.default
 
     @classmethod
-    def _reader_options_admit(cls, options: Optional[Options], record_absence: bool) -> bool:
+    def _reader_options_admit(cls, options: Options | None, record_absence: bool) -> bool:
         """Check this candidate's merged declarations BEFORE its probe runs; a veto is its own non-match.
         record_absence doubles as the ownership signal: it gates absence recordings and stages present-value ones."""
         for key, spec in merged_declaration(cls, DeclarationSurface.READER).items():
@@ -159,7 +159,7 @@ class BaseInputData(ABC):
 
     @classmethod
     def _absent_reader_option_admits(
-        cls, key: str, spec: PropertySpec, options: Optional[Options], record_absence: bool
+        cls, key: str, spec: PropertySpec, options: Options | None, record_absence: bool
     ) -> bool:
         """Requiredness of an ABSENT key: required_when decides when declared, else NO_DEFAULT rejects.
         record_absence says whether the veto is recorded."""
@@ -268,7 +268,7 @@ class BaseInputData(ABC):
         self,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         """
         We look if feature scope data access or global scope access is set.
@@ -326,7 +326,7 @@ class BaseInputData(ABC):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection],
+        data_access_collection: DataAccessCollection | None,
     ) -> bool:
         if data_access_collection is None:
             return False
@@ -348,7 +348,7 @@ class BaseInputData(ABC):
         cls,
         feature_names: list[str],
         data_access_collection: DataAccessCollection,
-        options: Optional[Options] = None,
+        options: Options | None = None,
     ) -> tuple[Any, Any]:
         """
         We check for data access collection if any child classes match the data access.
@@ -396,7 +396,7 @@ class BaseInputData(ABC):
             )
         options.add_to_group(RESERVED_READER_OPTION_KEY, (cls_to_be_added, matched_data_access))
 
-    def init_reader(self, options: Optional[Options]) -> tuple["BaseInputData", Any]:
+    def init_reader(self, options: Options | None) -> tuple["BaseInputData", Any]:
         if options is None:
             raise ValueError(
                 f"Options were not set for {self.__class__.__name__}.init_reader().\n"
@@ -554,7 +554,7 @@ class BaseInputData(ABC):
         return path.endswith(cls.suffix())  # type: ignore[attr-defined]
 
     @classmethod
-    def _resolve_pinned_file(cls, data_access: Any, feature_names: list[str]) -> Optional[str]:
+    def _resolve_pinned_file(cls, data_access: Any, feature_names: list[str]) -> str | None:
         column_map: dict[str, str] = data_access.column_to_file
         files_registry: dict[str, str] = data_access.files
         pinned_handles: set[str] = {column_map[name] for name in feature_names if name in column_map}

--- a/mloda/core/abstract_plugins/components/input_data/creator/data_creator.py
+++ b/mloda/core/abstract_plugins/components/input_data/creator/data_creator.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.options import Options
@@ -19,7 +18,7 @@ class DataCreator(BaseInputData):
         self.feature_names = supports_features
 
     def matches(
-        self, feature_name: str, options: Options, data_access_collection: Optional[DataAccessCollection] = None
+        self, feature_name: str, options: Options, data_access_collection: DataAccessCollection | None = None
     ) -> bool:
         """
         This function can be overwritten to support more complex matching.

--- a/mloda/core/abstract_plugins/components/link.py
+++ b/mloda/core/abstract_plugins/components/link.py
@@ -4,7 +4,7 @@ from dataclasses import FrozenInstanceError, dataclass
 from datetime import timedelta
 from enum import Enum
 from uuid import uuid4
-from typing import Any, ClassVar, Literal, Optional
+from typing import Any, ClassVar, Literal
 
 
 from mloda.core.abstract_plugins.components.hashable_dict import _deep_hashable
@@ -248,9 +248,9 @@ class Link:
         jointype: JoinType | str,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
-        asof_config: Optional[AsOfJoinConfig] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
+        asof_config: AsOfJoinConfig | None = None,
     ) -> None:
         self.jointype = JoinType(jointype) if isinstance(jointype, str) else jointype
         self.left_feature_group = left.feature_group
@@ -272,8 +272,8 @@ class Link:
         jointype: JoinType,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]],
-        right_discriminator: Optional[dict[str, Any]],
+        left_discriminator: dict[str, Any] | None,
+        right_discriminator: dict[str, Any] | None,
     ) -> "Link":
         return cls(
             jointype, left, right, left_discriminator=left_discriminator, right_discriminator=right_discriminator
@@ -287,8 +287,8 @@ class Link:
         right: type[Any],
         left_index: int,
         right_index: int,
-        left_discriminator: Optional[dict[str, Any]],
-        right_discriminator: Optional[dict[str, Any]],
+        left_discriminator: dict[str, Any] | None,
+        right_discriminator: dict[str, Any] | None,
     ) -> "Link":
         left_idx = _get_index_from_feature_group(left, left_index, "left")
         right_idx = _get_index_from_feature_group(right, right_index, "right")
@@ -305,8 +305,8 @@ class Link:
         cls,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         return cls._from_specs(JoinType.INNER, left, right, left_discriminator, right_discriminator)
 
@@ -315,8 +315,8 @@ class Link:
         cls,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         return cls._from_specs(JoinType.LEFT, left, right, left_discriminator, right_discriminator)
 
@@ -325,8 +325,8 @@ class Link:
         cls,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         return cls._from_specs(JoinType.RIGHT, left, right, left_discriminator, right_discriminator)
 
@@ -335,8 +335,8 @@ class Link:
         cls,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         return cls._from_specs(JoinType.OUTER, left, right, left_discriminator, right_discriminator)
 
@@ -345,8 +345,8 @@ class Link:
         cls,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         return cls._from_specs(JoinType.APPEND, left, right, left_discriminator, right_discriminator)
 
@@ -355,8 +355,8 @@ class Link:
         cls,
         left: JoinSpec,
         right: JoinSpec,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         return cls._from_specs(JoinType.UNION, left, right, left_discriminator, right_discriminator)
 
@@ -367,8 +367,8 @@ class Link:
         right: type[Any],
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create INNER join using feature groups' index_columns()."""
         return cls._from_feature_groups(
@@ -422,8 +422,8 @@ class Link:
         right: type[Any],
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create LEFT join using feature groups' index_columns()."""
         return cls._from_feature_groups(
@@ -437,8 +437,8 @@ class Link:
         right: type[Any],
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create RIGHT join using feature groups' index_columns()."""
         return cls._from_feature_groups(
@@ -452,8 +452,8 @@ class Link:
         right: type[Any],
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create OUTER join using feature groups' index_columns()."""
         return cls._from_feature_groups(
@@ -467,8 +467,8 @@ class Link:
         right: type[Any],
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create APPEND join using feature groups' index_columns()."""
         return cls._from_feature_groups(
@@ -482,8 +482,8 @@ class Link:
         right: type[Any],
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create UNION join using feature groups' index_columns()."""
         return cls._from_feature_groups(
@@ -502,8 +502,8 @@ class Link:
         tolerance: float | int | timedelta | None = None,
         allow_exact_matches: bool = True,
         coerce_time_columns: bool = False,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create an ASOF (point-in-time) join from explicit JoinSpecs."""
         config = AsOfJoinConfig(
@@ -537,8 +537,8 @@ class Link:
         coerce_time_columns: bool = False,
         left_index: int = 0,
         right_index: int = 0,
-        left_discriminator: Optional[dict[str, Any]] = None,
-        right_discriminator: Optional[dict[str, Any]] = None,
+        left_discriminator: dict[str, Any] | None = None,
+        right_discriminator: dict[str, Any] | None = None,
     ) -> "Link":
         """Create an ASOF join, deriving the by-key Index from index_columns()."""
         left_idx = _get_index_from_feature_group(left, left_index, "left")

--- a/mloda/core/abstract_plugins/components/match_data/match_data.py
+++ b/mloda/core/abstract_plugins/components/match_data/match_data.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.options import Options
@@ -16,7 +16,7 @@ class MatchData:
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         """
         We look if feature scope data access or global scope access is set.
@@ -54,7 +54,7 @@ class MatchData:
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection],
+        data_access_collection: DataAccessCollection | None,
     ) -> bool:
         """
         We check for global scope data access if any data access collection matches the framework connection and matching logic."""
@@ -75,8 +75,8 @@ class MatchData:
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         """
         We check for data access collection if any child classes match the data access.

--- a/mloda/core/abstract_plugins/components/match_hook.py
+++ b/mloda/core/abstract_plugins/components/match_hook.py
@@ -8,7 +8,7 @@ Each keeps only its own recording and rollback now, driven by the outcome this h
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
@@ -31,14 +31,14 @@ class MatchHookOutcome:
 
     matched: bool
     returned: Any
-    error: Optional[Exception]
+    error: Exception | None
 
 
 def call_match_hook(
     feature_group: type[FeatureGroup],
     feature_name: FeatureName | str,
     options: Options,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> MatchHookOutcome:
     """Ask one candidate's match hook: a raise out of it is a non-match for that candidate only (#845).
 
@@ -70,16 +70,16 @@ class CriteriaProbeOutcome:
     matched: bool
     returned: Any
     # Disjoint: the one contained raise is a typed decline (value_rejection) or the candidate's own defect.
-    matcher_error: Optional[Exception]
-    value_rejection: Optional[PropertyValueRejection]
-    rejection: Optional[MatchRejection]
+    matcher_error: Exception | None
+    value_rejection: PropertyValueRejection | None
+    rejection: MatchRejection | None
 
 
 def probe_match_criteria(
     feature_group: type[FeatureGroup],
     feature_name: FeatureName | str,
     options: Options,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> CriteriaProbeOutcome:
     """Ask one candidate under its own rejection window; a marked abort propagates, the finally only resets."""
     token = MATCH_REJECTION_REASONS.set({})

--- a/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
+++ b/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, Optional, final
+from typing import Any, final
 
 from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics, ComparisonContract
 from mloda.core.abstract_plugins.components.index.index import Index
@@ -17,7 +17,7 @@ class BaseMergeEngine(ABC):
 
     provides_column_semantics: bool = False
 
-    def __init__(self, framework_connection: Optional[Any] = None) -> None:
+    def __init__(self, framework_connection: Any | None = None) -> None:
         """
         Initialize the merge engine.
 

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING, cast
+from typing import Any, TYPE_CHECKING, cast
 from copy import deepcopy
 
 from mloda.core.abstract_plugins.components.hashable_dict import _deep_equal, _deep_hashable, register_deep_node
@@ -149,8 +149,8 @@ class Options:
 
     def __init__(
         self,
-        group: Optional[dict[str, Any]] = None,
-        context: Optional[dict[str, Any]] = None,
+        group: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
         propagate_context_keys: frozenset[str] | None = None,
     ) -> None:
         self.group = _normalize_reader_class_keys(group) if group else {}

--- a/mloda/core/abstract_plugins/components/validators/datatype_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/datatype_validator.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -60,7 +60,7 @@ class DataTypeValidator:
     def validate(
         cls,
         features: Any,
-        get_column_data_type: Callable[[str], Optional[DataType]],
+        get_column_data_type: Callable[[str], DataType | None],
     ) -> None:
         """Validate that data columns match declared feature types.
 

--- a/mloda/core/abstract_plugins/components/validators/feature_set_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/feature_set_validator.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mloda.core.abstract_plugins.components.feature import Feature
@@ -23,7 +23,7 @@ class FeatureSetValidator:
                 raise ValueError("Features have different options")
 
     @staticmethod
-    def validate_feature_added(feature_name: Optional[str], context: str = "feature") -> None:
+    def validate_feature_added(feature_name: str | None, context: str = "feature") -> None:
         if feature_name is None:
             raise ValueError(f"Feature name is None in {context}")
 

--- a/mloda/core/abstract_plugins/components/validators/feature_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/feature_validator.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 
 
@@ -14,7 +13,7 @@ class FeatureValidator:
 
     @staticmethod
     def validate_compute_frameworks_resolved(
-        compute_frameworks: Optional[set[type[ComputeFramework]]], feature_name: str
+        compute_frameworks: set[type[ComputeFramework]] | None, feature_name: str
     ) -> None:
         if not compute_frameworks:
             raise ValueError(

--- a/mloda/core/abstract_plugins/components/validators/link_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/link_validator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mloda.core.abstract_plugins.components.link import Link
@@ -67,7 +67,7 @@ class LinkValidator:
                         )
 
     @classmethod
-    def validate_links(cls, links: Optional[set["Link"]]) -> None:
+    def validate_links(cls, links: set["Link"] | None) -> None:
         if links is None:
             return
 

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -2,7 +2,7 @@ import contextlib
 from abc import ABC
 from collections.abc import Callable, Generator, Iterable, Sequence
 from contextvars import ContextVar
-from typing import Any, Optional, final
+from typing import Any, final
 from uuid import UUID, uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
@@ -87,8 +87,8 @@ class ComputeFramework(ABC):
         self,
         mode: ParallelizationMode = ParallelizationMode.SYNC,
         children_if_root: frozenset[UUID] = frozenset(),
-        uuid: Optional[UUID] = None,
-        function_extender: Optional[set[Extender]] = None,
+        uuid: UUID | None = None,
+        function_extender: set[Extender] | None = None,
     ) -> None:
         """This class is initialized for step execution."""
         self.mode = mode
@@ -110,7 +110,7 @@ class ComputeFramework(ABC):
         self.object_ids: list[str] = []
 
         # connection object for frameworks that need persistent connections (e.g., DuckDB, Spark)
-        self.framework_connection_object: Optional[Any] = None
+        self.framework_connection_object: Any | None = None
 
     @classmethod
     def expected_data_framework(cls) -> Any:
@@ -208,8 +208,8 @@ class ComputeFramework(ABC):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         """
         If you only want to store the requested features, implement this functionality depending on your framework.
@@ -231,7 +231,7 @@ class ComputeFramework(ABC):
         """
         raise NotImplementedError(f"Merge functionality is for this compute framework not implemented {cls.__name__}.")
 
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         """
         Some compute frameworks (e.g., DuckDB, Spark) require sharing their connection
         with merge engines to ensure data consistency. Override this method in
@@ -249,7 +249,7 @@ class ComputeFramework(ABC):
         return False
 
     @classmethod
-    def pick_connection_from_dac(cls, data_access_collection: Any, options: Optional[Any] = None) -> Optional[Any]:
+    def pick_connection_from_dac(cls, data_access_collection: Any, options: Any | None = None) -> Any | None:
         """Pick the matching connection for this framework from the DataAccessCollection.
 
         Called at Engine setup (once per session), not on the per-request run path.
@@ -294,8 +294,8 @@ class ComputeFramework(ABC):
 
     @final
     def run_calculation(
-        self, feature_group: Any, features: Any, location: str | None, data: Optional[Any] = None
-    ) -> Optional[Any]:
+        self, feature_group: Any, features: Any, location: str | None, data: Any | None = None
+    ) -> Any | None:
         # case multiprocessing or case base api input feature
         if data is not None:
             self.data = data
@@ -534,7 +534,7 @@ class ComputeFramework(ABC):
         """
         return False
 
-    def _extract_column_dtype(self, data: Any, column_name: str) -> Optional[str]:
+    def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
         """Extract the dtype of a specific column as a human-readable string.
 
         Returns None when the framework does not support dtype extraction.
@@ -542,7 +542,7 @@ class ComputeFramework(ABC):
         """
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         """Resolve a column's native dtype to the unified DataType enum.
 
         Default: return None. Frameworks must override to convert their native
@@ -730,7 +730,7 @@ class ComputeFramework(ABC):
     def __hash__(self) -> int:
         return hash((id(type(self)), self.children_if_root))
 
-    def validate_expected_framework(self, location: Optional[str] = None) -> None:
+    def validate_expected_framework(self, location: str | None = None) -> None:
         """
         Validates that the data is in the expected framework.
         Only touch this if your framework supports multiple data frameworks.
@@ -757,7 +757,7 @@ class ComputeFramework(ABC):
 
     @final
     def add_already_calculated_children_and_drop_if_possible(
-        self, children: set[UUID], location: Optional[str] = None
+        self, children: set[UUID], location: str | None = None
     ) -> bool | frozenset[UUID]:
         self.already_calculated_children_tracker.update(children)
 
@@ -771,7 +771,7 @@ class ComputeFramework(ABC):
         return False
 
     @final
-    def get_function_extender(self, wrapper_function_enum: ExtenderHook) -> Optional[Extender]:
+    def get_function_extender(self, wrapper_function_enum: ExtenderHook) -> Extender | None:
         matching_extenders = []
         for extender in self.function_extender:
             if wrapper_function_enum in extender.wraps():
@@ -938,7 +938,7 @@ Available join types:
         return self.upload_table(location, self.uuid)
 
     @final
-    def upload_table(self, location: str, object_id: Optional[UUID] = None) -> str:
+    def upload_table(self, location: str, object_id: UUID | None = None) -> str:
         pa = require("pyarrow", _PYARROW_REASON)
         if object_id is None:
             object_id = uuid4()
@@ -986,7 +986,7 @@ Available join types:
         FlightServer.drop_tables(location, table_keys)
 
     @final
-    def drop_last_data(self, location: Optional[str] = None) -> None:
+    def drop_last_data(self, location: str | None = None) -> None:
         if isinstance(self.data, str) and location:
             self.drop_data({self.data}, location)
 
@@ -1003,8 +1003,8 @@ Available join types:
         self,
         selected_feature_names: Sequence[FeatureName],
         column_names: set[str],
-        ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> set[str] | list[str]:
         """
         Identifies columns that match feature names or follow the naming convention pattern.

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import logging
 from collections.abc import Collection, Mapping
-from typing import Any, ClassVar, Callable, Optional, final
+from typing import Any, ClassVar, Callable, final
 from abc import ABC
 
 from mloda.core.abstract_plugins.components.base_artifact import BaseArtifact
@@ -88,7 +88,7 @@ class FeatureGroup(ABC):
     for the full PROPERTY_MAPPING reference.
     """
 
-    PROPERTY_MAPPING: ClassVar[Optional[dict[str, PropertySpec]]] = None
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec] | None] = None
     """Override in subclasses to declare configurable parameters.
 
     Each key is a parameter name. Each value is a ``PropertySpec`` carrying the
@@ -97,7 +97,7 @@ class FeatureGroup(ABC):
     ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 
-    SUBTYPES: ClassVar[Optional[SubtypeDeclaration]] = None
+    SUBTYPES: ClassVar[SubtypeDeclaration | None] = None
     """Declarative subtype dimension of the family; ``None`` means no subtype dimension.
     The derived accessors below are ``@final`` (type-checker enforced) and derived from SUBTYPES."""
 
@@ -206,7 +206,7 @@ class FeatureGroup(ABC):
 
     @final
     @classmethod
-    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> str | None:
         """Resolve the raw subtype of a concrete feature: name parsing first, then options; never raises."""
         declaration = cls.SUBTYPES
         if declaration is None:
@@ -373,7 +373,7 @@ class FeatureGroup(ABC):
         return BaseFeatureGroupVersion.version(cls)
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         """
         This function should return the input data class used for this feature group.
         """
@@ -458,7 +458,7 @@ class FeatureGroup(ABC):
 
     @staticmethod
     def apply_naming_convention(
-        result: Any, feature_name: str, suffix_generator: Optional[Callable[[int], str]] = None
+        result: Any, feature_name: str, suffix_generator: Callable[[int], str] | None = None
     ) -> dict[str, Any]:
         """
         Applies naming convention to multi-column results.
@@ -513,7 +513,7 @@ class FeatureGroup(ABC):
         return [feature_name]
 
     @classmethod
-    def return_data_type_rule(cls, feature: Feature) -> Optional[DataType]:
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
         """
         Specifies a fixed return data type for this feature group, if applicable.
 
@@ -523,7 +523,7 @@ class FeatureGroup(ABC):
         """
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """
         Defines the input features required by this feature group.
 
@@ -537,7 +537,7 @@ class FeatureGroup(ABC):
         raise NotImplementedError
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         """
         Specifies the index columns used for merging or joining data.
 
@@ -551,7 +551,7 @@ class FeatureGroup(ABC):
         return None
 
     @classmethod
-    def supports_index(cls, index: Index) -> Optional[bool]:
+    def supports_index(cls, index: Index) -> bool | None:
         """
         Check if this feature group supports the given index.
 
@@ -579,7 +579,7 @@ class FeatureGroup(ABC):
 
     @classmethod
     def _matches_input_data(
-        cls, feature_name: str, options: Options, data_access_collection: Optional[DataAccessCollection]
+        cls, feature_name: str, options: Options, data_access_collection: DataAccessCollection | None
     ) -> bool:
         """
         Helper function to check if the input data matches.
@@ -602,7 +602,7 @@ class FeatureGroup(ABC):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         """
         Determines whether this feature group matches the given criteria.
@@ -841,7 +841,7 @@ class FeatureGroup(ABC):
 
     @classmethod
     def _is_root_and_matches_input_data(
-        cls, feature_name: str, options: Options, data_access_collection: Optional[DataAccessCollection]
+        cls, feature_name: str, options: Options, data_access_collection: DataAccessCollection | None
     ) -> bool:
         """
         Checks if the feature group is a root and matches input data.
@@ -857,7 +857,7 @@ class FeatureGroup(ABC):
     @final
     @classmethod
     def _matches_data(
-        cls, feature_name: str, options: Options, data_access_collection: Optional[DataAccessCollection]
+        cls, feature_name: str, options: Options, data_access_collection: DataAccessCollection | None
     ) -> bool:
         """
         This functionality is for matching data, when a data access is necessary.

--- a/mloda/core/abstract_plugins/function_extender.py
+++ b/mloda/core/abstract_plugins/function_extender.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 import functools
 import inspect
 import logging
@@ -124,7 +124,7 @@ class Extender(ABC):
         return feature_set.options
 
 
-def get_function_extender(function_extender: set[Extender], hook: ExtenderHook) -> Optional[Extender]:
+def get_function_extender(function_extender: set[Extender], hook: ExtenderHook) -> Extender | None:
     """Select the Extender(s) wrapping hook: None, the sole match, or a priority-sorted CompositeExtender."""
     matching_extenders = [ext for ext in function_extender if hook in ext.wraps()]
     if len(matching_extenders) == 0:
@@ -141,7 +141,7 @@ class CompositeExtender(Extender):
     Constructed internally by get_function_extender(); not meant to be subclassed or instantiated directly.
     """
 
-    def __init__(self, extenders: list[Extender], function_type: Optional[ExtenderHook] = None):
+    def __init__(self, extenders: list[Extender], function_type: ExtenderHook | None = None):
         self.extenders = sorted(extenders, key=lambda e: e.priority)
         self.function_type = function_type
 

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import logging
 from types import ModuleType
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -64,7 +64,7 @@ CORE_PLUGIN_MODULES: tuple[str, ...] = ("mloda.core.abstract_plugins.components.
 
 class PluginLoader:
     _disabled_groups: ClassVar[set[str]] = set()
-    _cached_loader: ClassVar[Optional["PluginLoader"]] = None
+    _cached_loader: ClassVar["PluginLoader | None"] = None
     _cached_generation: ClassVar[int | None] = None
     _building_thread_id: ClassVar[int | None] = None
     _cache_lock: ClassVar[threading.Lock] = threading.Lock()
@@ -344,7 +344,7 @@ class PluginLoader:
         package_path = Path(base_package).parent
         return package_path / group_name
 
-    def display_plugin_graph(self, plugin_category: Optional[str] = None) -> list[str]:
+    def display_plugin_graph(self, plugin_category: str | None = None) -> list[str]:
         """Display the plugin graph."""
 
         _list_plugins_dependencies: list[str] = []
@@ -360,7 +360,7 @@ class PluginLoader:
             raise ValueError(f"No plugins found for category {plugin_category}")
         return _list_plugins_dependencies
 
-    def list_loaded_modules(self, plugin_category: Optional[str] = None) -> list[str]:
+    def list_loaded_modules(self, plugin_category: str | None = None) -> list[str]:
         """List all loaded modules (plugins)."""
 
         _list_plugins_dependencies: list[str] = []

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -6,10 +6,10 @@ feature configuration files.
 """
 
 from dataclasses import dataclass, field, fields
-from typing import Any, Optional
+from typing import Any
 
 
-def validate_feature_group_scope(value: Any) -> Optional[str]:
+def validate_feature_group_scope(value: Any) -> str | None:
     """Config scope is a non-empty class-name string; the class-object form is Python-only."""
     # Local import: feature_group pulls in the plugin machinery, which this data-model module stays free of.
     from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
@@ -34,7 +34,7 @@ def validate_feature_group_scope(value: Any) -> Optional[str]:
     return value
 
 
-def validate_feature_group_not_in_options(options: Optional[dict[str, Any]], container_name: str) -> None:
+def validate_feature_group_not_in_options(options: dict[str, Any] | None, container_name: str) -> None:
     """Scope is a config field, not an option: a top-level 'feature_group' key in a container is a misplacement."""
     if options and "feature_group" in options:
         raise ValueError(
@@ -51,12 +51,12 @@ class FeatureConfig:
     name: str = field(metadata={"nested": True})
     options: dict[str, Any] = field(default_factory=dict, metadata={"nested": True})
     # A nested in_features dict reuses this field for a single source name or a further nested feature dict.
-    in_features: Optional[list[str] | dict[str, Any] | str] = field(default=None, metadata={"nested": True})
-    group_options: Optional[dict[str, Any]] = None
-    context_options: Optional[dict[str, Any]] = None
-    propagate_context_keys: Optional[list[str]] = None
-    column_index: Optional[int] = None
-    feature_group: Optional[str] = field(default=None, metadata={"nested": True})
+    in_features: list[str] | dict[str, Any] | str | None = field(default=None, metadata={"nested": True})
+    group_options: dict[str, Any] | None = None
+    context_options: dict[str, Any] | None = None
+    propagate_context_keys: list[str] | None = None
+    column_index: int | None = None
+    feature_group: str | None = field(default=None, metadata={"nested": True})
 
     def __post_init__(self) -> None:
         """Validate the invariants shared by the top-level and the nested feature dict."""

--- a/mloda/core/api/plan_info.py
+++ b/mloda/core/api/plan_info.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Literal, Optional, TYPE_CHECKING
+from typing import Literal, TYPE_CHECKING
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
@@ -54,37 +54,37 @@ class PlanStep:
 
     step_kind: Literal["compute", "join", "transform"]
     feature_names: tuple[str, ...]
-    feature_group: Optional[type["FeatureGroup"]]
-    compute_framework: Optional[type["ComputeFramework"]]
-    source_feature_group: Optional[type["FeatureGroup"]]
-    source_compute_framework: Optional[type["ComputeFramework"]]
-    join_type: Optional[str] = None
+    feature_group: type["FeatureGroup"] | None
+    compute_framework: type["ComputeFramework"] | None
+    source_feature_group: type["FeatureGroup"] | None
+    source_compute_framework: type["ComputeFramework"] | None
+    join_type: str | None = None
     requested_feature_names: tuple[str, ...] = ()
     injected_feature_names: tuple[str, ...] = ()
     input_feature_names: tuple[str, ...] = ()
-    join_destination_side: Optional[Literal["left", "right"]] = None
-    join_token: Optional[UUID] = field(default=None, compare=False)
+    join_destination_side: Literal["left", "right"] | None = None
+    join_token: UUID | None = field(default=None, compare=False)
     declared_left_frameworks: tuple[type["ComputeFramework"], ...] = ()
     declared_right_frameworks: tuple[type["ComputeFramework"], ...] = ()
 
     @property
-    def feature_group_name(self) -> Optional[str]:
+    def feature_group_name(self) -> str | None:
         return None if self.feature_group is None else self.feature_group.get_class_name()
 
     @property
-    def compute_framework_name(self) -> Optional[str]:
+    def compute_framework_name(self) -> str | None:
         return None if self.compute_framework is None else self.compute_framework.get_class_name()
 
     @property
-    def source_feature_group_name(self) -> Optional[str]:
+    def source_feature_group_name(self) -> str | None:
         return None if self.source_feature_group is None else self.source_feature_group.get_class_name()
 
     @property
-    def source_compute_framework_name(self) -> Optional[str]:
+    def source_compute_framework_name(self) -> str | None:
         return None if self.source_compute_framework is None else self.source_compute_framework.get_class_name()
 
     @property
-    def join_inverted(self) -> Optional[bool]:
+    def join_inverted(self) -> bool | None:
         return None if self.join_destination_side is None else self.join_destination_side == "right"
 
     @property
@@ -98,7 +98,7 @@ class PlanStep:
 
 def build_plan_steps(
     execution_plan: Iterable[TransformFrameworkStep | JoinStep | FeatureGroupStep],
-    resolved_join_plan: Optional["ResolvedJoinPlan"] = None,
+    resolved_join_plan: "ResolvedJoinPlan | None" = None,
 ) -> list[PlanStep]:
     """Map the steps of an ExecutionPlan onto PlanStep records, in execution-plan order.
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -15,7 +15,7 @@ Example:
     docs = get_feature_group_docs()
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import SOURCE_INTROSPECTION_ERRORS
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
@@ -67,7 +67,7 @@ def _safe_version(fg_class: type[FeatureGroup]) -> str:
     )
 
 
-def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
+def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], str | None]:
     """Return the sorted subtype support matrix, degrading a raising class to ({}, message)."""
     empty: dict[str, frozenset[str]] = {}
     matrix, error = safe_field_with_error(lambda: fg_class.subtype_support_matrix(), empty)
@@ -78,9 +78,9 @@ def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, l
 
 def _resolved_subtype_fields(
     fg_class: type[FeatureGroup], feature_name: FeatureName, options: Options
-) -> tuple[Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None]:
     """Resolve (subtype, subtype_family) for a candidate, degrading a raising declaration to (None, None)."""
-    subtype: Optional[str] = safe_field(lambda: fg_class.resolve_subtype(feature_name, options), None)
+    subtype: str | None = safe_field(lambda: fg_class.resolve_subtype(feature_name, options), None)
     if subtype is None:
         return None, None
     raw_subtype = subtype
@@ -101,11 +101,11 @@ def _dedup_degrading_on_conflict(
 
 
 def get_feature_group_docs(
-    name: Optional[str] = None,
-    search: Optional[str] = None,
-    compute_framework: Optional[str | type[ComputeFramework]] = None,
-    version_contains: Optional[str] = None,
-    plugin_collector: Optional[PluginCollector] = None,
+    name: str | None = None,
+    search: str | None = None,
+    compute_framework: str | type[ComputeFramework] | None = None,
+    version_contains: str | None = None,
+    plugin_collector: PluginCollector | None = None,
     registered_only: bool = False,
 ) -> list[FeatureGroupInfo]:
     """
@@ -176,7 +176,7 @@ def get_feature_group_docs(
         if version_contains is not None and version_contains not in version:
             continue
 
-        declaration: Optional[SubtypeDeclaration] = safe_field(
+        declaration: SubtypeDeclaration | None = safe_field(
             lambda: fg_class.SUBTYPES, None, field=f"{cls_name}.SUBTYPES"
         )
         subtype_key = declaration.key if declaration is not None else None
@@ -207,8 +207,8 @@ def get_feature_group_docs(
 
 
 def get_compute_framework_docs(
-    name: Optional[str] = None,
-    search: Optional[str] = None,
+    name: str | None = None,
+    search: str | None = None,
     available_only: bool = False,
     registered_only: bool = False,
 ) -> list[ComputeFrameworkInfo]:
@@ -272,9 +272,9 @@ def get_compute_framework_docs(
 
 
 def get_extender_docs(
-    name: Optional[str] = None,
-    search: Optional[str] = None,
-    wraps: Optional[str] = None,
+    name: str | None = None,
+    search: str | None = None,
+    wraps: str | None = None,
     registered_only: bool = False,
 ) -> list[ExtenderInfo]:
     """
@@ -337,12 +337,12 @@ def get_extender_docs(
 def resolve_feature(
     feature: str | Feature,
     *,
-    options: Optional[Options] = None,
-    plugin_collector: Optional[PluginCollector] = None,
+    options: Options | None = None,
+    plugin_collector: PluginCollector | None = None,
     feature_group: str | type[FeatureGroup] | None = None,
-    links: Optional[set[Link]] = None,
-    data_access_collection: Optional[DataAccessCollection] = None,
-    compute_frameworks: Optional[set[type[ComputeFramework]]] = None,
+    links: set[Link] | None = None,
+    data_access_collection: DataAccessCollection | None = None,
+    compute_frameworks: set[type[ComputeFramework]] | None = None,
 ) -> ResolvedFeature:
     """
     Resolve a feature name (or a Feature object) to its matching FeatureGroup class.
@@ -388,7 +388,7 @@ def resolve_feature(
                 "resolve_feature(Feature(...)) is the single source of truth for name, options and scope; "
                 "set them on the Feature, do not also pass 'options' or 'feature_group'"
             )
-        feature_obj: Optional[Feature] = feature
+        feature_obj: Feature | None = feature
         feature_name = str(feature.name)
         scope = feature.feature_group_scope
         resolved_options = feature.options

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -15,7 +15,7 @@ class FeatureGroupInfo:
     supported_feature_names: set[str]
     prefix: str
     # Subtype discriminator option key of the family (SUBTYPES.key), None for shape B and undeclared families.
-    subtype_key: Optional[str] = None
+    subtype_key: str | None = None
     # Sorted subtype universe: declared subtype values plus parametric family names.
     subtypes: list[str] = field(default_factory=list)
     # Sorted parametric subtype family names (e.g. "ntile" covering "ntile_2").
@@ -23,7 +23,7 @@ class FeatureGroupInfo:
     # Sorted supported subtypes per framework from compute_framework_definition(); empty for abstract classes.
     subtype_support: dict[str, list[str]] = field(default_factory=dict)
     # Message when the capability declaration is invalid, None for a legitimately empty matrix.
-    subtype_error: Optional[str] = None
+    subtype_error: str | None = None
 
 
 @dataclass
@@ -48,14 +48,14 @@ class ExtenderInfo:
 @dataclass
 class ResolvedFeature:
     feature_name: str
-    feature_group: Optional[type["FeatureGroup"]]
+    feature_group: type["FeatureGroup"] | None
     candidates: list[type["FeatureGroup"]]
-    error: Optional[str]
+    error: str | None
     # Frameworks supporting the feature, evaluated under the options passed to resolve_feature (empty by default).
     supported_compute_frameworks: list[str] = field(default_factory=list)
     # Frameworks rejecting the feature, evaluated under the options passed to resolve_feature (empty by default).
     unsupported_compute_frameworks: list[str] = field(default_factory=list)
     # Resolved subtype of the feature under the passed options, None when none resolves.
-    subtype: Optional[str] = None
+    subtype: str | None = None
     # Family name only when the subtype is a parametric instance (e.g. "ntile" for "ntile_2"), else None.
-    subtype_family: Optional[str] = None
+    subtype_family: str | None = None

--- a/mloda/core/api/prepare/setup_compute_framework.py
+++ b/mloda/core/api/prepare/setup_compute_framework.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.feature_collection import Features
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
@@ -10,9 +10,9 @@ class SetupComputeFramework:
 
     def __init__(
         self,
-        user_compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]],
+        user_compute_frameworks: set[type[ComputeFramework]] | list[str] | None,
         features: Features,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
     ) -> None:
         available_compute_frameworks = get_all_subclasses(ComputeFramework)
 

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from dataclasses import replace
-from typing import Any, Callable, Generator, Optional
+from typing import Any, Callable, Generator
 
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collection import (
     ApiInputDataCollection,
@@ -59,17 +59,17 @@ class mlodaAPI:
     def __init__(
         self,
         requested_features: Features | list[Feature | str],
-        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
+        plugin_collector: PluginCollector | None = None,
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
-        column_ordering: Optional[str] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
-        function_extender: Optional[set[Extender]] = None,
+        column_ordering: str | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
+        function_extender: set[Extender] | None = None,
     ) -> None:
         # Setup boundary: any invalid request argument surfaces as the typed error before planning.
         try:
@@ -83,7 +83,7 @@ class mlodaAPI:
             _requested_features = deepcopy(requested_features) if copy_features else requested_features
 
             # Handle api_data: create ApiInputDataCollection if api_data provided
-            api_input_data_collection: Optional[ApiInputDataCollection] = None
+            api_input_data_collection: ApiInputDataCollection | None = None
             if api_data is not None and len(api_data) > 0:
                 api_input_data_collection = ApiInputDataCollection()
                 for key_name, key_data in api_data.items():
@@ -115,7 +115,7 @@ class mlodaAPI:
     def _process_features(
         self,
         requested_features: Features | list[Feature | str],
-        api_input_data_collection: Optional[ApiInputDataCollection],
+        api_input_data_collection: ApiInputDataCollection | None,
     ) -> Features:
         """Processes the requested features, ensuring they are in the correct format and adding API input data."""
         features = requested_features if isinstance(requested_features, Features) else Features(requested_features)
@@ -133,20 +133,20 @@ class mlodaAPI:
     def run_all(
         cls,
         features: Features | list[Feature | str],
-        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        flight_server: Optional[Any] = None,
-        function_extender: Optional[set[Extender]] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        flight_server: Any | None = None,
+        function_extender: set[Extender] | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
+        plugin_collector: PluginCollector | None = None,
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
-        column_ordering: Optional[str] = None,
-        carrier: Optional[dict[str, str]] = None,
-        child_bootstrap: Optional[Callable[[], None]] = None,
+        column_ordering: str | None = None,
+        carrier: dict[str, str] | None = None,
+        child_bootstrap: Callable[[], None] | None = None,
     ) -> RunResult:
         """
         Run feature computation in one step.
@@ -215,20 +215,20 @@ class mlodaAPI:
     def stream_all(
         cls,
         features: Features | list[Feature | str],
-        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        flight_server: Optional[Any] = None,
-        function_extender: Optional[set[Extender]] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        flight_server: Any | None = None,
+        function_extender: set[Extender] | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
+        plugin_collector: PluginCollector | None = None,
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
-        column_ordering: Optional[str] = None,
-        carrier: Optional[dict[str, str]] = None,
-        child_bootstrap: Optional[Callable[[], None]] = None,
+        column_ordering: str | None = None,
+        carrier: dict[str, str] | None = None,
+        child_bootstrap: Callable[[], None] | None = None,
     ) -> ResultStream:
         """Stream results at feature-group granularity.
 
@@ -271,17 +271,17 @@ class mlodaAPI:
     def prepare(
         cls,
         features: Features | list[Feature | str],
-        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
+        plugin_collector: PluginCollector | None = None,
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
-        column_ordering: Optional[str] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
-        function_extender: Optional[set[Extender]] = None,
+        column_ordering: str | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
+        function_extender: set[Extender] | None = None,
     ) -> "mlodaAPI":
         """Build an execution plan without running it.
 
@@ -308,17 +308,17 @@ class mlodaAPI:
         cls,
         features: Features | list[Feature | str],
         *,
-        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
+        plugin_collector: PluginCollector | None = None,
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
-        column_ordering: Optional[str] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
-        function_extender: Optional[set[Extender]] = None,
+        column_ordering: str | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
+        function_extender: set[Extender] | None = None,
     ) -> list[PlanStep]:
         """Resolve the execution plan without executing it.
 
@@ -352,17 +352,17 @@ class mlodaAPI:
         cls,
         features: Features | list[Feature | str],
         *,
-        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
+        plugin_collector: PluginCollector | None = None,
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
-        column_ordering: Optional[str] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
-        function_extender: Optional[set[Extender]] = None,
+        column_ordering: str | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
+        function_extender: set[Extender] | None = None,
     ) -> ResolutionDiagnosis:
         """Non-raising whole-request resolution preflight.
 
@@ -447,13 +447,13 @@ class mlodaAPI:
 
     def run(
         self,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        flight_server: Optional[Any] = None,
-        function_extender: Optional[set[Extender]] = None,
-        artifacts: Optional[dict[str, Any]] = None,
-        carrier: Optional[dict[str, str]] = None,
-        child_bootstrap: Optional[Callable[[], None]] = None,
+        flight_server: Any | None = None,
+        function_extender: set[Extender] | None = None,
+        artifacts: dict[str, Any] | None = None,
+        carrier: dict[str, str] | None = None,
+        child_bootstrap: Callable[[], None] | None = None,
     ) -> list[Any]:
         """Execute the prepared session and return results.
 
@@ -482,13 +482,13 @@ class mlodaAPI:
 
     def stream_run(
         self,
-        api_data: Optional[dict[str, dict[str, Any]]] = None,
+        api_data: dict[str, dict[str, Any]] | None = None,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        flight_server: Optional[Any] = None,
-        function_extender: Optional[set[Extender]] = None,
-        artifacts: Optional[dict[str, Any]] = None,
-        carrier: Optional[dict[str, str]] = None,
-        child_bootstrap: Optional[Callable[[], None]] = None,
+        flight_server: Any | None = None,
+        function_extender: set[Extender] | None = None,
+        artifacts: dict[str, Any] | None = None,
+        carrier: dict[str, str] | None = None,
+        child_bootstrap: Callable[[], None] | None = None,
     ) -> Generator[Any, None, None]:
         """Execute the prepared session and yield each feature group's result as it completes.
 
@@ -507,9 +507,9 @@ class mlodaAPI:
         self,
         runner: ExecutionOrchestrator,
         parallelization_modes: set[ParallelizationMode],
-        function_extender: Optional[set[Extender]],
-        api_data: Optional[dict[str, dict[str, Any]]],
-        artifacts: Optional[dict[str, Any]],
+        function_extender: set[Extender] | None,
+        api_data: dict[str, dict[str, Any]] | None,
+        artifacts: dict[str, Any] | None,
         run_context: RunContext,
     ) -> Generator[Any, None, None]:
         """Deferred half of ``stream_run``: iterating this is what actually drives computation."""
@@ -536,10 +536,10 @@ class mlodaAPI:
     def _batch_run(
         self,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        flight_server: Optional[Any] = None,
-        function_extender: Optional[set[Extender]] = None,
-        api_data: Optional[dict[str, Any]] = None,
-        artifacts: Optional[dict[str, Any]] = None,
+        flight_server: Any | None = None,
+        function_extender: set[Extender] | None = None,
+        api_data: dict[str, Any] | None = None,
+        artifacts: dict[str, Any] | None = None,
         run_context: RunContext | None = None,
     ) -> ExecutionOrchestrator:
         """Sets up the engine runner and runs the engine computation."""
@@ -561,9 +561,9 @@ class mlodaAPI:
         self,
         runner: ExecutionOrchestrator,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        function_extender: Optional[set[Extender]] = None,
-        api_data: Optional[dict[str, Any]] = None,
-        artifacts: Optional[dict[str, Any]] = None,
+        function_extender: set[Extender] | None = None,
+        api_data: dict[str, Any] | None = None,
+        artifacts: dict[str, Any] | None = None,
         run_context: RunContext | None = None,
     ) -> None:
         """Runs the engine computation within a context manager."""
@@ -587,9 +587,9 @@ class mlodaAPI:
         self,
         runner: ExecutionOrchestrator,
         parallelization_modes: set[ParallelizationMode],
-        function_extender: Optional[set[Extender]],
-        api_data: Optional[dict[str, Any]],
-        artifacts: Optional[dict[str, Any]] = None,
+        function_extender: set[Extender] | None,
+        api_data: dict[str, Any] | None,
+        artifacts: dict[str, Any] | None = None,
         run_context: RunContext | None = None,
     ) -> None:
         """Enters the runner context with strict-mode-filtered extenders."""
@@ -624,7 +624,7 @@ class mlodaAPI:
     def _setup_engine_runner(
         self,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        flight_server: Optional[Any] = None,
+        flight_server: Any | None = None,
     ) -> ExecutionOrchestrator:
         """Sets up the engine runner based on parallelization mode."""
         if self.engine is None:
@@ -653,9 +653,7 @@ class mlodaAPI:
             raise ValueError("You need to run any run function beforehand.")
         return self.runner.get_artifacts()
 
-    def _add_api_input_data(
-        self, feature: Feature, api_input_data_collection: Optional[ApiInputDataCollection]
-    ) -> None:
+    def _add_api_input_data(self, feature: Feature, api_input_data_collection: ApiInputDataCollection | None) -> None:
         """Adds API input data to the feature options if available."""
         if api_input_data_collection:
             api_input_data_column_names = api_input_data_collection.get_column_names()

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -1,7 +1,7 @@
 import functools
 from collections.abc import Callable, Iterable
 from multiprocessing.managers import BaseManager
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -45,7 +45,7 @@ class CfwManager:
     def __init__(
         self,
         parallelization_modes: set[ParallelizationMode],
-        function_extender: Optional[set[Extender]] = None,
+        function_extender: set[Extender] | None = None,
     ) -> None:
         """
         Initializes the CfwManager.
@@ -62,7 +62,7 @@ class CfwManager:
         ] = {}  # cfw uuid -> (cfw class name, children_if_root)
         self.cfw_merge_relation: dict[UUID, tuple[UUID, str]] = {}  # merge relation
 
-        self.location: Optional[str] = None  # multiprocessing location
+        self.location: str | None = None  # multiprocessing location
         self.error = False  # multiprocessing error flag
         self.msg: Any = None
         self.exc_info: Any = None
@@ -73,9 +73,9 @@ class CfwManager:
 
         self.artifact_to_save: dict[str, Any] = {}
 
-        self.runtime_artifacts: Optional[dict[str, Any]] = None
+        self.runtime_artifacts: dict[str, Any] | None = None
 
-        self.api_data: Optional[dict[str, Any]] = None
+        self.api_data: dict[str, Any] | None = None
 
         self.run_context: RunContext = RunContext()
 
@@ -83,7 +83,7 @@ class CfwManager:
         """Associates a set of Flyway dataset UUIDs with a Compute Framework UUID."""
         self.uuid_flyway_datasets[cf_uuid] = object_ids
 
-    def get_uuid_flyway_datasets(self, cf_uuid: UUID) -> Optional[set[UUID]]:
+    def get_uuid_flyway_datasets(self, cf_uuid: UUID) -> set[UUID] | None:
         """Retrieves the set of Flyway dataset UUIDs associated with a Compute Framework UUID."""
         return self.uuid_flyway_datasets.get(cf_uuid, None)
 
@@ -99,7 +99,7 @@ class CfwManager:
         self,
         cf_class_name: str,
         feature_uuid: UUID,
-    ) -> Optional[UUID]:
+    ) -> UUID | None:
         """
         Retrieves the UUID of a Compute Framework based on its class name and a feature UUID.
 
@@ -119,7 +119,7 @@ class CfwManager:
                 return cfw_uuid
         return None
 
-    def get_unique_cfw_uuid(self, cf_class_name: str, tfs_ids: set[UUID]) -> Optional[UUID]:
+    def get_unique_cfw_uuid(self, cf_class_name: str, tfs_ids: set[UUID]) -> UUID | None:
         """
         Resolves a set of tfs_ids to at most one distinct Compute Framework UUID.
 
@@ -227,7 +227,7 @@ class CfwManager:
         if not self.location:
             self.location = location
 
-    def get_location(self) -> Optional[str]:
+    def get_location(self) -> str | None:
         """Retrieves the location for multiprocessing."""
         return self.location
 
@@ -261,7 +261,7 @@ class CfwManager:
         """Retrieves the exception information."""
         return self.exc_info
 
-    def get_function_extender(self) -> Optional[set[Extender]]:
+    def get_function_extender(self) -> set[Extender] | None:
         """Retrieves the optional set of function extenders."""
         return self.function_extender
 
@@ -286,7 +286,7 @@ class CfwManager:
         """Sets runtime artifacts passed to run() for load-mode resolution."""
         self.runtime_artifacts = artifacts
 
-    def get_runtime_artifacts(self) -> Optional[dict[str, Any]]:
+    def get_runtime_artifacts(self) -> dict[str, Any] | None:
         """Retrieves runtime artifacts, or None if not provided."""
         return self.runtime_artifacts
 
@@ -294,7 +294,7 @@ class CfwManager:
         """Sets the API data."""
         self.api_data = api_data
 
-    def get_api_data_by_name(self, key: str) -> Optional[Any]:
+    def get_api_data_by_name(self, key: str) -> Any | None:
         """
         Retrieves API data by name.
 

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from copy import deepcopy
 import logging
-from typing import Any, Optional, cast
+from typing import Any, cast
 from uuid import UUID
 import uuid
 
@@ -58,13 +58,13 @@ class Engine:
         self,
         features: Features,
         compute_frameworks: set[type[ComputeFramework]],
-        links: Optional[set[Link]],
-        data_access_collection: Optional[DataAccessCollection] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_input_data_collection: Optional[ApiInputDataCollection] = None,
-        plugin_collector: Optional[PluginCollector] = None,
-        column_ordering: Optional[str] = None,
-        function_extender: Optional[set[Extender]] = None,
+        links: set[Link] | None,
+        data_access_collection: DataAccessCollection | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_input_data_collection: ApiInputDataCollection | None = None,
+        plugin_collector: PluginCollector | None = None,
+        column_ordering: str | None = None,
+        function_extender: set[Extender] | None = None,
         run_id: str | None = None,
     ) -> None:
         # setup variables which track the primary sources and the compute platforms
@@ -125,11 +125,11 @@ class Engine:
                 connection_map[cfw_class] = conn
         return connection_map
 
-    def get_function_extender(self, hook: ExtenderHook) -> Optional[Extender]:
+    def get_function_extender(self, hook: ExtenderHook) -> Extender | None:
         """Select the extender(s) registered for hook, delegating to the shared free function."""
         return get_function_extender(self.function_extender, hook)
 
-    def compute(self, flight_server: Optional[ParallelRunnerFlightServer] = None) -> ExecutionOrchestrator:
+    def compute(self, flight_server: ParallelRunnerFlightServer | None = None) -> ExecutionOrchestrator:
         execution_plan_copy = deepcopy(self.execution_planner)
         orchestrator = ExecutionOrchestrator(
             execution_plan_copy,
@@ -455,7 +455,7 @@ class Engine:
         self,
         feature_group_class: type[FeatureGroup],
         feature: Feature,
-        child_uuid: Optional[UUID],
+        child_uuid: UUID | None,
         if_index_feature: bool = False,
     ) -> bool:
         # Materialize declared defaults at intake: default-equivalent twins become equal and merge
@@ -523,7 +523,7 @@ class Engine:
         uuid: UUID,
         options: Options,
         feature_name: FeatureName,
-        parent_domain: Optional[str] = None,
+        parent_domain: str | None = None,
         depth: int = 0,
     ) -> frozenset[str] | None:
         """Handles recursion for input features of a feature group."""
@@ -565,7 +565,7 @@ class Engine:
             feature.compute_frameworks = compute_frameworks
         return feature
 
-    def set_data_type(self, feature: Feature, feature_group_class: type[FeatureGroup]) -> Optional[DataType]:
+    def set_data_type(self, feature: Feature, feature_group_class: type[FeatureGroup]) -> DataType | None:
         fg_data_type = feature_group_class.return_data_type_rule(feature)
         if feature.data_type and fg_data_type:
             if feature.data_type != fg_data_type:

--- a/mloda/core/core/step/abstract_step.py
+++ b/mloda/core/core/step/abstract_step.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, final
+from typing import Any, final
 from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -18,9 +18,9 @@ class Step(ABC):
         self,
         cfw_register: CfwManager,
         cfw: ComputeFramework,
-        from_cfw: Optional[ComputeFramework | UUID] = None,
-        data: Optional[Any] = None,
-    ) -> Optional[Any]:
+        from_cfw: ComputeFramework | UUID | None = None,
+        data: Any | None = None,
+    ) -> Any | None:
         """Define what executing this step involves."""
         pass
 

--- a/mloda/core/core/step/feature_group_step.py
+++ b/mloda/core/core/step/feature_group_step.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 from mloda.core.abstract_plugins.components.base_artifact import BaseArtifact
 from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData
@@ -17,7 +17,7 @@ class FeatureGroupStep(Step):
         features: FeatureSet,
         required_uuids: set[UUID],
         compute_framework: type[ComputeFramework],
-        children_if_root: Optional[set[UUID]] = None,
+        children_if_root: set[UUID] | None = None,
         api_input_data: BaseApiData | bool = False,
     ) -> None:
         if children_if_root is None:
@@ -44,9 +44,9 @@ class FeatureGroupStep(Step):
         self,
         cfw_register: CfwManager,
         cfw: ComputeFramework,
-        from_cfw: Optional[ComputeFramework | UUID] = None,  # Not used in this implementation
-        data: Optional[Any] = None,
-    ) -> Optional[Any]:
+        from_cfw: ComputeFramework | UUID | None = None,  # Not used in this implementation
+        data: Any | None = None,
+    ) -> Any | None:
         self.location = cfw_register.get_location()
 
         runtime_artifacts = cfw_register.get_runtime_artifacts()
@@ -69,7 +69,7 @@ class FeatureGroupStep(Step):
             return data
         return None
 
-    def run_calculate_feature(self, cfw: ComputeFramework, data: Optional[Any] = None) -> Any:
+    def run_calculate_feature(self, cfw: ComputeFramework, data: Any | None = None) -> Any:
         if self.feature_group.calculate_feature is None:
             raise ValueError("FeatureGroup calculate_feature is not implemented")
 

--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any
 from uuid import UUID, uuid4
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import ComputeFrameworkTransformer
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -21,7 +21,7 @@ class JoinStep(Step):
         destination_framework_uuids: set[UUID],
         source_framework_uuids: set[UUID],
         swap_merge_sides: bool = False,
-        token: Optional[UUID] = None,
+        token: UUID | None = None,
     ) -> None:
         self.link = link
         self.swap_merge_sides = swap_merge_sides
@@ -64,7 +64,7 @@ class JoinStep(Step):
         with context.activate():
             _invoke_extender(extender, instrument(context, self._do_merge_data), cfw, from_cfw_data)
 
-    def _join_keys(self) -> Optional[tuple[str, ...]]:
+    def _join_keys(self) -> tuple[str, ...] | None:
         """Pairs each left column with its corresponding right column; None for APPEND/UNION, which merge without keys."""
         if self.link.jointype in (JoinType.APPEND, JoinType.UNION):
             return None
@@ -92,9 +92,9 @@ class JoinStep(Step):
         self,
         cfw_register: CfwManager,
         cfw: ComputeFramework,
-        from_cfw: Optional[ComputeFramework | UUID] = None,
-        data: Optional[Any] = None,
-    ) -> Optional[Any]:
+        from_cfw: ComputeFramework | UUID | None = None,
+        data: Any | None = None,
+    ) -> Any | None:
         self.location = cfw_register.get_location()
 
         if from_cfw is None:
@@ -126,7 +126,7 @@ class JoinStep(Step):
             raise ValueError("From_cfw is a UUID, but we are not using flightserver.")
         return from_cfw.get_data(), from_cfw.uuid
 
-    def matched(self, other_framework: type[ComputeFramework], uuid: UUID) -> Optional[UUID]:
+    def matched(self, other_framework: type[ComputeFramework], uuid: UUID) -> UUID | None:
         """
         If matched, return the uuid of the join step.
         """

--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
@@ -21,9 +21,9 @@ class TransformFrameworkStep(Step):
         required_uuids: set[UUID],
         from_feature_group: type[FeatureGroup],
         to_feature_group: type[FeatureGroup],
-        link_id: Optional[UUID] = None,
-        source_framework_uuids: Optional[set[UUID]] = None,
-        source_step_uuid: Optional[UUID] = None,
+        link_id: UUID | None = None,
+        source_framework_uuids: set[UUID] | None = None,
+        source_step_uuid: UUID | None = None,
     ) -> None:
         if source_framework_uuids is None:
             source_framework_uuids = set()
@@ -40,7 +40,7 @@ class TransformFrameworkStep(Step):
         self.transformer = ComputeFrameworkTransformer()
 
         # This variable is only set, if the TFS was requested by a joinstep.
-        self.source_framework_uuid: Optional[UUID] = None
+        self.source_framework_uuid: UUID | None = None
         if len(source_framework_uuids) > 0:
             self.source_framework_uuid = next(iter(source_framework_uuids))
 
@@ -80,9 +80,9 @@ class TransformFrameworkStep(Step):
         self,
         cfw_register: CfwManager,
         cfw: ComputeFramework,
-        from_cfw: Optional[ComputeFramework | UUID] = None,
-        data: Optional[Any] = None,
-    ) -> Optional[Any]:
+        from_cfw: ComputeFramework | UUID | None = None,
+        data: Any | None = None,
+    ) -> Any | None:
         self.location = cfw_register.get_location()
 
         if from_cfw is None:

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol, cast, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 
@@ -7,16 +7,16 @@ from mloda.core.abstract_plugins.components.utils import unhashable_part
 @runtime_checkable
 class FilterParameter(Protocol):
     @property
-    def value(self) -> Optional[Any]: ...
+    def value(self) -> Any | None: ...
 
     @property
-    def values(self) -> Optional[list[Any]]: ...
+    def values(self) -> list[Any] | None: ...
 
     @property
-    def min_value(self) -> Optional[Any]: ...
+    def min_value(self) -> Any | None: ...
 
     @property
-    def max_value(self) -> Optional[Any]: ...
+    def max_value(self) -> Any | None: ...
 
     @property
     def max_exclusive(self) -> bool: ...
@@ -59,11 +59,11 @@ class FilterParameterImpl:
         return cls(_raw=tuple(sorted(normalized.items())))
 
     @property
-    def value(self) -> Optional[Any]:
+    def value(self) -> Any | None:
         return self._get("value")
 
     @property
-    def values(self) -> Optional[list[Any]]:
+    def values(self) -> list[Any] | None:
         # Stored as a tuple or frozenset for hashability; hand out the declared list type. A
         # frozenset iterates in hash-seed order, so it's re-sorted here to stay deterministic.
         stored = self._get("values")
@@ -71,14 +71,14 @@ class FilterParameterImpl:
             return sorted(stored, key=repr)
         if isinstance(stored, tuple):
             return list(stored)
-        return cast(Optional[list[Any]], stored)
+        return cast(list[Any] | None, stored)
 
     @property
-    def min_value(self) -> Optional[Any]:
+    def min_value(self) -> Any | None:
         return self._get("min")
 
     @property
-    def max_value(self) -> Optional[Any]:
+    def max_value(self) -> Any | None:
         return self._get("max")
 
     @property

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -1,7 +1,7 @@
 from copy import copy, deepcopy
 from datetime import datetime, timezone
 from itertools import chain
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -156,7 +156,7 @@ class GlobalFilter:
         self,
         feature_group: type[FeatureGroup],
         feat: Feature,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> set[SingleFilter]:
         """
         We need to figure out if the filter feature is a part of the feature class and thus can be used as filter.
@@ -252,7 +252,7 @@ class GlobalFilter:
         return filter_options
 
     def _warn_on_diverging_options(
-        self, feature_group: Optional[type[FeatureGroup]], feat_options: Options, filter_options: Options
+        self, feature_group: type[FeatureGroup] | None, feat_options: Options, filter_options: Options
     ) -> None:
         """Report keys the filter feature declares differently, unless intake provably erases the difference."""
         for key, value in chain(feat_options.group.items(), feat_options.context.items()):
@@ -277,7 +277,7 @@ class GlobalFilter:
             logger.warning(message)
 
     @staticmethod
-    def _intake_fill(feature_group: Optional[type[FeatureGroup]], key: str, filter_options: Options) -> Any:
+    def _intake_fill(feature_group: type[FeatureGroup] | None, key: str, filter_options: Options) -> Any:
         """The value intake materializes for ``key``, None when it fills nothing.
 
         Mirrors ``FeatureGroup.options_with_defaults``: a concrete spec default fills a key the spec reads
@@ -308,7 +308,7 @@ class GlobalFilter:
         self,
         feature_group: type[FeatureGroup],
         filter: SingleFilter,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         """A raising match hook is a non-match for this filter only, mirroring the resolution seam (#845).
 
@@ -530,8 +530,8 @@ class GlobalFilter:
         self,
         event_from: datetime,
         event_to: datetime,
-        valid_from: Optional[datetime] = None,
-        valid_to: Optional[datetime] = None,
+        valid_from: datetime | None = None,
+        valid_to: datetime | None = None,
         max_exclusive: bool = True,
         event_time_column: str | Feature = DefaultOptionKeys.reference_time,
         validity_time_column: str | Feature = DefaultOptionKeys.time_travel,
@@ -551,8 +551,8 @@ class GlobalFilter:
         Parameters:
         - event_from (datetime): Start of the time range (with timezone).
         - event_to (datetime): End of the time range (with timezone).
-        - valid_from (Optional[datetime]): Start of the validity period (optional, with timezone).
-        - valid_to (Optional[datetime]): End of the validity period (optional, with timezone).
+        - valid_from (datetime | None): Start of the validity period (optional, with timezone).
+        - valid_to (datetime | None): End of the validity period (optional, with timezone).
         - max_exclusive (bool): If True, the `event_to` and `valid_to` values are treated as exclusive.
         - event_time_column: the column name for the event time filter. Default is DefaultOptionKeys.reference_time.
         - validity_time_column: the column name for the validity time filter. Default is DefaultOptionKeys.time_travel.

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 import sys
 from copy import deepcopy
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import (
     SOURCE_INTROSPECTION_ERRORS,
@@ -147,7 +147,7 @@ def _running_in_zmq_shell() -> bool:
     return bool(ipython_instance.__class__.__name__ == "ZMQInteractiveShell")
 
 
-def _safe_class_source_hash(cls: type[FeatureGroup]) -> Optional[str]:
+def _safe_class_source_hash(cls: type[FeatureGroup]) -> str | None:
     """Return source hash for a FeatureGroup subclass or None if unavailable.
 
     ``inspect.getsource`` raises ``OSError`` (no source backing) or ``TypeError``
@@ -272,7 +272,7 @@ def _any_live_in_module(members: list[type[FeatureGroup]]) -> bool:
     return any(_is_live_in_module(cls) for cls in members)
 
 
-def _cell_label(cls: type[FeatureGroup]) -> Optional[str]:
+def _cell_label(cls: type[FeatureGroup]) -> str | None:
     """Return the first synthetic ``<...>`` filename a class's methods live in.
 
     Returns ``None`` for classes whose methods all live in real source files.
@@ -313,7 +313,7 @@ class PreFilterPlugins:
     def __init__(
         self,
         compute_frameworks: set[type[ComputeFramework]],
-        plugin_collector: Optional[PluginCollector] = None,
+        plugin_collector: PluginCollector | None = None,
     ) -> None:
         feature_groups = self._set_feature_groups(plugin_collector)
         compute_frameworks = self._set_compute_frameworks(compute_frameworks, plugin_collector)
@@ -325,7 +325,7 @@ class PreFilterPlugins:
     def get_accessible_plugins(self) -> FeatureGroupEnvironmentMapping:
         return self.accessible_plugins
 
-    def _set_feature_groups(self, plugin_collector: Optional[PluginCollector] = None) -> set[type[FeatureGroup]]:
+    def _set_feature_groups(self, plugin_collector: PluginCollector | None = None) -> set[type[FeatureGroup]]:
         accessible_feature_groups = self.get_featuregroup_subclasses()
 
         loaded_universe_was_non_empty = bool(accessible_feature_groups)
@@ -395,7 +395,7 @@ class PreFilterPlugins:
     def _set_compute_frameworks(
         self,
         compute_frameworks: set[type[ComputeFramework]],
-        plugin_collector: Optional[PluginCollector] = None,
+        plugin_collector: PluginCollector | None = None,
     ) -> set[type[ComputeFramework]]:
         compute_frameworks = compute_frameworks.intersection(self.get_cfw_subclasses())
 

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from copy import copy, deepcopy
-from typing import Any, Generator, NamedTuple, Optional
+from typing import Any, Generator, NamedTuple
 from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.error_utils import REPORT_URL, internal_invariant_error
@@ -93,8 +93,8 @@ class _JoinServedParent(NamedTuple):
 class ExecutionPlan:
     def __init__(
         self,
-        global_filter: Optional[GlobalFilter] = None,
-        api_input_data_collection: Optional[ApiInputDataCollection] = None,
+        global_filter: GlobalFilter | None = None,
+        api_input_data_collection: ApiInputDataCollection | None = None,
         resolved_input_feature_names: dict[UUID, frozenset[str] | None] | None = None,
     ) -> None:
         # Maps a step to itself so a dedup hit can recover the already-inserted canonical member.

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -2,7 +2,6 @@ import inspect
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import replace
-from typing import Optional
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 
@@ -110,16 +109,16 @@ class IdentifyFeatureGroupClass:
     _match_rejections: dict[type[FeatureGroup], MatchRejection]
     _matcher_errors: dict[type[FeatureGroup], str]
     _eliminations: dict[type[FeatureGroup], Elimination]
-    _data_access_collection: Optional[DataAccessCollection]
+    _data_access_collection: DataAccessCollection | None
     # Per-evaluation memos of the hooks more than one reader wants. evaluate() builds a fresh instance, so
     # they are scoped to one resolution attempt and never cache across runs.
-    _domain_outcomes: dict[type[FeatureGroup], tuple[Optional[Domain], Optional[Exception]]]
-    _links_outcomes: dict[type[FeatureGroup], tuple[Optional[bool], Optional[Exception]]]
+    _domain_outcomes: dict[type[FeatureGroup], tuple[Domain | None, Exception | None]]
+    _links_outcomes: dict[type[FeatureGroup], tuple[bool | None, Exception | None]]
     _declared_frameworks: dict[type[FeatureGroup], frozenset[type[ComputeFramework]]]
     _supported_names: dict[type[FeatureGroup], frozenset[str]]
     _prefixes: dict[type[FeatureGroup], str]
 
-    def __init__(self, data_access_collection: Optional[DataAccessCollection] = None) -> None:
+    def __init__(self, data_access_collection: DataAccessCollection | None = None) -> None:
         self._criteria_matched_feature_groups = set()
         self._abstract_matched_feature_groups = set()
         self._candidate_frameworks = {}
@@ -140,8 +139,8 @@ class IdentifyFeatureGroupClass:
         cls,
         feature: Feature,
         accessible_plugins: FeatureGroupEnvironmentMapping,
-        links: Optional[set[Link]],
-        data_access_collection: Optional[DataAccessCollection] = None,
+        links: set[Link] | None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> EvaluationResult:
         """Run the matching/filter logic without raising, returning a structured result."""
         # Pre-matching guard: a >1 pin fires regardless of whether any candidate matches (the old check
@@ -174,7 +173,7 @@ class IdentifyFeatureGroupClass:
         result: EvaluationResult,
         accessible_plugins: FeatureGroupEnvironmentMapping,
         feature: Feature,
-        links: Optional[set[Link]],
+        links: set[Link] | None,
     ) -> RenderFacts:
         """Capture the non-elimination facts the messages still need. Only reached when the pass has no winner.
 
@@ -210,7 +209,7 @@ class IdentifyFeatureGroupClass:
                 hints.add(prefix)
         return frozenset(hints)
 
-    def _domain_outcome(self, feature_group: type[FeatureGroup]) -> tuple[Optional[Domain], Optional[Exception]]:
+    def _domain_outcome(self, feature_group: type[FeatureGroup]) -> tuple[Domain | None, Exception | None]:
         """Memoized get_domain() OUTCOME, value or raise, so one candidate's hook runs once per evaluation.
 
         The outcome rather than the value, because the two readers disagree on error semantics: the decision
@@ -331,7 +330,7 @@ class IdentifyFeatureGroupClass:
         return tuple(known_names)
 
     def _fails_name_blind_gate(
-        self, feature_group: type[FeatureGroup], feature: Feature, links: Optional[set[Link]]
+        self, feature_group: type[FeatureGroup], feature: Feature, links: set[Link] | None
     ) -> bool:
         """Capture-side retest of the three name-blind gates, scope then domain then links, that never raises.
 
@@ -377,7 +376,7 @@ class IdentifyFeatureGroupClass:
         feature_group: type[FeatureGroup],
         compute_frameworks: set[type[ComputeFramework]],
         feature: Feature,
-        links: Optional[set[Link]],
+        links: set[Link] | None,
     ) -> bool:
         """No name at all can resolve to this candidate: it has no framework left, or it lost at a name-blind gate.
 
@@ -403,7 +402,7 @@ class IdentifyFeatureGroupClass:
         result: EvaluationResult,
         accessible_plugins: FeatureGroupEnvironmentMapping,
         feature: Feature,
-        links: Optional[set[Link]],
+        links: set[Link] | None,
     ) -> frozenset[str]:
         """Catalog names of dead candidates that no live candidate owns and no live candidate's prefix covers.
 
@@ -432,8 +431,8 @@ class IdentifyFeatureGroupClass:
         self,
         feature: Feature,
         accessible_plugins: FeatureGroupEnvironmentMapping,
-        links: Optional[set[Link]],
-        data_access_collection: Optional[DataAccessCollection] = None,
+        links: set[Link] | None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> FeatureGroupEnvironmentMapping:
         _identified_feature_groups: FeatureGroupEnvironmentMapping = {}
 
@@ -527,7 +526,7 @@ class IdentifyFeatureGroupClass:
         """Record the first gate a non-winning name-matching candidate failed; one entry per candidate."""
         self._eliminations.setdefault(feature_group, Elimination(stage=stage, reason=reason))
 
-    def _value_rejection(self, feature_group: type[FeatureGroup]) -> Optional[MatchRejection]:
+    def _value_rejection(self, feature_group: type[FeatureGroup]) -> MatchRejection | None:
         """The MatchRejection the first match pass recorded for this candidate class, if any.
 
         The candidate's criteria match records its own rejection under a per-candidate window; this
@@ -544,7 +543,7 @@ class IdentifyFeatureGroupClass:
             return f"does not declare the requested domain '{requested}'"
         return f"declares domain '{candidate_domain}', but the run requested '{requested}'"
 
-    def _filter_feature_group_by_links(self, feature_group: type[FeatureGroup], links: Optional[set[Link]]) -> bool:
+    def _filter_feature_group_by_links(self, feature_group: type[FeatureGroup], links: set[Link] | None) -> bool:
         """Decision-side links gate: unguarded, so a raising index hook still fails the engine loudly."""
         supported, error = self._links_outcome(feature_group, links)
         if error is not None:
@@ -554,8 +553,8 @@ class IdentifyFeatureGroupClass:
         return supported
 
     def _links_outcome(
-        self, feature_group: type[FeatureGroup], links: Optional[set[Link]]
-    ) -> tuple[Optional[bool], Optional[Exception]]:
+        self, feature_group: type[FeatureGroup], links: set[Link] | None
+    ) -> tuple[bool | None, Exception | None]:
         """Memoized links-gate OUTCOME, verdict or raise, so one candidate's index hooks run once per evaluation.
 
         The outcome rather than the verdict, for the reason _domain_outcome caches one: the decision filter
@@ -573,7 +572,7 @@ class IdentifyFeatureGroupClass:
         return self._links_outcomes[feature_group]
 
     @staticmethod
-    def _links_gate(feature_group: type[FeatureGroup], links: Optional[set[Link]]) -> bool:
+    def _links_gate(feature_group: type[FeatureGroup], links: set[Link] | None) -> bool:
         # Case index columns not given, so no validation possible
         if feature_group.index_columns() is None:
             return True
@@ -596,7 +595,7 @@ class IdentifyFeatureGroupClass:
         self,
         feature_group: type[FeatureGroup],
         feature: Feature,
-        data_access_collection: Optional[DataAccessCollection],
+        data_access_collection: DataAccessCollection | None,
     ) -> bool:
         """A raise out of the match hook is a non-match for that candidate only, not a run-wide abort (#845).
 
@@ -695,8 +694,8 @@ class IdentifyFeatureGroupClass:
 def evaluate_and_render(
     feature: Feature,
     accessible_plugins: FeatureGroupEnvironmentMapping,
-    links: Optional[set[Link]] = None,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    links: set[Link] | None = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> tuple[EvaluationResult, str | None]:
     """One resolution pass plus its failure message; the message is None iff the feature resolved."""
     # Unguarded: ComputeFrameworkPinError is a misuse validated before matching, so it escapes unconverted.
@@ -707,8 +706,8 @@ def evaluate_and_render(
 def resolve_or_raise(
     feature: Feature,
     accessible_plugins: FeatureGroupEnvironmentMapping,
-    links: Optional[set[Link]] = None,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    links: set[Link] | None = None,
+    data_access_collection: DataAccessCollection | None = None,
     partial_records: Sequence[ResolutionRecord] = (),
 ) -> EvaluationResult:
     """Evaluate one feature and raise the typed FeatureResolutionError on failure."""

--- a/mloda/core/prepare/resolve_graph.py
+++ b/mloda/core/prepare/resolve_graph.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Optional
 from uuid import UUID
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
@@ -15,7 +14,7 @@ PlannedQueue = list[LinkFrameworkTrekker | tuple[type[FeatureGroup], set[Feature
 
 
 class ResolveGraph:
-    def __init__(self, graph: Graph, links: Optional[set[Link]] = None):
+    def __init__(self, graph: Graph, links: set[Link] | None = None):
         self.graph = graph
         self.nodes_per_feature_group: dict[type[FeatureGroup], set[Feature]] = {}
         self.resolver_compute_framework = ResolveComputeFrameworks(self.graph)

--- a/mloda/core/prepare/resolve_links.py
+++ b/mloda/core/prepare/resolve_links.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, defaultdict
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -197,7 +197,7 @@ class LinkTrekker:
 
 
 class ResolveLinks:
-    def __init__(self, graph: Graph, links: Optional[set[Link]] = None) -> None:
+    def __init__(self, graph: Graph, links: set[Link] | None = None) -> None:
         self.graph = graph
         self.links = links
         self.link_trekker = LinkTrekker()
@@ -280,7 +280,7 @@ class ResolveLinks:
         right_fg: type,
         right_feature: Any = None,
         left_feature: Any = None,
-        pinned_links: Optional[list[Link]] = None,
+        pinned_links: list[Link] | None = None,
     ) -> list[Link]:
         """Find all matching links using two-pass matching: exact first, then polymorphic.
 
@@ -396,8 +396,8 @@ class ResolveLinks:
     def create_link_trekker_key(
         self,
         link: Link,
-        left_frameworks: Optional[set[type[ComputeFramework]]] = None,
-        right_frameworks: Optional[set[type[ComputeFramework]]] = None,
+        left_frameworks: set[type[ComputeFramework]] | None = None,
+        right_frameworks: set[type[ComputeFramework]] | None = None,
     ) -> LinkFrameworkTrekker:
         """Both sides reduce exactly like Feature.get_compute_framework; the join lookup compares the two."""
         if left_frameworks is None or right_frameworks is None:

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -5,7 +5,7 @@ import threading
 import traceback
 import logging
 from dataclasses import replace
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
@@ -34,8 +34,8 @@ class ComputeFrameworkExecutor:
         self,
         cfw_register: CfwManager,
         worker_manager: WorkerManager,
-        tfs_connection_map: Optional[dict[type[ComputeFramework], Any]] = None,
-        function_extender: Optional[set[Extender]] = None,
+        tfs_connection_map: dict[type[ComputeFramework], Any] | None = None,
+        function_extender: set[Extender] | None = None,
     ) -> None:
         """
         Initialize the executor with dependencies.
@@ -62,7 +62,7 @@ class ComputeFrameworkExecutor:
         cf_class: type[ComputeFramework],
         parallelization_mode: ParallelizationMode,
         children_if_root: set[UUID],
-        uuid: Optional[UUID] = None,
+        uuid: UUID | None = None,
     ) -> UUID:
         """
         Initializes a compute framework.
@@ -156,7 +156,7 @@ class ComputeFrameworkExecutor:
         """
         Prepares a step for execution by initializing or retrieving the associated CFW.
         """
-        cfw_uuid: Optional[UUID] = None
+        cfw_uuid: UUID | None = None
 
         if isinstance(step, FeatureGroupStep):
             resolved_uuid = self.cfw_register.get_unique_cfw_uuid(step.compute_framework.get_class_name(), step.tfs_ids)
@@ -228,7 +228,7 @@ class ComputeFrameworkExecutor:
         """
         Prepares CFWs required for TransformFrameworkStep or JoinStep.
         """
-        from_cfw: Optional[Any] = None
+        from_cfw: Any | None = None
         if isinstance(step, TransformFrameworkStep):
             from_cfw = self.prepare_tfs_right_cfw(step)
             from_cfw = self.cfw_collection[from_cfw]

--- a/mloda/core/runtime/data_lifecycle_manager.py
+++ b/mloda/core/runtime/data_lifecycle_manager.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import ComputeFrameworkTransformer
@@ -19,9 +19,9 @@ class DataLifecycleManager:
 
     def __init__(
         self,
-        transformer: Optional[ComputeFrameworkTransformer] = None,
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        transformer: ComputeFrameworkTransformer | None = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> None:
         """
         Initializes DataLifecycleManager with empty state and transformer.
@@ -39,7 +39,7 @@ class DataLifecycleManager:
         self.request_feature_order = request_feature_order
 
     def drop_data_for_finished_cfws(
-        self, finished_ids: set[UUID], cfw_collection: dict[UUID, ComputeFramework], location: Optional[str] = None
+        self, finished_ids: set[UUID], cfw_collection: dict[UUID, ComputeFramework], location: str | None = None
     ) -> None:
         """
         Drops data for CFWs when all their dependent steps are finished.
@@ -62,7 +62,7 @@ class DataLifecycleManager:
             del self.track_data_to_drop[cfw_uuid]
 
     def drop_cfw_data(
-        self, cfw_uuid: UUID, cfw_collection: dict[UUID, ComputeFramework], location: Optional[str] = None
+        self, cfw_uuid: UUID, cfw_collection: dict[UUID, ComputeFramework], location: str | None = None
     ) -> None:
         """
         Drops data associated with a specific CFW.
@@ -79,7 +79,7 @@ class DataLifecycleManager:
             cfw.drop_last_data(None)
 
     def add_to_result_data_collection(
-        self, cfw: ComputeFramework, features: FeatureSet, step_uuid: UUID, location: Optional[str] = None
+        self, cfw: ComputeFramework, features: FeatureSet, step_uuid: UUID, location: str | None = None
     ) -> None:
         """
         Adds result data to the collection if features are requested.
@@ -99,7 +99,7 @@ class DataLifecycleManager:
             self.result_data_collection[step_uuid] = result
 
     def get_result_data(
-        self, cfw: ComputeFramework, selected_feature_names: Sequence[FeatureName], location: Optional[str] = None
+        self, cfw: ComputeFramework, selected_feature_names: Sequence[FeatureName], location: str | None = None
     ) -> Any:
         """
         Gets result data from the compute framework.

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -4,7 +4,7 @@ import multiprocessing
 import threading
 import time
 from collections.abc import Sequence
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 from uuid import UUID
 import logging
 
@@ -87,10 +87,10 @@ class ExecutionOrchestrator:
     def __init__(
         self,
         execution_planner: ExecutionPlan,
-        flight_server: Optional[ParallelRunnerFlightServer] = None,
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
-        tfs_connection_map: Optional[dict[type[ComputeFramework], Any]] = None,
+        flight_server: ParallelRunnerFlightServer | None = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
+        tfs_connection_map: dict[type[ComputeFramework], Any] | None = None,
     ) -> None:
         """
         Initializes the ExecutionOrchestrator with an execution plan and optional flight server.
@@ -103,10 +103,10 @@ class ExecutionOrchestrator:
 
         self.cfw_register: CfwManager
         self.manager: Any = None
-        self.function_extender: Optional[set[Extender]] = None
+        self.function_extender: set[Extender] | None = None
 
         # multiprocessing - delegate to WorkerManager
-        self.location: Optional[str] = None
+        self.location: str | None = None
         self.worker_manager = WorkerManager()
 
         # Data lifecycle - delegate to DataLifecycleManager
@@ -411,7 +411,7 @@ class ExecutionOrchestrator:
         self.data_lifecycle_manager.add_to_result_data_collection(cfw, features, step_uuid, self.location)
 
     def get_result_data(
-        self, cfw: ComputeFramework, selected_feature_names: Sequence[FeatureName], location: Optional[str] = None
+        self, cfw: ComputeFramework, selected_feature_names: Sequence[FeatureName], location: str | None = None
     ) -> Any:
         """
         Gets result data from the compute framework.
@@ -425,9 +425,9 @@ class ExecutionOrchestrator:
     def __enter__(
         self,
         parallelization_modes: set[ParallelizationMode] = {ParallelizationMode.SYNC},
-        function_extender: Optional[set[Extender]] = None,
-        api_data: Optional[dict[str, Any]] = None,
-        artifacts: Optional[dict[str, Any]] = None,
+        function_extender: set[Extender] | None = None,
+        api_data: dict[str, Any] | None = None,
+        artifacts: dict[str, Any] | None = None,
         run_context: RunContext | None = None,
     ) -> None:
         """

--- a/mloda/core/runtime/validate_multiprocessing_link.py
+++ b/mloda/core/runtime/validate_multiprocessing_link.py
@@ -6,7 +6,7 @@ current process: a value resolvable here but not inside a freshly spawned worker
 
 import pickle  # nosec
 from collections.abc import Callable, Iterable
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.abstract_plugins.function_extender import Extender
@@ -124,7 +124,7 @@ def _unpicklable_child_bootstrap_error(child_bootstrap: Callable[[], None]) -> s
     )
 
 
-def raise_on_unpicklable_child_bootstrap(child_bootstrap: Optional[Callable[[], None]]) -> None:
+def raise_on_unpicklable_child_bootstrap(child_bootstrap: Callable[[], None] | None) -> None:
     """Raise ValueError if child_bootstrap is not None and multiprocessing cannot pickle it."""
     if child_bootstrap is None:
         return
@@ -145,7 +145,7 @@ def _unpicklable_extender_error(extender: Extender) -> str:
     )
 
 
-def raise_on_unpicklable_extender(function_extender: Optional[set[Extender]]) -> None:
+def raise_on_unpicklable_extender(function_extender: set[Extender] | None) -> None:
     """Raise ValueError if function_extender is not None/empty and any extender in it cannot be pickled."""
     if not function_extender:
         return

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -6,7 +6,7 @@ import threading
 import time
 import logging
 from multiprocessing.process import BaseProcess
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 from uuid import UUID
 
 from mloda.core.runtime.mp_context import mp_spawn_context, spawn_daemon_process
@@ -58,7 +58,7 @@ class WorkerManager:
 
         return process, command_queue, result_queue
 
-    def get_process_queues(self, cfw_uuid: UUID) -> Optional[tuple[Any, Any, Any]]:
+    def get_process_queues(self, cfw_uuid: UUID) -> tuple[Any, Any, Any] | None:
         """Return registered tuple or None."""
         return self.process_register.get(cfw_uuid)
 

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.provider import BaseMergeEngine
@@ -53,7 +53,7 @@ class DuckDBFramework(ComputeFramework):
     This framework does not support multiprocessing, so it should not be used with multiprocessing.
     """
 
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         """Use given DuckDB connection.
 
         Pins the DuckDB session timezone to UTC on first assignment so that timestamp
@@ -105,8 +105,8 @@ class DuckDBFramework(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         """Materialize the final result as a PyArrow Table.
 
@@ -137,7 +137,7 @@ class DuckDBFramework(ComputeFramework):
             return str(dtypes[idx])
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if column_name not in data.columns:
             return None
         idx = data.columns.index(column_name)

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, cast
 
 try:
     import duckdb
@@ -54,7 +54,7 @@ class DuckdbRelation(SqlBaseRelation):
     def __init__(self, connection: duckdb.DuckDBPyConnection, relation: duckdb.DuckDBPyRelation) -> None:
         self._connection = connection
         self._relation = relation
-        self._alias: Optional[str] = None
+        self._alias: str | None = None
 
     @property
     def connection(self) -> duckdb.DuckDBPyConnection:
@@ -117,7 +117,7 @@ class DuckdbRelation(SqlBaseRelation):
         new_rel._alias = alias
         return new_rel
 
-    def get_alias(self) -> Optional[str]:
+    def get_alias(self) -> str | None:
         return self._alias
 
     _VALID_JOIN_TYPES = {"inner", "left", "right", "outer"}

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_filter_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics
 from mloda.provider import BaseFilterEngine
 from mloda.user import SingleFilter
@@ -15,13 +15,13 @@ try:
         Reference,
     )
 except ImportError:
-    IcebergTable: Optional[type[Any]] = None  # type: ignore[no-redef]
-    LessThan: Optional[type[Any]] = None  # type: ignore[no-redef]
-    GreaterThanOrEqual: Optional[type[Any]] = None  # type: ignore[no-redef]
-    LessThanOrEqual: Optional[type[Any]] = None  # type: ignore[no-redef]
-    EqualTo: Optional[type[Any]] = None  # type: ignore[no-redef]
-    And: Optional[type[Any]] = None  # type: ignore[no-redef]
-    Reference: Optional[type[Any]] = None  # type: ignore[no-redef]
+    IcebergTable: type[Any] | None = None  # type: ignore[no-redef]
+    LessThan: type[Any] | None = None  # type: ignore[no-redef]
+    GreaterThanOrEqual: type[Any] | None = None  # type: ignore[no-redef]
+    LessThanOrEqual: type[Any] | None = None  # type: ignore[no-redef]
+    EqualTo: type[Any] | None = None  # type: ignore[no-redef]
+    And: type[Any] | None = None  # type: ignore[no-redef]
+    Reference: type[Any] | None = None  # type: ignore[no-redef]
 
 
 class IcebergFilterEngine(BaseFilterEngine):

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
 from mloda.user import FeatureName
@@ -55,7 +55,7 @@ class IcebergFramework(ComputeFramework):
     provided via set_framework_connection_object() before use.
     """
 
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         """
         Set the Iceberg catalog for table operations.
 
@@ -114,8 +114,8 @@ class IcebergFramework(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         """
         Select specific columns from Iceberg table.
@@ -160,7 +160,7 @@ class IcebergFramework(ComputeFramework):
             return None
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if IcebergTable is not None and isinstance(data, IcebergTable):
             schema = data.schema()
             if column_name not in set(schema.column_names):
@@ -256,7 +256,7 @@ class IcebergFramework(ComputeFramework):
 
         raise ValueError(f"Data type {type(data)} is not supported by {self.__class__.__name__}")
 
-    def validate_expected_framework(self, location: Optional[str] = None) -> None:
+    def validate_expected_framework(self, location: str | None = None) -> None:
         """
         Override to accept both Iceberg tables and PyArrow tables.
 

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import BaseTransformer
 
 try:
@@ -67,7 +67,7 @@ class IcebergPyArrowTransformer(BaseTransformer):
         return data.scan().to_arrow()
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         """
         Transform PyArrow table to Iceberg table.
 

--- a/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_merge_engine import PandasMergeEngine
@@ -38,8 +38,8 @@ class PandasDataFrame(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -55,7 +55,7 @@ class PandasDataFrame(ComputeFramework):
             return str(data[column_name].dtype)
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if column_name not in data.columns:
             return None
         dtype = data[column_name].dtype

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseTransformer
 
@@ -59,5 +59,5 @@ class PandasPyArrowTransformer(BaseTransformer):
         return pa.Table.from_arrays(pyarrow_table.columns, schema=new_schema)
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         return pa.Table.to_pandas(data)

--- a/mloda_plugins/compute_framework/base_implementations/polars/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/dataframe.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.provider import BaseMergeEngine
@@ -39,8 +39,8 @@ class PolarsDataFrame(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -56,13 +56,13 @@ class PolarsDataFrame(ComputeFramework):
             return str(data[column_name].dtype)
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if column_name not in data.columns:
             return None
         return self._polars_type_to_data_type(data[column_name].dtype)
 
     @staticmethod
-    def _polars_type_to_data_type(dtype: Any) -> Optional[DataType]:
+    def _polars_type_to_data_type(dtype: Any) -> DataType | None:
         if pl is None:
             return None
         if dtype == pl.Int32:

--- a/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.hook_context import OutputSchema
 from mloda.user import FeatureName
@@ -40,8 +40,8 @@ class PolarsLazyDataFrame(PolarsDataFrame):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         column_names = set(data.collect_schema().names())
         _selected_feature_names = self.identify_naming_convention(
@@ -60,7 +60,7 @@ class PolarsLazyDataFrame(PolarsDataFrame):
             return str(schema[column_name])
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         schema = data.collect_schema()
         if column_name not in schema.names():
             return None

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_lazy_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_lazy_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseTransformer
 
@@ -55,7 +55,7 @@ class PolarsLazyPyArrowTransformer(BaseTransformer):
         return collected_df.to_arrow()
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         """
         Transform a PyArrow Table to a Polars LazyFrame.
 

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseTransformer
 
@@ -52,7 +52,7 @@ class PolarsPyArrowTransformer(BaseTransformer):
         return data.to_arrow()
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         """
         Transform a PyArrow Table to a Polars DataFrame.
 

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
 from mloda.provider import BaseFilterEngine, BaseMaskEngine
@@ -70,8 +70,8 @@ class PyArrowTable(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         column_names = set(data.schema.names)
         _selected_feature_names = self.identify_naming_convention(
@@ -87,7 +87,7 @@ class PyArrowTable(ComputeFramework):
             return str(data.schema.field(column_name).type)
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if column_name not in data.schema.names:
             return None
         return DataType.from_arrow_type_safe(data.schema.field(column_name).type)

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import decimal
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_merge_engine import (
@@ -64,8 +64,8 @@ class PythonDictFramework(ComputeFramework):
         self,
         data: dict[str, list[Any]],
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> dict[str, list[Any]]:
         if not data:
             return {}
@@ -107,7 +107,7 @@ class PythonDictFramework(ComputeFramework):
                 return type(value).__name__
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         for val in self._column_values(data, column_name):
             if val is None:
                 continue

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseTransformer
 
@@ -57,7 +57,7 @@ class PythonDictPyArrowTransformer(BaseTransformer):
         return pa.table(data)
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         """
         Transform a PyArrow Table to a columnar dict.
 

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.spark.spark_merge_engine import SparkMergeEngine
@@ -37,7 +37,7 @@ class SparkFramework(ComputeFramework):
     It requires a SparkSession to be provided through the framework connection object.
     """
 
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         """Use given SparkSession connection."""
         if SparkSession is None:
             raise ImportError("PySpark is not installed. To be able to use this framework, please install pyspark.")
@@ -83,8 +83,8 @@ class SparkFramework(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -100,7 +100,7 @@ class SparkFramework(ComputeFramework):
             return str(data.schema[column_name].dataType)
         return None
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if column_name not in data.columns:
             return None
         spark_type = data.schema[column_name].dataType

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseTransformer
 
@@ -56,7 +56,7 @@ class SparkPyArrowTransformer(BaseTransformer):
         return data.toArrow()
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         """
         Transform a PyArrow Table to a Spark DataFrame.
 

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_pyarrow_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseTransformer
 
@@ -46,7 +46,7 @@ class SqlBasePyArrowTransformer(BaseTransformer):
         return cls._convert_to_arrow(data)
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         if framework_connection_object is None:
             raise ValueError("A connection object is required for this transformation.")
 

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -2,7 +2,7 @@ import logging
 import re
 import sqlite3
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -18,7 +18,7 @@ from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation
 logger = logging.getLogger(__name__)
 
 
-def _regexp(pattern: str, string: Optional[str]) -> bool:
+def _regexp(pattern: str, string: str | None) -> bool:
     """SQLite REGEXP implementation. Warning: pattern comes from filter values; malicious
     patterns (e.g. '(a+)+$') can cause exponential backtracking on crafted input."""
     if string is None:
@@ -27,7 +27,7 @@ def _regexp(pattern: str, string: Optional[str]) -> bool:
 
 
 class SqliteFramework(ComputeFramework):
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         if framework_connection_object is None:
             raise ValueError("A sqlite3.Connection object is required.")
         if not isinstance(framework_connection_object, sqlite3.Connection):
@@ -65,8 +65,8 @@ class SqliteFramework(ComputeFramework):
         self,
         data: Any,
         selected_feature_names: Sequence[FeatureName],
-        column_ordering: Optional[str] = None,
-        request_feature_order: Optional[list[str]] = None,
+        column_ordering: str | None = None,
+        request_feature_order: list[str] | None = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -107,7 +107,7 @@ class SqliteFramework(ComputeFramework):
         idx = data.columns.index(column_name)
         return str(data.types[idx])
 
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         if not hasattr(data, "columns") or column_name not in data.columns:
             return None
         idx = data.columns.index(column_name)

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
@@ -6,7 +6,7 @@ import re
 import sqlite3
 import uuid
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 
 from mloda_plugins.compute_framework.base_implementations.sql.sql_base_relation import SqlBaseRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
@@ -170,14 +170,14 @@ class SqliteRelation(SqlBaseRelation):
         connection: sqlite3.Connection,
         table_name: str,
         _is_view: bool = False,
-        _types: Optional[Sequence[pa.DataType | None]] = None,
+        _types: Sequence[pa.DataType | None] | None = None,
     ) -> None:
         self._connection = connection
         self._table_name = table_name
-        self._alias: Optional[str] = None
+        self._alias: str | None = None
         self._is_view = _is_view
-        self._cached_columns: Optional[list[str]] = None
-        self._cached_types: Optional[list[pa.DataType | None]] = list(_types) if _types is not None else None
+        self._cached_columns: list[str] | None = None
+        self._cached_types: list[pa.DataType | None] | None = list(_types) if _types is not None else None
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -209,7 +209,7 @@ class SqliteRelation(SqlBaseRelation):
         return [type_map.get(column, pa.string()) for column in columns]
 
     @property
-    def type_hints(self) -> Optional[list[pa.DataType | None]]:
+    def type_hints(self) -> list[pa.DataType | None] | None:
         """Propagated per-column type hints aligned with columns, None per unresolved column; never scans rows."""
         return self._type_hints_for_current_columns()
 
@@ -217,12 +217,12 @@ class SqliteRelation(SqlBaseRelation):
         cursor = self._connection.execute(f"PRAGMA table_info({quote_ident(self._table_name)})")
         return {row[1]: _sqlite_affinity_to_arrow_type(str(row[2])) for row in cursor.fetchall()}
 
-    def _type_hints_for_current_columns(self) -> Optional[list[pa.DataType | None]]:
+    def _type_hints_for_current_columns(self) -> list[pa.DataType | None] | None:
         if self._cached_types is None or len(self._cached_types) != len(self.columns):
             return None
         return list(self._cached_types)
 
-    def _types_for_current_columns(self) -> Optional[list[pa.DataType]]:
+    def _types_for_current_columns(self) -> list[pa.DataType] | None:
         type_hints = self._type_hints_for_current_columns()
         if type_hints is None:
             return None
@@ -244,7 +244,7 @@ class SqliteRelation(SqlBaseRelation):
         self._cached_types = resolved_hints
         return [arrow_type for arrow_type in resolved_hints if arrow_type is not None]
 
-    def _types_for_projection(self, columns: list[str]) -> Optional[list[pa.DataType | None]]:
+    def _types_for_projection(self, columns: list[str]) -> list[pa.DataType | None] | None:
         current_type_hints = self._types_for_current_columns()
         if current_type_hints is None:
             return None
@@ -255,7 +255,7 @@ class SqliteRelation(SqlBaseRelation):
 
     def _types_for_raw_sql_projection(
         self, projection: str, output_columns: list[str]
-    ) -> Optional[list[pa.DataType | None]]:
+    ) -> list[pa.DataType | None] | None:
         if not _raw_sql_projection_starts_with_star(projection):
             return None
         source_columns = self.columns
@@ -269,12 +269,12 @@ class SqliteRelation(SqlBaseRelation):
     @staticmethod
     def _types_for_join_projection(
         left_cols: list[str],
-        left_types: Optional[Sequence[pa.DataType | None]],
+        left_types: Sequence[pa.DataType | None] | None,
         right_cols: list[str],
-        right_types: Optional[Sequence[pa.DataType | None]],
+        right_types: Sequence[pa.DataType | None] | None,
         shared: set[str],
         coalesce_shared: bool = False,
-    ) -> Optional[list[pa.DataType | None]]:
+    ) -> list[pa.DataType | None] | None:
         if left_types is None or right_types is None:
             return None
         left_type_map = dict(zip(left_cols, left_types, strict=True))
@@ -304,12 +304,12 @@ class SqliteRelation(SqlBaseRelation):
             _types=types,
         )
 
-    def select(self, *columns: str, _raw_sql: Optional[str] = None) -> "SqliteRelation":
+    def select(self, *columns: str, _raw_sql: str | None = None) -> "SqliteRelation":
         """Project columns. _raw_sql bypasses quoting: never pass user-controlled input."""
         new_name = _next_table_name()
         if _raw_sql is not None:
             projection = _raw_sql
-            types: Optional[list[pa.DataType | None]] = None
+            types: list[pa.DataType | None] | None = None
         else:
             projection = ", ".join(quote_ident(c) for c in columns)
             types = self._types_for_projection(list(columns))
@@ -326,7 +326,7 @@ class SqliteRelation(SqlBaseRelation):
         rel._alias = alias
         return rel
 
-    def get_alias(self) -> Optional[str]:
+    def get_alias(self) -> str | None:
         return self._alias
 
     def limit(self, n: int) -> "SqliteRelation":

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -5,7 +5,7 @@ Base implementation for clustering feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -228,7 +228,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Custom validation done via _validate_string_match() hook
 
     @classmethod
-    def _extract_clustering_params(cls, feature: Feature) -> tuple[Optional[str], Optional[int | str]]:
+    def _extract_clustering_params(cls, feature: Feature) -> tuple[str | None, int | str | None]:
         """
         Extract algorithm and k_value from a feature.
 

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -5,7 +5,7 @@ Base implementation for missing value imputation feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -218,7 +218,7 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return imputation_method
 
     @classmethod
-    def _extract_imputation_method(cls, feature: Feature) -> Optional[str]:
+    def _extract_imputation_method(cls, feature: Feature) -> str | None:
         """
         Extract imputation method from a feature.
 
@@ -318,8 +318,8 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         data: Any,
         imputation_method: str,
         in_features: list[str],
-        constant_value: Optional[Any] = None,
-        group_by_features: Optional[list[str]] = None,
+        constant_value: Any | None = None,
+        group_by_features: list[str] | None = None,
     ) -> Any:
         """
         Method to perform the imputation. Should be implemented by subclasses.

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pandas.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for missing value imputation feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 from mloda.provider import ComputeFramework
@@ -49,8 +49,8 @@ class PandasMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: pd.DataFrame,
         imputation_method: str,
         in_features: list[str],
-        constant_value: Optional[Any] = None,
-        group_by_features: Optional[list[str]] = None,
+        constant_value: Any | None = None,
+        group_by_features: list[str] | None = None,
     ) -> pd.Series:
         """
         Perform the imputation using Pandas.
@@ -137,7 +137,7 @@ class PandasMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: pd.DataFrame,
         imputation_method: str,
         in_features: str,
-        constant_value: Optional[Any],
+        constant_value: Any | None,
         group_by_features: list[str],
     ) -> pd.Series:
         """

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -4,7 +4,7 @@ PyArrow implementation for missing value imputation feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -53,8 +53,8 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: pa.Table,
         imputation_method: str,
         in_features: list[str],
-        constant_value: Optional[Any] = None,
-        group_by_features: Optional[list[str]] = None,
+        constant_value: Any | None = None,
+        group_by_features: list[str] | None = None,
     ) -> pa.Array:
         """
         Perform the imputation using PyArrow compute functions.
@@ -167,7 +167,7 @@ class PyArrowMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: pa.Table,
         imputation_method: str,
         in_features: str,  # Note: grouped imputation only supports single column
-        constant_value: Optional[Any],
+        constant_value: Any | None,
         group_by_features: list[str],
     ) -> pa.Array:
         """

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import statistics
 from collections import Counter
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import ComputeFramework
 
@@ -65,8 +65,8 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: dict[str, list[Any]],
         imputation_method: str,
         in_features: list[str],
-        constant_value: Optional[Any] = None,
-        group_by_features: Optional[list[str]] = None,
+        constant_value: Any | None = None,
+        group_by_features: list[str] | None = None,
     ) -> list[Any]:
         """
         Perform the imputation using pure Python operations.
@@ -158,7 +158,7 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: dict[str, list[Any]],
         imputation_method: str,
         in_features: str,  # Note: grouped imputation only supports single column
-        constant_value: Optional[Any],
+        constant_value: Any | None,
         group_by_features: list[str],
     ) -> list[Any]:
         """

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -5,7 +5,7 @@ Base implementation for dimensionality reduction feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -303,7 +303,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
         return algorithm, dimension, source_features, algo_options
 
     @classmethod
-    def _extract_dim_reduction_params(cls, feature: Feature) -> tuple[Optional[str], Optional[int], Options]:
+    def _extract_dim_reduction_params(cls, feature: Feature) -> tuple[str | None, int | None, Options]:
         """
         Extract dimensionality reduction algorithm, dimension, and options from a feature.
 

--- a/mloda_plugins/feature_group/experimental/dynamic_feature_group_factory/dynamic_feature_group_factory.py
+++ b/mloda_plugins/feature_group/experimental/dynamic_feature_group_factory/dynamic_feature_group_factory.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Options
 from mloda.user import FeatureName
@@ -213,13 +213,13 @@ class DynamicFeatureGroupCreator:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if "match_feature_group_criteria" in properties:
                 return properties["match_feature_group_criteria"](cls, feature_name, options, data_access_collection)  # type: ignore[no-any-return]
             return super(new_class, cls).match_feature_group_criteria(feature_name, options, data_access_collection)  # type: ignore[misc, arg-type, no-any-return]
 
-        def input_data(cls) -> Optional[BaseInputData]:  # type: ignore[no-untyped-def]
+        def input_data(cls) -> BaseInputData | None:  # type: ignore[no-untyped-def]
             if "input_data" in properties:
                 return properties["input_data"]()  # type: ignore[no-any-return]
             return super(new_class, cls).input_data()  # type: ignore[misc, arg-type, no-any-return]
@@ -241,7 +241,7 @@ class DynamicFeatureGroupCreator:
                 return
             super(new_class, cls).validate_output_features(data, features)  # type: ignore[misc, arg-type]
 
-        def artifact(cls) -> Optional[type[Any]]:  # type: ignore[no-untyped-def]
+        def artifact(cls) -> type[Any] | None:  # type: ignore[no-untyped-def]
             if "artifact" in properties:
                 return properties["artifact"]()  # type: ignore[no-any-return]
             return super(new_class, cls).artifact()  # type: ignore[misc, arg-type, no-any-return]
@@ -251,22 +251,22 @@ class DynamicFeatureGroupCreator:
                 return properties["compute_framework_rule"]()  # type: ignore[no-any-return]
             return super(new_class, cls).compute_framework_rule()  # type: ignore[misc, arg-type, no-any-return]
 
-        def return_data_type_rule(cls, feature: Any) -> Optional[DataType]:  # type: ignore[no-untyped-def]
+        def return_data_type_rule(cls, feature: Any) -> DataType | None:  # type: ignore[no-untyped-def]
             if "return_data_type_rule" in properties:
                 return properties["return_data_type_rule"](cls, feature)  # type: ignore[no-any-return]
             return super(new_class, cls).return_data_type_rule(feature)  # type: ignore[misc, arg-type, no-any-return]
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:  # type: ignore[no-untyped-def]
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:  # type: ignore[no-untyped-def]
             if "input_features" in properties:
                 return properties["input_features"](self, options, feature_name)  # type: ignore[no-any-return]
             return super(new_class, self).input_features(options, feature_name)  # type: ignore[misc, arg-type, no-any-return]
 
-        def index_columns(cls) -> Optional[list[Index]]:  # type: ignore[no-untyped-def]
+        def index_columns(cls) -> list[Index] | None:  # type: ignore[no-untyped-def]
             if "index_columns" in properties:
                 return properties["index_columns"]()  # type: ignore[no-any-return]
             return super(new_class, cls).index_columns()  # type: ignore[misc, arg-type, no-any-return]
 
-        def supports_index(cls, index: Index) -> Optional[bool]:  # type: ignore[no-untyped-def]
+        def supports_index(cls, index: Index) -> bool | None:  # type: ignore[no-untyped-def]
             if "supports_index" in properties:
                 return properties["supports_index"](cls, index)  # type: ignore[no-any-return]
             return super(new_class, cls).supports_index(index)  # type: ignore[misc, arg-type, no-any-return]

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -5,7 +5,7 @@ Base implementation for forecasting feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.provider import BaseArtifact
@@ -184,7 +184,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         """
         return ForecastingArtifact
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Extract source feature and time filter feature from either configuration-based options or string parsing."""
 
         source_feature: str | None = None
@@ -443,7 +443,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         return True
 
     @classmethod
-    def _extract_forecast_params(cls, feature: Feature) -> tuple[Optional[str], Optional[int], Optional[str]]:
+    def _extract_forecast_params(cls, feature: Feature) -> tuple[str | None, int | None, str | None]:
         """
         Extract forecast-specific parameters (algorithm, horizon, time_unit) from a feature.
 
@@ -508,8 +508,8 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         time_unit: str,
         in_features: list[str],
         time_filter_feature: str,
-        model_artifact: Optional[Any] = None,
-    ) -> tuple[Any, Optional[Any]]:
+        model_artifact: Any | None = None,
+    ) -> tuple[Any, Any | None]:
         """
         Method to perform the forecasting. Should be implemented by subclasses.
 
@@ -541,8 +541,8 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         time_unit: str,
         in_features: list[str],
         time_filter_feature: str,
-        model_artifact: Optional[Any] = None,
-    ) -> tuple[Any, Any, Any, Optional[Any]]:
+        model_artifact: Any | None = None,
+    ) -> tuple[Any, Any, Any, Any | None]:
         """
         Method to perform forecasting and return point forecast plus confidence intervals.
 

--- a/mloda_plugins/feature_group/experimental/forecasting/forecasting_artifact.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/forecasting_artifact.py
@@ -5,7 +5,7 @@ Artifact for storing trained forecasting models.
 import json
 import pickle  # nosec
 import base64
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseArtifact
 from mloda.provider import FeatureSet
@@ -94,7 +94,7 @@ class ForecastingArtifact(BaseArtifact):
         return artifact
 
     @classmethod
-    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Optional[Any]:
+    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Any | None:
         """
         Save the forecasting model artifact.
 
@@ -108,7 +108,7 @@ class ForecastingArtifact(BaseArtifact):
         return cls._serialize_artifact(artifact)
 
     @classmethod
-    def custom_loader(cls, features: FeatureSet) -> Optional[Any]:
+    def custom_loader(cls, features: FeatureSet) -> Any | None:
         """
         Load the forecasting model artifact.
 

--- a/mloda_plugins/feature_group/experimental/forecasting/pandas.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for forecasting feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from datetime import datetime, timedelta
 
@@ -118,7 +118,7 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
         time_unit: str,
         in_features: list[str],
         time_filter_feature: str,
-        model_artifact: Optional[Any] = None,
+        model_artifact: Any | None = None,
     ) -> tuple[pd.Series, dict[str, Any]]:
         """
         Perform forecasting using scikit-learn models.
@@ -459,7 +459,7 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
         return future_df
 
     @classmethod
-    def _train_model(cls, X: pd.DataFrame, y: pd.Series, algorithm: str) -> tuple[Any, Optional[StandardScaler]]:
+    def _train_model(cls, X: pd.DataFrame, y: pd.Series, algorithm: str) -> tuple[Any, StandardScaler | None]:
         """
         Train a forecasting model using the specified algorithm.
 
@@ -507,7 +507,7 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
         time_unit: str,
         in_features: list[str],
         time_filter_feature: str,
-        model_artifact: Optional[Any] = None,
+        model_artifact: Any | None = None,
     ) -> tuple[pd.Series, pd.Series, pd.Series, dict[str, Any]]:
         """
         Perform forecasting with confidence intervals.

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -5,7 +5,7 @@ Base implementation for geo distance feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -124,7 +124,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         ),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Extract point features from either configuration-based options or string parsing."""
 
         # Try string-based parsing first
@@ -235,7 +235,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return distance_type, source_features[0], source_features[1]
 
     @classmethod
-    def _extract_distance_unit(cls, feature: Feature) -> Optional[str]:
+    def _extract_distance_unit(cls, feature: Feature) -> str | None:
         """
         Extract distance unit (distance type) from a feature.
 

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -5,7 +5,7 @@ Base implementation for node centrality feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -272,7 +272,7 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return cls._extract_operation_and_source_feature(feature, cls._extract_centrality_type, "centrality type")
 
     @classmethod
-    def _extract_centrality_type(cls, feature: Feature) -> Optional[str]:
+    def _extract_centrality_type(cls, feature: Feature) -> str | None:
         """
         Extract centrality type from a feature.
 
@@ -306,7 +306,7 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         centrality_type: str,
         node_feature: str,
         graph_type: str = "undirected",
-        weight_column: Optional[str] = None,
+        weight_column: str | None = None,
     ) -> Any:
         """
         Method to calculate the centrality. Should be implemented by subclasses.

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for node centrality feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 
 try:
@@ -103,7 +103,7 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         centrality_type: str,
         node_feature: str,
         graph_type: str = "undirected",
-        weight_column: Optional[str] = None,
+        weight_column: str | None = None,
     ) -> pd.Series:
         """
         Calculate centrality metrics for nodes in a graph.
@@ -165,7 +165,7 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         nodes: np.ndarray[Any, Any],
         source_col: str,
         target_col: str,
-        weight_column: Optional[str] = None,
+        weight_column: str | None = None,
         graph_type: str = "undirected",
     ) -> pd.DataFrame:
         """

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -202,7 +202,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Return the artifact class for sklearn encoder persistence."""
         return SklearnArtifact
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Extract source feature from either configuration-based options or string parsing."""
 
         # Try string-based parsing first
@@ -307,7 +307,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return cls._extract_operation_and_source_feature(feature, cls._extract_encoder_type, "encoder type")
 
     @classmethod
-    def _extract_encoder_type(cls, feature: Feature) -> Optional[str]:
+    def _extract_encoder_type(cls, feature: Feature) -> str | None:
         """
         Extract encoder type from a feature.
 

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -129,7 +129,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Pipelines support variable number of in_features
     IN_FEATURE_SEPARATOR = ","  # Use comma for multiple source features
     MIN_IN_FEATURES = 1
-    MAX_IN_FEATURES: Optional[int] = None  # Unlimited
+    MAX_IN_FEATURES: int | None = None  # Unlimited
 
     # Hooks calculate_feature calls: _check_source_features_exist, _add_result_to_data.
     REQUIRED_COLUMNWISE_HOOKS = COLUMNWISE_HOOKS
@@ -139,7 +139,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Return the artifact class for sklearn pipeline persistence."""
         return SklearnArtifact
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Extract source features from either configuration-based options or string parsing."""
 
         # Try string-based parsing first
@@ -171,7 +171,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[Any] = None,
+        data_access_collection: Any | None = None,
     ) -> bool:
         """Reject the one rule a spec cannot express: PIPELINE_NAME and PIPELINE_STEPS are mutually exclusive.
 
@@ -260,7 +260,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return pipeline_name, source_features
 
     @classmethod
-    def _extract_pipeline_name(cls, feature: Feature) -> Optional[str]:
+    def _extract_pipeline_name(cls, feature: Feature) -> str | None:
         """
         Extract pipeline name from a feature.
 

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -195,7 +195,7 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return cls._extract_operation_and_source_feature(feature, cls._extract_scaler_type, "scaler type")
 
     @classmethod
-    def _extract_scaler_type(cls, feature: Feature) -> Optional[str]:
+    def _extract_scaler_type(cls, feature: Feature) -> str | None:
         """
         Extract scaler type from a feature.
 

--- a/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
@@ -7,7 +7,7 @@ import base64
 import logging
 import tempfile
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.provider import BaseArtifact
@@ -123,7 +123,7 @@ class SklearnArtifact(BaseArtifact):
         return artifact
 
     @classmethod
-    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Optional[Any]:
+    def custom_saver(cls, features: FeatureSet, artifact: Any) -> Any | None:
         """
         Save sklearn artifacts to file(s).
 
@@ -187,7 +187,7 @@ class SklearnArtifact(BaseArtifact):
         return storage_dir / filename
 
     @classmethod
-    def custom_loader(cls, features: FeatureSet) -> Optional[Any]:
+    def custom_loader(cls, features: FeatureSet) -> Any | None:
         """
         Load sklearn artifacts from file(s).
 
@@ -243,7 +243,7 @@ class SklearnArtifact(BaseArtifact):
             return None
 
     @classmethod
-    def load_sklearn_artifact(cls, features: FeatureSet, artifact_key: str) -> Optional[dict[str, Any]]:
+    def load_sklearn_artifact(cls, features: FeatureSet, artifact_key: str) -> dict[str, Any] | None:
         """
         Helper method to load a specific sklearn artifact by key.
 

--- a/mloda_plugins/feature_group/experimental/source_input_feature.py
+++ b/mloda_plugins/feature_group/experimental/source_input_feature.py
@@ -38,7 +38,7 @@ Further, it allows defining:
         ```
 """
 
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
 from mloda.user import FeatureName
@@ -88,7 +88,7 @@ class SourceInputFeature(FeatureGroup):
         - merges:  Specifies merge operations between features.
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return SourceInputFeatureComposite.input_features(options, feature_name)
 
 
@@ -109,12 +109,12 @@ class SourceTuple(NamedTuple):
     """
 
     feature_name: str
-    source_class: Optional[type[FeatureGroup | str]] = None
-    source_value: Optional[str] = None
-    left_link: Optional[tuple[type[FeatureGroup], str | Index]] = None
-    right_link: Optional[tuple[type[FeatureGroup], str | Index]] = None
-    join_type: Optional[JoinType] = None
-    merge_index: Optional[str | Index] = None
+    source_class: type[FeatureGroup | str] | None = None
+    source_value: str | None = None
+    left_link: tuple[type[FeatureGroup], str | Index] | None = None
+    right_link: tuple[type[FeatureGroup], str | Index] | None = None
+    join_type: JoinType | None = None
+    merge_index: str | Index | None = None
 
 
 class SourceInputFeatureComposite:
@@ -123,7 +123,7 @@ class SourceInputFeatureComposite:
     """
 
     @classmethod
-    def input_features(cls, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(cls, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """
         Retrieves the set of input features based on the provided options.
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -5,7 +5,7 @@ Base implementation for text cleaning feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -134,7 +134,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return cls._extract_operation_and_source_feature(feature, cls._extract_cleaning_operations, "operations")
 
     @classmethod
-    def _extract_cleaning_operations(cls, feature: Feature) -> Optional[tuple[Any, Any]]:
+    def _extract_cleaning_operations(cls, feature: Feature) -> tuple[Any, Any] | None:
         """Cleaning operations from feature options (both paths), or None when absent."""
         operations = feature.options.get(cls.CLEANING_OPERATIONS)
         return operations if operations is not None else None

--- a/mloda_plugins/feature_group/experimental/time_reference_mixin.py
+++ b/mloda_plugins/feature_group/experimental/time_reference_mixin.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
 
 from mloda.core.abstract_plugins.components.contract.comparison_contract import (
     ColumnSemantics,
@@ -32,7 +31,7 @@ class TimeReferenceMixin:
     )
 
     @classmethod
-    def get_reference_time_column(cls, options: Optional[Options] = None) -> str:
+    def get_reference_time_column(cls, options: Options | None = None) -> str:
         """
         Get the reference time column name from options or use the default.
 

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -133,7 +133,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
     REQUIRED_COLUMNWISE_HOOKS = COLUMN_DISCOVERY_HOOKS
 
     # Custom input_features needed to add time_filter_feature
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Extract source feature from either configuration-based options or string parsing."""
 
         source_feature: str | None = None
@@ -173,7 +173,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         return True
 
     @classmethod
-    def _extract_time_window_params(cls, feature: Feature) -> tuple[Optional[str], Optional[int], Optional[str]]:
+    def _extract_time_window_params(cls, feature: Feature) -> tuple[str | None, int | None, str | None]:
         """
         Extract time window parameters (window_function, window_size, time_unit) from a feature.
 
@@ -417,7 +417,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         window_size: int,
         time_unit: str,
         in_features: list[str],
-        time_filter_feature: Optional[str] = None,
+        time_filter_feature: str | None = None,
     ) -> Any:
         """
         Method to perform the time window operation. Should be implemented by subclasses.

--- a/mloda_plugins/feature_group/experimental/time_window/pandas.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for time window feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -77,7 +77,7 @@ class PandasTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         window_size: int,
         time_unit: str,
         in_features: list[str],
-        time_filter_feature: Optional[str] = None,
+        time_filter_feature: str | None = None,
     ) -> Any:
         """
         Perform the time window operation using Pandas rolling window functions.

--- a/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
@@ -4,7 +4,7 @@ PyArrow implementation for time window feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 import bisect
 
 import pyarrow as pa
@@ -84,7 +84,7 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         window_size: int,
         time_unit: str,
         in_features: list[str],
-        time_filter_feature: Optional[str] = None,
+        time_filter_feature: str | None = None,
     ) -> pa.Array:
         """
         Perform the time window operation using PyArrow compute functions.

--- a/mloda_plugins/feature_group/input_data/read_db_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_db_feature.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
@@ -14,7 +14,7 @@ class ReadDBFeature(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadDB()
 
     @classmethod

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 from mloda.provider import BaseInputData, FeatureSet, PropertySpec
 from mloda.user import DataAccessCollection, Options
@@ -132,7 +132,7 @@ class ReadDocument(BaseInputData):
         cls,
         data_accesses: list[str],
         feature_names: list[str],
-        document_suffixes: Optional["frozenset[str]"] = None,
+        document_suffixes: frozenset[str] | None = None,
     ) -> Any:
         try:
             suffix = cls.suffix()
@@ -152,7 +152,7 @@ class ReadDocument(BaseInputData):
         return None
 
     @classmethod
-    def _document_file_matches(cls, path: str, document_suffixes: "frozenset[str]") -> bool:
+    def _document_file_matches(cls, path: str, document_suffixes: frozenset[str]) -> bool:
         if not cls._has_suffix():
             return False
         if not path.endswith(cls.suffix()):
@@ -162,7 +162,7 @@ class ReadDocument(BaseInputData):
         return True
 
     @classmethod
-    def _is_structured_suffix(cls, filename: str, document_suffixes: "frozenset[str]") -> bool:
+    def _is_structured_suffix(cls, filename: str, document_suffixes: frozenset[str]) -> bool:
         """Return True if filename has a structured suffix not overridden by document_suffixes."""
         for s in ReadFile._structured_suffixes:
             if filename.endswith(s) and s not in document_suffixes:

--- a/mloda_plugins/feature_group/input_data/read_document_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_document_feature.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
@@ -14,7 +14,7 @@ class ReadDocumentFeature(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadDocument()
 
     @classmethod

--- a/mloda_plugins/feature_group/input_data/read_file_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_file_feature.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
@@ -15,7 +15,7 @@ class ReadFileFeature(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadFile()
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ follow_imports = "skip"
 line-length = 120
 
 [tool.ruff.lint]
-extend-select = ["UP006", "UP007"]
+extend-select = ["UP006", "UP007", "UP045"]
 
 [tool.ruff.lint.per-file-ignores]
 # marimo notebook idioms static linting can't follow (cell imports, re-exports, cross-cell names).

--- a/tests/test_core/test_abstract_plugins/test_abstract_base_matcher.py
+++ b/tests/test_core/test_abstract_plugins/test_abstract_base_matcher.py
@@ -8,7 +8,7 @@ and aborts resolution for the whole run. Such a base must simply not match.
 
 import inspect
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -39,7 +39,7 @@ class ConcreteRootFeatureGroup(FeatureGroup):
     """Concrete root feature group: no input features, creates its own data."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"issue692_root_feature"})
 
     @classmethod
@@ -59,7 +59,7 @@ class ConcreteSubclassOfAbstractBase(AbstractBaseWithAbstractMethod):
         return data
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"issue692_subclass_root_feature"})
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_abstract_feature_group.py
+++ b/tests/test_core/test_abstract_plugins/test_abstract_feature_group.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import numpy as np
 import pytest
 from mloda.user import DataAccessCollection
@@ -15,7 +14,7 @@ class BaseTestFeatureGroup1(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if "BaseTestFeature" in str(feature_name) and "1" in str(feature_name):
             return True
@@ -28,20 +27,20 @@ class BaseTestFeatureGroup2(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if "BaseTestFeature" in str(feature_name) and "2" in str(feature_name):
             return True
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """This function should return the input features for the feature group
         if this feature is dependent on other features.
         Else, return None"""
         return {Feature.str_of("BaseTestFeature1"), Feature.int32_of("BaseTestFeature1")}
 
     @classmethod
-    def return_data_type_rule(cls, feature: Feature) -> Optional[DataType]:
+    def return_data_type_rule(cls, feature: Feature) -> DataType | None:
         if "BaseTestFeature" in feature.name and "2" in feature.name:
             return DataType.STRING
         return None

--- a/tests/test_core/test_abstract_plugins/test_class_identity.py
+++ b/tests/test_core/test_abstract_plugins/test_class_identity.py
@@ -7,7 +7,7 @@ rather than name-based identity. This ensures that dynamically created classes w
 `__name__` but different domains (or different class objects) are treated as distinct entities.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -30,7 +30,7 @@ def create_feature_group_class(name: str, domain: Domain) -> type:
         def get_domain(cls) -> Domain:
             return domain
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
             return None
 
     DynamicFeatureGroup.__name__ = name
@@ -163,7 +163,7 @@ def create_domain_feature_group(domain_name: str, feature_value: int) -> type[Fe
             return domain
 
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"domain_feature"})
 
         @classmethod

--- a/tests/test_core/test_abstract_plugins/test_column_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_column_ordering.py
@@ -1,6 +1,6 @@
 """Tests for column ordering in identify_naming_convention() and mlodaAPI."""
 
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -74,7 +74,7 @@ class SimpleTestFeature(FeatureGroup):
     """Simple test feature for API tests."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"SimpleTestFeature"})
 
     @classmethod
@@ -341,7 +341,7 @@ class MultiFeatureGroup(FeatureGroup):
     """Test feature group that supports 5 features (FeatureA through FeatureE)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"FeatureA", "FeatureB", "FeatureC", "FeatureD", "FeatureE"})
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -1,7 +1,7 @@
 """Tests for FeatureChainParserMixin."""
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -87,7 +87,7 @@ class _HiddenAttribute:
     def __set_name__(self, owner: type, name: str) -> None:
         self.name = name
 
-    def __get__(self, obj: object, objtype: Optional[type] = None) -> None:
+    def __get__(self, obj: object, objtype: type | None = None) -> None:
         raise AttributeError(self.name)
 
 
@@ -142,7 +142,7 @@ class MockFeatureGroupSingleInFeatureCustomReason(FeatureChainParserMixin):
     }
 
     @classmethod
-    def _in_feature_count_reason(cls, feature_name: str | FeatureName, count: int) -> Optional[str]:
+    def _in_feature_count_reason(cls, feature_name: str | FeatureName, count: int) -> str | None:
         """Custom arity wording that must win over the mixin's generic MIN/MAX message."""
         if count != 1:
             return f"{cls.__name__} needs exactly one input column; got {count}."

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -9,7 +9,7 @@ All fixture names carry an "esc732" marker so they cannot collide with other tes
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -148,7 +148,7 @@ class DirectParserOverrideFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         name = str(feature_name)
         if options.get(PIPELINE_KEY) is None and "esc732_pipeline_" not in name:
@@ -160,7 +160,7 @@ class DirectParserOverrideFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             prefix_patterns=[cls.PREFIX_PATTERN],
         )
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -172,11 +172,11 @@ class NeighborFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == PIPELINE_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -203,7 +203,7 @@ class RaisingTypeErrorValidatorFeatureGroup(FeatureChainParserMixin, FeatureGrou
         ),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -221,7 +221,7 @@ class RaisingAttributeErrorValidatorFeatureGroup(FeatureChainParserMixin, Featur
         )
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -239,7 +239,7 @@ class RaisingKeyErrorValidatorFeatureGroupEsc763(FeatureChainParserMixin, Featur
         )
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -256,7 +256,7 @@ class RaisingKeyErrorGuardFeatureGroupEsc763(FeatureChainParserMixin, FeatureGro
         )
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -283,7 +283,7 @@ class RaisingKeyErrorRequiredWhenFeatureGroupEsc763(FeatureChainParserMixin, Fea
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         name = str(feature_name)
         # Classmethod is mandatory: required_when forbids a staticmethod matcher. Claim only this
@@ -297,7 +297,7 @@ class RaisingKeyErrorRequiredWhenFeatureGroupEsc763(FeatureChainParserMixin, Fea
             prefix_patterns=[cls.PREFIX_PATTERN],
         )
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -309,11 +309,11 @@ class RequiredWhenNeighborFeatureGroupEsc763(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == REQUIRED_WHEN_FEATURE_ESC763
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -265,10 +265,10 @@ class ConditionalRequiredFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     }
 
     @classmethod
-    def input_data(cls) -> Optional[DataCreator]:
+    def input_data(cls) -> DataCreator | None:
         return DataCreator({"result_feature"})
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
@@ -11,7 +11,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 import pytest
 
@@ -109,7 +109,7 @@ def _raise(exc: BaseException) -> Any:
     raise exc
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -128,7 +128,7 @@ def _make_probe_fg(answer: Callable[[], Any]) -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> Any:  # Any, not bool: a non-bool out of a `-> bool` hook is exactly what the helper coerces.
             return answer()
 
@@ -139,7 +139,7 @@ def _make_probe_fg(answer: Callable[[], Any]) -> type[FeatureGroup]:
 class _OutcomeSnapshot:
     """Plain-data readout of one call_match_hook call. Holds no class and no exception object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     escaped_is_the_raised_object: bool
     is_the_result_type: bool
     matched_is_true: bool
@@ -149,14 +149,14 @@ class _OutcomeSnapshot:
     returned_shown: str
     error_is_none: bool
     error_is_the_raised_object: bool
-    error_type: Optional[str]
-    error_message: Optional[str]
+    error_type: str | None
+    error_message: str | None
 
 
 def _drive(
     answer: Callable[[], Any],
     returned: Any = _NOTHING,
-    raised: Optional[BaseException] = None,
+    raised: BaseException | None = None,
 ) -> _OutcomeSnapshot:
     """Call the helper against one throwaway group and read the outcome out as plain data.
 
@@ -165,8 +165,8 @@ def _drive(
     """
     fg = _make_probe_fg(answer)
     outcome: Any = None
-    escaped: Optional[BaseException] = None
-    error: Optional[BaseException] = None
+    escaped: BaseException | None = None
+    error: BaseException | None = None
     matched: Any = None
     raw: Any = None
     try:
@@ -296,19 +296,19 @@ class TestTheHelperContainsARaise:
 class _ContainedErrorSnapshot:
     """Plain-data readout of the exception one contained raise hands back. Holds no exception object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     is_the_raised_object: bool
     has_traceback: bool
-    type_name: Optional[str]
-    message: Optional[str]
+    type_name: str | None
+    message: str | None
     is_a_property_value_rejection: bool
 
 
 def _drive_contained_error(marker: Exception) -> _ContainedErrorSnapshot:
     """Contain one raise and read the exception the outcome carries, traceback included, out as plain data."""
     fg = _make_probe_fg(partial(_raise, marker))
-    outcome: Optional[MatchHookOutcome] = None
-    error: Optional[Exception] = None
+    outcome: MatchHookOutcome | None = None
+    error: Exception | None = None
     try:
         outcome, escaped = _capture(partial(call_match_hook, fg, PROBE_FEATURE, Options(), None))
         error = None if outcome is None else outcome.error
@@ -391,7 +391,7 @@ def test_the_filter_seam_calls_the_helper_once_per_filter(monkeypatch: pytest.Mo
     global_filter.add_filter(FILTER_FEATURE_A, FilterType.EQUAL, {"value": 1})
     global_filter.add_filter(FILTER_FEATURE_B, FilterType.EQUAL, {"value": 2})
     matched: Any = None
-    escaped: Optional[str] = None
+    escaped: str | None = None
     names: tuple[str, ...] = ()
     try:
         matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, Feature(HOST_FEATURE), None))
@@ -419,7 +419,7 @@ def test_the_resolution_seam_calls_the_helper_once_per_candidate(monkeypatch: py
     fg = _make_probe_fg(lambda: True)
     identifier = IdentifyFeatureGroupClass()
     verdict: Any = None
-    escaped: Optional[str] = None
+    escaped: str | None = None
     try:
         verdict, escaped = _capture(
             partial(identifier._filter_feature_group_by_criteria, fg, Feature(PROBE_FEATURE), None)

--- a/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_base_merge_engine.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_base_merge_engine.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 import pandas as pd
 import pandas.testing as pdt
-from typing import Any, Optional
+from typing import Any
 from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -23,7 +23,7 @@ from tests.test_plugins.compute_framework.test_tooling.merge_link import make_me
 
 class AppendMergeTestFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={f"{cls.get_class_name()}{i}" for i in range(0, 99)})
 
     @classmethod
@@ -43,7 +43,7 @@ class SecondAppendMergeTestFeature(AppendMergeTestFeature):
 
 
 class GroupedAppendMergeTestFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         def add_run_id(some_uuid: UUID, right: int = 0) -> tuple[str]:
             return (f"{some_uuid}{str(cnt + right)}",)
 
@@ -80,7 +80,7 @@ class GroupedAppendMergeTestFeature(FeatureGroup):
 
 
 class Call2GroupedAppendMergeTestFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         iteration = options.get("iteration")
 
         features = frozenset({f"AppendMergeTestFeature{i}" for i in range(iteration)})

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -517,7 +517,7 @@ class TestReaderOptionToleratesNoneOptions:
     def test_none_options_return_the_declared_default(self) -> None:
         """With no Options at all, the declared fallback applies exactly as for an absent key."""
         parent, _, _ = _decl_family()
-        none_options: Any = None  # the accessor's contract widens to Optional[Options]
+        none_options: Any = None  # the accessor's contract widens to Options | None
 
         assert parent.reader_option("rod_key_a", none_options) == "parent_a"
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_validators/test_datatype_validator.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_validators/test_datatype_validator.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable
 
 import pytest
 import pyarrow as pa
@@ -12,8 +12,8 @@ from mloda.user import Feature
 from mloda.provider import FeatureSet
 
 
-def _arrow_resolver(table: pa.Table) -> Callable[[str], Optional[DataType]]:
-    def resolve(col: str) -> Optional[DataType]:
+def _arrow_resolver(table: pa.Table) -> Callable[[str], DataType | None]:
+    def resolve(col: str) -> DataType | None:
         if col not in table.schema.names:
             return None
         return DataType.from_arrow_type_safe(table.schema.field(col).type)
@@ -192,7 +192,7 @@ class TestValidateEnforcesOnPandas:
             DataTypeValidator.validate(feature_set, lambda col: fw._extract_column_data_type(df, col))
 
     def test_typed_feature_group_runs_through_run_all_on_pandas_matching_passes(self) -> None:
-        from typing import Any, Optional
+        from typing import Any
 
         import pandas as pd
 
@@ -205,7 +205,7 @@ class TestValidateEnforcesOnPandas:
 
         class _Src(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[Any]:
+            def input_data(cls) -> Any | None:
                 return DataCreator({"price"})
 
             @classmethod
@@ -248,7 +248,7 @@ class TestValidateEnforcesOnPandas:
         assert df["price_typed_match"].tolist() == [2.0, 4.0, 6.0]
 
     def test_typed_feature_group_runs_through_run_all_on_pandas_mismatch_raises(self) -> None:
-        from typing import Any, Optional
+        from typing import Any
 
         import pandas as pd
         import pytest as _pytest
@@ -262,7 +262,7 @@ class TestValidateEnforcesOnPandas:
 
         class _Src(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[Any]:
+            def input_data(cls) -> Any | None:
                 return DataCreator({"price"})
 
             @classmethod

--- a/tests/test_core/test_abstract_plugins/test_eq_notimplemented.py
+++ b/tests/test_core/test_abstract_plugins/test_eq_notimplemented.py
@@ -5,7 +5,7 @@ when compared to incompatible types. Per Python data model conventions, __eq__
 should return NotImplemented (which Python translates to False) rather than raising.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -25,7 +25,7 @@ class _EqTestFeatureGroup(FeatureGroup):
     discovers it via FeatureGroup.__subclasses__().
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
         return None
 
 

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_format_feature_group_class.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_format_feature_group_class.py
@@ -2,8 +2,6 @@
 production (engine.py, execution_plan.py, feature_group_step.py) after the plural
 format_feature_group_classes was removed."""
 
-from typing import Optional
-
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
@@ -13,7 +11,7 @@ from mloda.user import Feature, Options
 class SampleFeatureGroupAlpha(FeatureGroup):
     """A test feature group for formatting tests."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -24,7 +22,7 @@ class SampleFeatureGroupWithDomain(FeatureGroup):
     def get_domain(cls) -> Domain:
         return Domain("sales")
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_is_root_raise_log_no_traceback.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_is_root_raise_log_no_traceback.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Optional
 
 import pytest
 
@@ -35,7 +34,7 @@ class IsRootLogProbeFG(FeatureGroup):
     test pins it, so the registry-pollution guard would fire on the leak instead of the log contract.
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         raise IsRootProbeExploded(ISROOT_MESSAGE)
 
 

--- a/tests/test_core/test_abstract_plugins/test_multi_column_auto_resolution.py
+++ b/tests/test_core/test_abstract_plugins/test_multi_column_auto_resolution.py
@@ -7,7 +7,7 @@ This test shows the complete flow of:
 3. Chained processor works with consumer's single-column output
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -30,7 +30,7 @@ class MultiColumnTestDataCreator(FeatureGroup):
     """Test data creator providing source data for multi-column tests."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         """Return a DataCreator with the supported feature names."""
         return DataCreator({"source_data"})
 
@@ -65,7 +65,7 @@ class MultiColumnProducer(FeatureGroup):
         """Explicitly support base_feature."""
         return {"base_feature"}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Requires source_data as input."""
         return {Feature("source_data")}
 
@@ -118,7 +118,7 @@ class MultiColumnConsumer(FeatureGroup):
         """Explicitly support consumed_feature."""
         return {"consumed_feature"}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """
         Requires base_feature as input (without ~N suffix).
 
@@ -187,7 +187,7 @@ class ChainedProcessor(FeatureGroup):
         """Explicitly support chained_feature."""
         return {"chained_feature"}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Requires consumed_feature as input."""
         return {Feature("consumed_feature")}
 

--- a/tests/test_core/test_abstract_plugins/test_n_result_columns.py
+++ b/tests/test_core/test_abstract_plugins/test_n_result_columns.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
 from mloda.user import FeatureName
@@ -17,7 +17,7 @@ class NFeatureNameBase(FeatureGroup):
 
 
 class NFeatureConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.not_typed("NFeatureNameBase")}
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_e2e.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_e2e.py
@@ -10,7 +10,7 @@ Parallel-safety: assertions are membership-based and the feature name is unique
 to this module; the autouse conftest fixture restores the default registry.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Feature, PluginCollector, PluginLoader, mloda, register_plugin
@@ -22,7 +22,7 @@ class StrictE2ERunAllFeatureGroup(FeatureGroup):
     """Root feature group producing one columnar feature for the strict e2e run."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({FEAT})
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_extenders.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_extenders.py
@@ -22,7 +22,7 @@ parallel-safety.
 """
 
 import logging
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import pytest
 
@@ -168,14 +168,14 @@ class _RecordingRunner:
     """Stand-in for ExecutionOrchestrator that records what __enter__ receives."""
 
     def __init__(self) -> None:
-        self.received_extenders: Optional[set[Extender]] = None
+        self.received_extenders: set[Extender] | None = None
 
     def __enter__(
         self,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
-        function_extender: Optional[set[Extender]] = None,
-        api_data: Optional[dict[str, Any]] = None,
-        artifacts: Optional[dict[str, Any]] = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
+        function_extender: set[Extender] | None = None,
+        api_data: dict[str, Any] | None = None,
+        artifacts: dict[str, Any] | None = None,
         run_context: RunContext | None = None,
     ) -> None:
         self.received_extenders = function_extender

--- a/tests/test_core/test_abstract_plugins/test_set_feature_name.py
+++ b/tests/test_core/test_abstract_plugins/test_set_feature_name.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import DataAccessCollection
 from mloda.user import Feature
@@ -30,7 +30,7 @@ class ATestSetFeatureNameBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -40,7 +40,7 @@ class ATestSetFeatureNameBase(FeatureGroup):
 
 
 class ATestSetFeatureNameFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.int64_of("ATestSetFeatureNameBase1"), Feature.int64_of("ATestSetFeatureNameBase2")}
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
+++ b/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
@@ -13,7 +13,7 @@ Expected Behavior:
 - Feature("base~0") returns ONLY base~0 column (new capability)
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,7 @@ class SubColumnTestDataCreator(FeatureGroup):
     """Test data creator providing source data for sub-column tests."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"source_data"})
 
     @classmethod
@@ -67,7 +67,7 @@ class MultiColumnProducerForSubColumnTest(FeatureGroup):
     def feature_names_supported(cls) -> set[str]:
         return {"base_feature"}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("source_data")}
 
     @classmethod
@@ -97,7 +97,7 @@ class SubColumnConsumer(FeatureGroup):
     def feature_names_supported(cls) -> set[str]:
         return {"sub_column_consumer_output"}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("base_feature~1")}
 
     @classmethod
@@ -385,7 +385,7 @@ class TestSubColumnIntegration:
             def feature_names_supported(cls) -> set[str]:
                 return {"validating_consumer_output"}
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature("base_feature~1")}
 
             @classmethod
@@ -449,7 +449,7 @@ class TestSubColumnIntegration:
             def feature_names_supported(cls) -> set[str]:
                 return {"multi_sub_column_consumer_output"}
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature("base_feature~0"), Feature("base_feature~2")}
 
             @classmethod
@@ -638,7 +638,7 @@ class TestSubColumnIntegration:
             def feature_names_supported(cls) -> set[str]:
                 return {"first_consumer_output"}
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature("base_feature~1")}
 
             @classmethod
@@ -658,7 +658,7 @@ class TestSubColumnIntegration:
             def feature_names_supported(cls) -> set[str]:
                 return {"second_consumer_output"}
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature("first_consumer_output")}
 
             @classmethod

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -11,7 +11,7 @@ in_features path, which bypasses FeatureConfig validation), invalid values are
 rejected with ValueError, and the schema advertises it.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -579,7 +579,7 @@ class ConfigScopeSourceA(FeatureGroup):
     """Source A: provides the shared "config_shared_token" plus "config_value_a"."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"config_shared_token", "config_value_a"})
 
     @classmethod
@@ -594,7 +594,7 @@ class ConfigScopeSourceB(FeatureGroup):
     """Source B: also provides the shared "config_shared_token" plus "config_value_b"."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"config_shared_token", "config_value_b"})
 
     @classmethod
@@ -663,7 +663,7 @@ class ConfigScopeAggregationSource(FeatureGroup):
     """Source data for the aggregated-family scope test."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"config_scope_sales"})
 
     @classmethod

--- a/tests/test_core/test_api/feature_config/test_feature_config_nested_modern_options.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_nested_modern_options.py
@@ -27,7 +27,7 @@ into a computed dependency.
 """
 
 import json
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -631,7 +631,7 @@ class NestedConfigEngineSource(FeatureGroup):
     """Root source: creates the raw column the innermost nested feature reads."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"cfg_nested_base"})
 
     @classmethod
@@ -646,7 +646,7 @@ class NestedConfigEngineDoubler(FeatureGroup):
     def feature_names_supported(cls) -> set[str]:
         return {"cfg_nested_doubled", "cfg_nested_outer"}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return set(options.get_in_features())
 
     @classmethod

--- a/tests/test_core/test_api/test_capability_run_all.py
+++ b/tests/test_core/test_api/test_capability_run_all.py
@@ -9,7 +9,7 @@ Both tests are expected to PASS against the already-merged capability behaviour;
 they lock the current end-to-end contract in place.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -33,7 +33,7 @@ class E2ECapRunAllFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({FEAT})
 
     @classmethod

--- a/tests/test_core/test_api/test_classmethod_consistency.py
+++ b/tests/test_core/test_api/test_classmethod_consistency.py
@@ -2,7 +2,7 @@
 
 import collections.abc
 import inspect
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 from mloda.core.api.request import mlodaAPI
@@ -15,7 +15,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 class ClassMethodFeature(FeatureGroup):
     """A simple feature for classmethod dispatch tests."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="cm_id", index=Index(("cm_id",))),
             Feature(name="cm_value", index=Index(("cm_id",))),

--- a/tests/test_core/test_api/test_diagnose.py
+++ b/tests/test_core/test_api/test_diagnose.py
@@ -17,7 +17,7 @@ leak into another module's candidate universe in the parallel suite.
 """
 
 import dataclasses
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -50,7 +50,7 @@ class DiagnoseSource_812(FeatureGroup):
     """Pandas root source providing the feature the consumer chains off."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({SOURCE_FEATURE_812})
 
     @classmethod
@@ -65,7 +65,7 @@ class DiagnoseSource_812(FeatureGroup):
 class DiagnoseConsumer_812(FeatureGroup):
     """Consumes the source feature, so the source becomes a derived input during recursion."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_FEATURE_812)}
 
     @classmethod
@@ -85,7 +85,7 @@ class DiagnoseConsumer_812(FeatureGroup):
 class DiagnoseRaisingInputs_812(FeatureGroup):
     """Resolves, but raises a plain ValueError during the planning recursion (not a resolution failure)."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         raise ValueError("diagnose planning boom 812")
 
     @classmethod

--- a/tests/test_core/test_api/test_plan_info.py
+++ b/tests/test_core/test_api/test_plan_info.py
@@ -47,7 +47,7 @@ import ast
 import dataclasses
 from collections import Counter
 from pathlib import Path
-from typing import Any, Literal, Optional, get_args, get_origin
+from typing import Any, Literal, get_args, get_origin
 from uuid import UUID
 
 import pandas as pd
@@ -89,7 +89,7 @@ class PlanInfoPandasSource(FeatureGroup):
     """Pandas root source feeding the chained aggregation request."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_sales", "plan_info_price"})
 
     @classmethod
@@ -105,7 +105,7 @@ class PlanInfoArrowSource(FeatureGroup):
     """PyArrow root source: forces a transform step into the pandas aggregation group."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_arrow_sales"})
 
     @classmethod
@@ -125,7 +125,7 @@ class PlanInfoNeverExecutes(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_never_executed"})
 
     @classmethod
@@ -141,7 +141,7 @@ class PlanInfoLeftSource(FeatureGroup):
     """Left side of the single-framework join scenario."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_jid", "plan_info_left_val"})
 
     @classmethod
@@ -153,7 +153,7 @@ class PlanInfoLeftSource(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("plan_info_jid",))]
 
 
@@ -161,7 +161,7 @@ class PlanInfoRightSource(FeatureGroup):
     """Right side of the single-framework join scenario."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_jid", "plan_info_right_val"})
 
     @classmethod
@@ -173,14 +173,14 @@ class PlanInfoRightSource(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("plan_info_jid",))]
 
 
 class PlanInfoJoinConsumer(FeatureGroup):
     """Consumes features from both join sides, which forces a join step into the plan."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("plan_info_left_val"), Feature("plan_info_right_val")}
 
     @classmethod
@@ -201,7 +201,7 @@ class PlanInfoCrossLeftPandas(FeatureGroup):
     """Left side of the cross-framework join scenario: pandas."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_xjid", "plan_info_xleft_val"})
 
     @classmethod
@@ -213,7 +213,7 @@ class PlanInfoCrossLeftPandas(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("plan_info_xjid",))]
 
 
@@ -225,7 +225,7 @@ class PlanInfoCrossRightArrow(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"plan_info_xjid", "plan_info_xright_val"})
 
     @classmethod
@@ -237,14 +237,14 @@ class PlanInfoCrossRightArrow(FeatureGroup):
         return {PyArrowTable}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("plan_info_xjid",))]
 
 
 class PlanInfoCrossConsumer(FeatureGroup):
     """Consumes one feature per side of the cross-framework join."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("plan_info_xleft_val"), Feature("plan_info_xright_val")}
 
     @classmethod
@@ -264,7 +264,7 @@ class PlanInfoCrossConsumer(FeatureGroup):
 class PlanInfoInvertedConsumer(FeatureGroup):
     """Consumes the same two join sides on PyArrow, which puts the merge destination on the declared right side."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("plan_info_xleft_val"), Feature("plan_info_xright_val")}
 
     @classmethod

--- a/tests/test_core/test_api/test_prepare_run.py
+++ b/tests/test_core/test_api/test_prepare_run.py
@@ -6,7 +6,7 @@ These tests define the contract for a two-phase execution model:
   2. run() - instance method that executes with fresh api_data, reusing the cached plan
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
 from mloda.user import mloda, mlodaAPI, Feature, PluginCollector
@@ -19,7 +19,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 class PrepareRunApiFeature(FeatureGroup):
     """A simple feature that consumes api data for prepare/run tests."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="api_id", index=Index(("api_id",))),
             Feature(name="api_value", index=Index(("api_id",))),
@@ -229,7 +229,7 @@ class _PrepareRunExtenderFeatureGroup(FeatureGroup):
     """Simple root feature group for pinning function_extender fallback between prepare() and run()."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_PFEXT_MARKER}_col"})
 
     @classmethod

--- a/tests/test_core/test_api/test_resolution_report.py
+++ b/tests/test_core/test_api/test_resolution_report.py
@@ -20,7 +20,7 @@ would leak into another module's candidate universe in the parallel suite.
 """
 
 import dataclasses
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import pandas as pd
@@ -60,7 +60,7 @@ class ResReportSource_811(FeatureGroup):
     """Pandas root source providing the feature the consumer chains off."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"res_report_sales"})
 
     @classmethod
@@ -75,7 +75,7 @@ class ResReportSource_811(FeatureGroup):
 class ResReportConsumer_811(FeatureGroup):
     """Consumes the source feature, so the source becomes a derived input during recursion."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("res_report_sales")}
 
     @classmethod
@@ -100,7 +100,7 @@ class ResReportCountingSource_811(FeatureGroup):
     """Root source whose match hook counts calls, proving resolution_report() does not re-match."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"res_report_counted_811"})
 
     @classmethod
@@ -108,7 +108,7 @@ class ResReportCountingSource_811(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         RES_REPORT_MATCH_CALLS_811[cls.get_class_name()] = RES_REPORT_MATCH_CALLS_811.get(cls.get_class_name(), 0) + 1
         return super().match_feature_group_criteria(feature_name, options, data_access_collection)
@@ -139,11 +139,11 @@ class ResReportGoodFG_811(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == GOOD_FEATURE_811
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -14,7 +14,7 @@ import sys
 import textwrap
 
 import pytest
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.domain import Domain
@@ -69,7 +69,7 @@ class SplitCapResolveFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -84,7 +84,7 @@ class SplitCapResolveFeatureGroup(FeatureGroup):
     ) -> bool:
         return compute_framework is not PythonDictFramework
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -100,7 +100,7 @@ class AllRejectedCapResolveFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -115,7 +115,7 @@ class AllRejectedCapResolveFeatureGroup(FeatureGroup):
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -131,7 +131,7 @@ class OptionGatedResolveFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -139,7 +139,7 @@ class OptionGatedResolveFeatureGroup(FeatureGroup):
             return False
         return bool(options.get(PARTITION_BY_KEY))
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -155,7 +155,7 @@ class OptionCapResolveFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -172,7 +172,7 @@ class OptionCapResolveFeatureGroup(FeatureGroup):
             return bool(options.get(ALLOW_PYTHON_DICT_KEY))
         return True
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -207,11 +207,11 @@ class ScopedResolveFamilyBase693(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -223,7 +223,7 @@ class ScopedResolveSiblingOne693(ScopedResolveFamilyBase693):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -238,7 +238,7 @@ class ScopedResolveSiblingTwo693(ScopedResolveFamilyBase693):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -253,7 +253,7 @@ class ScopedResolveLoneChild693(ScopedResolveFamilyBase693):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -272,13 +272,13 @@ class UnrelatedScopedResolve693FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
         return feature_name == UNRELATED_SCOPED_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -490,7 +490,7 @@ class TestResolveFeatureSubclassFiltering:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 return feature_name == "SubclassFilterTestFeature"
 
@@ -524,7 +524,7 @@ class TestResolveFeatureSubclassFiltering:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 return feature_name == "CandidatesTestFeature"
 

--- a/tests/test_core/test_api/test_resolve_feature_full_request.py
+++ b/tests/test_core/test_api/test_resolve_feature_full_request.py
@@ -5,11 +5,11 @@ Target contract for resolve_feature (to be implemented in the Green phase):
     def resolve_feature(
         feature: str | Feature,
         *,
-        options: Optional[Options] = None,
-        plugin_collector: Optional[PluginCollector] = None,
+        options: Options | None = None,
+        plugin_collector: PluginCollector | None = None,
         feature_group: str | type[FeatureGroup] | None = None,
-        links: Optional[set[Link]] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        links: set[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> ResolvedFeature: ...
 
 The full request the engine seam ``IdentifyFeatureGroupClass.evaluate`` consumes is
@@ -30,7 +30,7 @@ feature_group)`` every test here FAILS for the right reason: the str-only first 
 accept a ``Feature``, and ``links`` / ``data_access_collection`` are not parameters at all.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -86,11 +86,11 @@ class PlainResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == PLAIN_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -110,11 +110,11 @@ class DomainAResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == DOMAIN_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -134,11 +134,11 @@ class DomainBResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == DOMAIN_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -154,11 +154,11 @@ class FrameworkPinResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == FRAMEWORK_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -170,7 +170,7 @@ class LinkResolve756FeatureGroup(FeatureGroup):
         return {PandasDataFrame, PythonDictFramework}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index((LINK_INDEX_COLUMN,))]
 
     @classmethod
@@ -178,11 +178,11 @@ class LinkResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == LINK_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -198,7 +198,7 @@ class DataAccessResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if str(feature_name) != DATA_ACCESS_FEATURE:
             return False
@@ -206,7 +206,7 @@ class DataAccessResolve756FeatureGroup(FeatureGroup):
             return False
         return EXPECTED_FILE_HANDLE in set(data_access_collection.files.values())
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -222,7 +222,7 @@ class RaisingDacResolve756FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if str(feature_name) != RAISING_DAC_FEATURE:
             return False
@@ -230,7 +230,7 @@ class RaisingDacResolve756FeatureGroup(FeatureGroup):
             raise RuntimeError("resolve756 reader-style match hook blew up on a data access collection")
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_api/test_resolve_feature_prefilter_universe.py
+++ b/tests/test_core/test_api/test_resolve_feature_prefilter_universe.py
@@ -3,7 +3,7 @@
 ``PreFilterPlugins`` (``mloda/core/prepare/accessible_plugins.py``) is the same builder ``Engine.__init__``
 uses, so the debug API resolves against the universe a real run sees. What that routing pins:
 
-  1. A keyword-only ``compute_frameworks: Optional[set[type[ComputeFramework]]]`` parameter. Restricting to
+  1. A keyword-only ``compute_frameworks: set[type[ComputeFramework]] | None`` parameter. Restricting to
      a framework a matching group does not declare empties its available set, so the group fails to resolve,
      mirroring how ``PreFilterPlugins`` intersects the caller's framework set.
   2. A ``plugin_collector`` yields the same universe the engine builds, registry strict mode included.
@@ -12,7 +12,6 @@ uses, so the debug API resolves against the universe a real run sees. What that 
 """
 
 import gc
-from typing import Optional
 
 import pytest
 
@@ -54,11 +53,11 @@ class PythonDictOnlyResolve757FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == PYTHON_DICT_ONLY_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -74,11 +73,11 @@ class StrictExcludedResolve757FeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == STRICT_EXCLUDED_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -102,11 +101,11 @@ def _make_broken_rule_fg_757() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == BROKEN_RULE_FEATURE_757
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return BrokenRuleResolve757FG

--- a/tests/test_core/test_api/test_run_context_api.py
+++ b/tests/test_core/test_api/test_run_context_api.py
@@ -1,6 +1,6 @@
 """E2E tests for RunContext plumbing through mlodaAPI, CfwManager, and _build_run_context()."""
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.run_context import RunContext
 from mloda.core.abstract_plugins.verified_context import verified_context
@@ -18,7 +18,7 @@ def _run_context_api_bootstrap() -> None:
 
 class _RunContextApiFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"run_context_api_col"})
 
     @classmethod

--- a/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
+++ b/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
@@ -14,7 +14,6 @@ test_plugin_docs.py) so it does not leak into the session-wide subclass registry
 """
 
 import gc
-from typing import Optional
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -45,11 +44,11 @@ def _make_broken_rule_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == SBDG_BROKEN_RULE_FEATURE
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return SbdgBrokenRuleFG

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -2,7 +2,6 @@
 
 import gc
 from abc import abstractmethod
-from typing import Optional
 
 import pytest
 
@@ -47,7 +46,7 @@ R4_KEY = "sbddr4_kind"
 R5_FEATURE = "sbdd_resolver_feature"
 
 
-def _sbdd_raising_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _sbdd_raising_resolver(feature_name: str, options: Options) -> str | None:
     raise RuntimeError("sbdd resolver exploded")
 
 
@@ -164,11 +163,11 @@ class SubDeclDocOptionFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == OPTION_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -184,11 +183,11 @@ class SubDeclDocPlainFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == PLAIN_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -229,11 +228,11 @@ class SubDeclDocRaisingResolverFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == R5_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -8,7 +8,6 @@ surfaces as subtype_error in the docs.
 """
 
 import logging
-from typing import Optional
 
 import pytest
 
@@ -46,7 +45,7 @@ class SbfixRaisingHookFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == SBFIX_HOOK_FEATURE
 
@@ -59,7 +58,7 @@ class SbfixRaisingHookFG(FeatureGroup):
     ) -> bool:
         raise RuntimeError("sbfix hook exploded")
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -75,7 +74,7 @@ class Sbfix852EmptyHookFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == SBFIX852_EMPTY_HOOK_FEATURE
 
@@ -88,7 +87,7 @@ class Sbfix852EmptyHookFG(FeatureGroup):
     ) -> bool:
         raise RuntimeError()
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -111,7 +110,7 @@ class SbfixDocBogusSupportedFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PythonDictFramework}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_artifacts/test_artifact_prepare_run.py
+++ b/tests/test_core/test_artifacts/test_artifact_prepare_run.py
@@ -6,7 +6,7 @@ single prepare() session.
 """
 
 import hashlib
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseArtifact, BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Feature, mloda, PluginCollector
@@ -17,7 +17,7 @@ class PrepareRunArtifactFeature(FeatureGroup):
     """Artifact-capable feature group for prepare/run tests."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @staticmethod
@@ -52,7 +52,7 @@ class VerifiableArtifactFeature(FeatureGroup):
     ARTIFACT_VALUE = "model|v1-alpha|weights=0.1,0.2,0.3"
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @staticmethod

--- a/tests/test_core/test_artifacts/test_artifacts.py
+++ b/tests/test_core/test_artifacts/test_artifacts.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseArtifact
 from mloda.provider import BaseInputData
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 class BaseTestArtifactFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @staticmethod

--- a/tests/test_core/test_artifacts/test_artifacts_public_api.py
+++ b/tests/test_core/test_artifacts/test_artifacts_public_api.py
@@ -5,7 +5,7 @@ Validates the patterns documented in docs/docs/in_depth/artifacts.md:
   2. run_all() for loading artifacts via options
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseArtifact, BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Feature, mloda
@@ -16,7 +16,7 @@ class PublicApiArtifactFeature(FeatureGroup):
     """Artifact feature group mirroring the documentation example."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @staticmethod

--- a/tests/test_core/test_core/test_engine_error_messages.py
+++ b/tests/test_core/test_core/test_engine_error_messages.py
@@ -4,7 +4,7 @@ These tests verify that error messages use human-readable formatting
 with class names and module paths instead of raw class representations.
 """
 
-from typing import Optional, cast
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -30,18 +30,18 @@ class NoIndexFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             return "NoIndexTestFeature" in str(feature_name)
         return "NoIndexTestFeature" in feature_name
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         """Returns None to simulate the 'no indexes defined' error condition."""
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_core/test_step/test_feature_group_step_error_messages.py
+++ b/tests/test_core/test_core/test_step/test_feature_group_step_error_messages.py
@@ -5,7 +5,6 @@ use the format_feature_group_class format: "ClassName (module.path)"
 instead of the default repr which shows "<class 'module.ClassName'>".
 """
 
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,7 +20,7 @@ from mloda.user import Feature, Options
 class MockFeatureGroup(FeatureGroup):
     """A mock feature group for testing error messages."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_core/test_step/test_transform_step_error_messages.py
+++ b/tests/test_core/test_core/test_step/test_transform_step_error_messages.py
@@ -1,6 +1,5 @@
 """Tests for improved error messages in TransformFrameworkStep."""
 
-from typing import Optional
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -29,11 +28,11 @@ class MockFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -21,7 +21,7 @@ Validation (filter column must be present when row elimination applies):
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import pytest
 import pyarrow as pa
@@ -59,7 +59,7 @@ class InlineMaskViaFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -106,7 +106,7 @@ class RegularFeatureGroupForFilterTest(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -148,7 +148,7 @@ class ForceFinalOnInlineEngine(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -177,7 +177,7 @@ class ForceFinalOnFinalEngine(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -225,7 +225,7 @@ class InlineMaskWithFinalElimination(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -272,7 +272,7 @@ class DropsFilterColumnFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -301,7 +301,7 @@ class DefaultFGDropsFilterColumn(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -326,7 +326,7 @@ class MutatesFilterColumnToInt(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -355,7 +355,7 @@ class MutatesFilterColumnToString(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "price"})
 
     @classmethod
@@ -384,7 +384,7 @@ class DefaultFGMutatesFilterColumnToInt(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -415,7 +415,7 @@ class CompatibleDtypeFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod

--- a/tests/test_core/test_filter/test_filter_criteria_effective_options.py
+++ b/tests/test_core/test_filter/test_filter_criteria_effective_options.py
@@ -8,7 +8,7 @@ called to match a filter feature, even though the very same classmethod observes
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
@@ -49,7 +49,7 @@ def _make_probe_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             # PFC_MAIN must always resolve: feature resolution itself observes declared (pre-default)
             # options, so gating the root request on PFC_KEY would break it whenever the key is absent.

--- a/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
+++ b/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
@@ -6,7 +6,7 @@ The fdg_ prefix keeps this module's keys unique.
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -45,7 +45,7 @@ def _rejecting_probe() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return False
 
@@ -59,7 +59,7 @@ def _accepting_probe() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == FDG_TARGET
 

--- a/tests/test_core/test_filter/test_filter_integration.py
+++ b/tests/test_core/test_filter/test_filter_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 
@@ -19,7 +19,7 @@ from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_
 
 class GlobalFilterBasicTest(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -39,7 +39,7 @@ class GlobalFilterBasicTest(FeatureGroup):
 
 class GlobalFilterFromDifferentColumnTest(GlobalFilterBasicTest):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"GlobalFilterFromDifferentColumn1", "GlobalFilterFromDifferentColumn2"})
 
     @classmethod
@@ -60,7 +60,7 @@ class GlobalFilterFromDifferentColumnTest(GlobalFilterBasicTest):
 
 class GlobalFilterHasDifferentNameTest(GlobalFilterBasicTest):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"GlobalFilterHasDifferentName1", "GlobalFilterHasDifferentName2"})
 
     @classmethod

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import pytest
 
@@ -51,7 +51,7 @@ E2E_TARGET = "gfc_target_feat_899"  # never requested directly; only reachable a
 T = TypeVar("T")
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -59,7 +59,7 @@ def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
         return None, f"{type(exc).__name__}: {exc}"
 
 
-def _single(filter_feature_name: str, options: Optional[Options] = None) -> SingleFilter:
+def _single(filter_feature_name: str, options: Options | None = None) -> SingleFilter:
     """A minimal EQUAL filter on one feature name, optionally carrying that filter feature's own options."""
     filter_feature: Feature | str = filter_feature_name if options is None else Feature(filter_feature_name, options)
     return SingleFilter(filter_feature, FilterType.EQUAL, {"value": 1})
@@ -80,7 +80,7 @@ def _make_raising_filter_matcher_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) == FILTER_FEATURE_RAISING:
                 raise RuntimeError(RAISE_MESSAGE)
@@ -103,7 +103,7 @@ def _make_escalating_filter_matcher_fg(marker: BaseException) -> type[FeatureGro
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) == FILTER_FEATURE_RAISING:
                 raise marker
@@ -216,7 +216,7 @@ def _make_hostile_filter_matcher_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) == FILTER_FEATURE_RAISING:
                 raise HostileFilterMatcherError899(RAISE_MESSAGE)
@@ -225,9 +225,9 @@ def _make_hostile_filter_matcher_fg() -> type[FeatureGroup]:
     return HostileFilterMatcherFG899
 
 
-def _ledger(global_filter: GlobalFilter) -> Optional[dict[Any, Any]]:
+def _ledger(global_filter: GlobalFilter) -> dict[Any, Any] | None:
     """The instance drop ledger, read via getattr so a missing one asserts readably instead of pinning the class."""
-    return cast(Optional[dict[Any, Any]], getattr(global_filter, "dropped_filters", None))
+    return cast(dict[Any, Any] | None, getattr(global_filter, "dropped_filters", None))
 
 
 def _reason_of(recorded: Any) -> Any:
@@ -241,7 +241,7 @@ def _messages(caplog: pytest.LogCaptureFixture, level: int) -> tuple[str, ...]:
     return tuple(record.getMessage() for record in records)
 
 
-def _capture_type_name(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture_type_name(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, type name). Reads no message: a double's str() raises."""
     try:
         return call(), None
@@ -253,8 +253,8 @@ def _capture_type_name(call: Callable[[], T]) -> tuple[Optional[T], Optional[str
 class _DropSnapshot:
     """Plain-data readout of one or more criteria calls. Holds no class and no exception object."""
 
-    results: tuple[Optional[bool], ...]
-    escaped: Optional[str]
+    results: tuple[bool | None, ...]
+    escaped: str | None
     has_ledger: bool
     keyed_by_group_and_filter: bool
     entries: tuple[tuple[str, str], ...]  # (feature group class name, filter feature name), sorted
@@ -269,7 +269,7 @@ def _drive_criteria(
     filter_feature_name: str,
     caplog: pytest.LogCaptureFixture,
     calls: int = 1,
-    options: Optional[Options] = None,
+    options: Options | None = None,
 ) -> _DropSnapshot:
     """Call criteria `calls` times against ONE GlobalFilter; the finally unbinds every name that pins the class."""
     caplog.clear()
@@ -277,11 +277,11 @@ def _drive_criteria(
     global_filter = GlobalFilter()
     # The engine probes a per-match deepcopy of one declaration, so all `calls` share one ledger key.
     declared = _single(filter_feature_name, options)
-    ledger: Optional[dict[Any, Any]] = None
+    ledger: dict[Any, Any] | None = None
     items: list[tuple[Any, Any]] = []
     try:
-        results: list[Optional[bool]] = []
-        escaped: Optional[str] = None
+        results: list[bool | None] = []
+        escaped: str | None = None
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
             for _ in range(calls):
                 value, failure = _capture_type_name(partial(global_filter.criteria, fg, deepcopy(declared), None))
@@ -391,7 +391,7 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
     class InFeaturesMixinFilterFG884(FeatureChainParserMixin, FeatureGroup):
         PROPERTY_MAPPING = {"operation": property_spec("operation", allowed_values=("op1",), context=True)}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return InFeaturesMixinFilterFG884
@@ -452,7 +452,7 @@ def _make_e2e_probe_fg(escalate: bool) -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) == E2E_TARGET:
                 if escalate:
@@ -487,7 +487,7 @@ def _single_row(frame: Any, column: str) -> Any:
     return values[0]
 
 
-def _run(escalate: bool) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+def _run(escalate: bool) -> tuple[dict[str, Any] | None, str | None]:
     """Run E2E_MAIN under a filter; the escape is text, not pytest.raises, whose ExceptionInfo pins the class."""
     fg = _make_e2e_probe_fg(escalate)
     collector = PluginCollector.enabled_feature_groups({fg})

--- a/tests/test_core/test_filter/test_filter_matcher_truthiness.py
+++ b/tests/test_core/test_filter/test_filter_matcher_truthiness.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 import pytest
 
@@ -102,7 +102,7 @@ FALSY_RETURNS: dict[str, Any] = {**FALSY_NON_BOOL_RETURNS, "literal_false": Fals
 TRUTHY_RETURNS: dict[str, Any] = {**TRUTHY_NON_BOOL_RETURNS, "literal_true": True}
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -152,7 +152,7 @@ def _make_non_bool_matcher_fg(returned: Any) -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> Any:  # Any, not bool: returning a non-bool out of a `-> bool` hook is the case under test.
             if str(feature_name) == FILTER_FEATURE:
                 return returned
@@ -175,7 +175,7 @@ def _make_mutating_exploding_bool_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> Any:  # Any, not bool: the write lands, then reading the return value is what raises.
             options.add_to_group(OPTION_KEY_927, OPTION_VALUE_927)
             return ExplodingBool927()
@@ -190,7 +190,7 @@ class _CriteriaSnapshot:
     is_false: bool
     is_true: bool
     shown: str
-    escaped: Optional[str]
+    escaped: str | None
     entries: tuple[tuple[str, str], ...]
     reasons: tuple[str, ...]
     warnings: tuple[str, ...]
@@ -206,7 +206,7 @@ def _drive_criteria(returned: Any, caplog: pytest.LogCaptureFixture, calls: int 
     declared = _single(FILTER_FEATURE)
     try:
         value: Any = None
-        escaped: Optional[str] = None
+        escaped: str | None = None
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
             for _ in range(calls):
                 value, escaped = _capture(partial(global_filter.criteria, fg, deepcopy(declared), None))
@@ -230,7 +230,7 @@ class _MatchedFilterSnapshot:
     """Plain-data readout of one identify_matched_filters call. Holds no class and no filter object."""
 
     names: tuple[str, ...]
-    escaped: Optional[str]
+    escaped: str | None
     entries: tuple[tuple[str, str], ...]
 
 
@@ -261,7 +261,7 @@ class _RawCriteriaGlobalFilter927(GlobalFilter):
         self,
         feature_group: type[FeatureGroup],
         filter: SingleFilter,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> Any:  # Any, not bool: bypassing the coercion inside criteria is the point of this double.
         return self.raw
 
@@ -293,7 +293,7 @@ class _ResolutionSnapshot:
     is_false: bool
     is_true: bool
     shown: str
-    escaped: Optional[str]
+    escaped: str | None
     warnings: tuple[str, ...]
     matcher_errors: tuple[tuple[str, str], ...]
     option_keys: tuple[str, ...]
@@ -328,7 +328,7 @@ def _drive_resolution(build: Callable[[], type[FeatureGroup]], caplog: pytest.Lo
 class _EliminationSnapshot:
     """Plain-data readout of one evaluate() pass. Holds no class and no Elimination object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     identified: tuple[str, ...]
     eliminations: tuple[tuple[str, str, str], ...]
 
@@ -586,7 +586,7 @@ def _make_e2e_probe_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> Any:  # Any, not bool: returning None out of a `-> bool` hook is the case under test.
             if str(feature_name) == E2E_TARGET:
                 return None
@@ -618,7 +618,7 @@ def _single_row(frame: Any, column: str) -> Any:
     return values[0]
 
 
-def _run() -> tuple[Optional[dict[str, Any]], Optional[str]]:
+def _run() -> tuple[dict[str, Any] | None, str | None]:
     """Run E2E_MAIN under a filter whose hook answers None; the escape is text, never an exception object."""
     fg = _make_e2e_probe_fg()
     collector = PluginCollector.enabled_feature_groups({fg})
@@ -698,7 +698,7 @@ def _make_unnameable_group_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> Any:  # Any, not bool: the None below is the falsy non-bool whose report then names the group.
             if str(feature_name) == FILTER_FEATURE:
                 return None
@@ -713,7 +713,7 @@ class _DegradedReportSnapshot:
 
     is_false: bool
     shown: str
-    escaped: Optional[str]
+    escaped: str | None
     drops: int
     warnings: tuple[str, ...]
 
@@ -745,7 +745,7 @@ def _drive_criteria_of(
 class _MatchingPassSnapshot:
     """Plain-data readout of one identify_matched_filters call. Holds no class and no filter object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     names: tuple[str, ...]
     drops: int
 
@@ -830,7 +830,7 @@ def _make_unreadable_report_e2e_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> Any:  # Any, not bool: the falsy non-bool below is what the filter seam then tries to report.
             if str(feature_name) == E2E_TARGET:
                 return UnnameableFalsy991()
@@ -852,7 +852,7 @@ def _make_unreadable_report_e2e_fg() -> type[FeatureGroup]:
     return UnreadableReportE2EFG991
 
 
-def _run_built(build: Callable[[], type[FeatureGroup]]) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+def _run_built(build: Callable[[], type[FeatureGroup]]) -> tuple[dict[str, Any] | None, str | None]:
     """Run E2E_MAIN under a filter matched by a group `build` makes; the escape is text, never an exception."""
     fg = build()
     collector = PluginCollector.enabled_feature_groups({fg})

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -93,7 +93,7 @@ def test_value_property_with_string_value() -> None:
 def test_values_property_returns_list_for_categorical() -> None:
     """Test values property returns list for categorical_inclusion filter.
 
-    The public accessor must honour its declared `Optional[list[Any]]` type even though the
+    The public accessor must honour its declared `list[Any] | None` type even though the
     internal storage keeps a tuple. Filter engines rely on this: PySpark's `Column.isin` only
     unwraps list/set arguments, so leaking a tuple silently breaks the Spark categorical filter.
     """

--- a/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
+++ b/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import gc
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -55,7 +55,7 @@ def _make_fg(capture: list[tuple[Feature, ...]] | None = None) -> type[FeatureGr
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) == FSP_FILTER:
                 # identify_matched_filters enriched the filter feature with the probing feature's options.

--- a/tests/test_core/test_filter/test_filter_sibling_divergence_scope.py
+++ b/tests/test_core/test_filter/test_filter_sibling_divergence_scope.py
@@ -8,7 +8,7 @@ import gc
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -70,7 +70,7 @@ def _make_fg(capture: list[tuple[Feature, ...]], notes: list[tuple[str, ...]]) -
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             name = str(feature_name)
             if name == FSD_SHARED_FILTER:
@@ -109,7 +109,7 @@ def _make_rename_fg(capture: list[tuple[Feature, ...]], notes: list[tuple[str, .
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) in {FSD_RN_A, FSD_RN_B, FSD_RN_FILTER}
 
@@ -145,7 +145,7 @@ def _make_freshness_fg(modes: list[tuple[str, ...]]) -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) in {FSD_FRESH_HOST, FSD_FRESH_FILTER}
 

--- a/tests/test_core/test_filter/test_option_divergence_warning_guards.py
+++ b/tests/test_core/test_filter/test_option_divergence_warning_guards.py
@@ -7,7 +7,7 @@ call the seam directly: every guard below decides nothing but whether one log li
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -46,12 +46,12 @@ class _ArrayLikeDefault:
         return "<array-like default>"
 
 
-def _emit(mapping: Optional[dict[str, PropertySpec]], feat_options: Options, filter_options: Options) -> None:
+def _emit(mapping: dict[str, PropertySpec] | None, feat_options: Options, filter_options: Options) -> None:
     """Run the seam once against a throwaway group; ``mapping`` None means no resolving group.
 
     The probe class stays local to this frame, so it cannot leak into the registry.
     """
-    feature_group: Optional[type[FeatureGroup]] = None
+    feature_group: type[FeatureGroup] | None = None
     if mapping is not None:
 
         class DwgProbeFeatureGroup(FeatureGroup):

--- a/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
+++ b/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
@@ -13,7 +13,7 @@ way the set loses its own member and a value-equal ``add_filter`` stops deduplic
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -212,7 +212,7 @@ def _make_cached_input_chain() -> tuple[Feature, type[FeatureGroup], type[Featur
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == SFO_CONSUMER_FEATURE
 

--- a/tests/test_core/test_filter/test_time_travel.py
+++ b/tests/test_core/test_filter/test_time_travel.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 
@@ -20,7 +20,7 @@ from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_
 
 class TimeTravelNegativeFilterTest(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod

--- a/tests/test_core/test_index/test_add_index.py
+++ b/tests/test_core/test_index/test_add_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import tempfile
-from typing import Any, Optional
+from typing import Any
 
 from mloda.user import PluginCollector
 from mloda_plugins.feature_group.input_data.read_db_feature import ReadDBFeature
@@ -55,7 +55,7 @@ class TestAddIndex:
     ) -> None:
         class ReadFileFeatureWithIndex(ReadFileFeature):
             @classmethod
-            def index_columns(cls) -> Optional[list[Index]]:
+            def index_columns(cls) -> list[Index] | None:
                 return [Index(("id",))]
 
             @classmethod
@@ -63,7 +63,7 @@ class TestAddIndex:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 # Feature is only valid for this test
                 if options.get("test_add_index_simple") is None:
@@ -79,7 +79,7 @@ class TestAddIndex:
 
         class DBInputDataTestFeatureGroupWithIndex(DBInputDataTestFeatureGroup):
             @classmethod
-            def index_columns(cls) -> Optional[list[Index]]:
+            def index_columns(cls) -> list[Index] | None:
                 return [Index(("id",))]
 
             @classmethod
@@ -105,13 +105,13 @@ class TestAddIndex:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 if "TestAddIndexFeature" in str(feature_name):
                     return True
                 return False
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature.int32_of("Amount"), Feature.int32_of("any_num")}
 
             @classmethod

--- a/tests/test_core/test_index/test_joinspec_without_index_columns.py
+++ b/tests/test_core/test_index/test_joinspec_without_index_columns.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup, FeatureSet
 from mloda.user import (
@@ -36,7 +36,7 @@ class TestJoinSpecWithoutIndexColumns:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 if options.get("test_joinspec_no_index") is None:
                     return False
@@ -56,7 +56,7 @@ class TestJoinSpecWithoutIndexColumns:
             """Reads 'Class' from CSV. Defines index_columns() returning [Index(('id',))]."""
 
             @classmethod
-            def index_columns(cls) -> Optional[list[Index]]:
+            def index_columns(cls) -> list[Index] | None:
                 return [Index(("id",))]
 
             @classmethod
@@ -64,7 +64,7 @@ class TestJoinSpecWithoutIndexColumns:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 if options.get("test_joinspec_no_index") is None:
                     return False
@@ -88,13 +88,13 @@ class TestJoinSpecWithoutIndexColumns:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 if isinstance(feature_name, FeatureName):
                     feature_name = str(feature_name)
                 return feature_name == "JoinSpecNoIndexResult"
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature("Amount"), Feature("Class")}
 
             @classmethod

--- a/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
+++ b/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 import pyarrow as pa
 import pytest
 from mloda.provider import BaseInputData
@@ -20,8 +20,8 @@ from mloda.provider import DefaultOptionKeys
 from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_SYNC_THREADING
 
 
-def _arrow_resolver(table: pa.Table) -> Callable[[str], Optional[DataType]]:
-    def resolve(col: str) -> Optional[DataType]:
+def _arrow_resolver(table: pa.Table) -> Callable[[str], DataType | None]:
+    def resolve(col: str) -> DataType | None:
         if col not in table.schema.names:
             return None
         return DataType.from_arrow_type_safe(table.schema.field(col).type)
@@ -39,7 +39,7 @@ class TypedFeatureSource(FeatureGroup):
         return table
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
 
@@ -52,7 +52,7 @@ class StringDataSource(FeatureGroup):
         return {cls.get_class_name(): ["a", "b", "c"]}
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
 
@@ -66,7 +66,7 @@ class Int64DataSource(FeatureGroup):
         return table
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"Int64DataSource"})
 
 
@@ -468,7 +468,7 @@ class TestStrictTypeEnforcementPropagation:
         # FeatureGroup that returns INT64 regardless of declared type
         class ReturnsInt64(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
+            def input_data(cls) -> BaseInputData | None:
                 return DataCreator(supports_features={"ReturnsInt64"})
 
             @classmethod
@@ -515,7 +515,7 @@ class TestStrictTypeEnforcementPropagation:
         # Dependency: returns INT64 regardless of declared type
         class BaseFG(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
+            def input_data(cls) -> BaseInputData | None:
                 return DataCreator(supports_features={"BaseFG"})
 
             @classmethod
@@ -525,10 +525,10 @@ class TestStrictTypeEnforcementPropagation:
         # Parent: depends on BaseFG with INT32 type
         class DerivedFG(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
+            def input_data(cls) -> BaseInputData | None:
                 return DataCreator(supports_features={"DerivedFG"})
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature.int32_of("BaseFG")}
 
             @classmethod

--- a/tests/test_core/test_integration/test_core/test_domain_propagation.py
+++ b/tests/test_core/test_integration/test_core/test_domain_propagation.py
@@ -7,7 +7,7 @@ dependency chain.
 Uses pytest.mark.parametrize for matrix testing of various scenarios.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -32,7 +32,7 @@ class DomainTestDataCreator(FeatureGroup):
         return TEST_DOMAIN
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"base_value"})
 
     @classmethod
@@ -64,7 +64,7 @@ class ChildFeatureGroup(FeatureGroup):
             feature_name = str(feature_name)
         return feature_name == "child_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {"base_value"}  # type: ignore[arg-type]
 
     @classmethod
@@ -95,7 +95,7 @@ class ParentFeatureGroup(FeatureGroup):
             feature_name = str(feature_name)
         return feature_name == "parent_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {"child_feature"}  # type: ignore[arg-type]
 
     @classmethod
@@ -126,7 +126,7 @@ class GrandchildFeatureGroup(FeatureGroup):
             feature_name = str(feature_name)
         return feature_name == "grandchild_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {"base_value"}  # type: ignore[arg-type]
 
     @classmethod
@@ -157,7 +157,7 @@ class IntermediateFeatureGroup(FeatureGroup):
             feature_name = str(feature_name)
         return feature_name == "intermediate_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {"grandchild_feature"}  # type: ignore[arg-type]
 
     @classmethod
@@ -188,7 +188,7 @@ class GrandparentFeatureGroup(FeatureGroup):
             feature_name = str(feature_name)
         return feature_name == "grandparent_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {"intermediate_feature"}  # type: ignore[arg-type]
 
     @classmethod
@@ -312,8 +312,8 @@ class TestDomainPropagationMatrix:
     def test_features_class_domain_propagation(
         self,
         child_input: str | Feature,
-        parent_domain: Optional[str],
-        expected_child_domain: Optional[str],
+        parent_domain: str | None,
+        expected_child_domain: str | None,
     ) -> None:
         """Test Features class handles domain propagation correctly."""
         features = Features([child_input], parent_domain=parent_domain)

--- a/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
+++ b/tests/test_core/test_integration/test_core/test_link_planner_orientation_characterization.py
@@ -1,6 +1,6 @@
 """Characterizes which feature group's data ends up as the left merge argument of a link."""
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -97,7 +97,7 @@ class OrientCharLeftInPandas(FeatureGroup):
     """Declared left side of pair A, so a Pandas child joins in the declared orientation."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"oc_a_left_key", "oc_a_left_payload"})
 
     @classmethod
@@ -111,7 +111,7 @@ class OrientCharLeftInPandas(FeatureGroup):
 
 class OrientCharRightInArrow(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"oc_a_right_key", "oc_a_right_payload"})
 
     @classmethod
@@ -127,7 +127,7 @@ class OrientCharLeftInArrow(FeatureGroup):
     """Declared left side of pair B, so a Pandas child inverts the declared orientation."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"oc_b_left_key", "oc_b_left_payload"})
 
     @classmethod
@@ -141,7 +141,7 @@ class OrientCharLeftInArrow(FeatureGroup):
 
 class OrientCharRightInPandas(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"oc_b_right_key", "oc_b_right_payload"})
 
     @classmethod
@@ -155,7 +155,7 @@ class OrientCharRightInPandas(FeatureGroup):
 
 class OrientCharThirdInDict(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"oc_c_key", "oc_c_payload"})
 
     @classmethod
@@ -170,7 +170,7 @@ class OrientCharThirdInDict(FeatureGroup):
 class OrientCharDeclaredChild(FeatureGroup):
     """Runs in the framework of pair A's declared left parent."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _pair_features("oc_a")
 
     @classmethod
@@ -185,7 +185,7 @@ class OrientCharDeclaredChild(FeatureGroup):
 class OrientCharInvertedChild(FeatureGroup):
     """Runs in the framework of pair B's declared right parent."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _pair_features("oc_b")
 
     @classmethod
@@ -200,7 +200,7 @@ class OrientCharInvertedChild(FeatureGroup):
 class OrientCharArrowChild(FeatureGroup):
     """Declares the framework of pair B's declared left parent."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _pair_features("oc_b")
 
     @classmethod
@@ -213,7 +213,7 @@ class OrientCharArrowChild(FeatureGroup):
 
 
 class OrientCharChainChild(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="oc_a_left_key"),
             Feature(name="oc_a_left_payload"),

--- a/tests/test_core/test_integration/test_core/test_missing_links_error.py
+++ b/tests/test_core/test_integration/test_core/test_missing_links_error.py
@@ -13,7 +13,7 @@ This prevents confusing KeyError messages at runtime and educates users about
 the requirement for explicit Links when merging multiple dependencies.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow.compute as pc
 import pytest
@@ -36,7 +36,7 @@ class RootFeatureA(FeatureGroup):
     """First root feature for testing"""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -52,7 +52,7 @@ class RootFeatureB(FeatureGroup):
     """Second root feature for testing"""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -70,7 +70,7 @@ class MultiDependencyFeature(FeatureGroup):
     This will trigger the validation error when Links are not provided.
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature.int32_of("RootFeatureA"),
             Feature.int32_of("RootFeatureB"),

--- a/tests/test_core/test_integration/test_core/test_named_data_access_handles.py
+++ b/tests/test_core/test_integration/test_core/test_named_data_access_handles.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -94,8 +94,8 @@ class _DoubledValueFG(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if feature_name not in cls.feature_names_supported():
             return None
@@ -116,7 +116,7 @@ class _DoubledValueFG(FeatureGroup, MatchData):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {SqliteFramework}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("value")}
 
     @classmethod

--- a/tests/test_core/test_integration/test_core/test_right_join_side_binding.py
+++ b/tests/test_core/test_integration/test_core/test_right_join_side_binding.py
@@ -1,6 +1,6 @@
 """A RIGHT join binds the declared left group as the left merge argument; surplus left keys expose a swap."""
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -84,7 +84,7 @@ def _packed_rows(results: Any, column: str) -> list[str]:
 
 class RightBindLeftInArrow(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsb_left_key", "rjsb_left_payload"})
 
     @classmethod
@@ -98,7 +98,7 @@ class RightBindLeftInArrow(FeatureGroup):
 
 class RightBindRightInPandas(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsb_right_key", "rjsb_right_payload"})
 
     @classmethod
@@ -113,7 +113,7 @@ class RightBindRightInPandas(FeatureGroup):
 class RightBindChild(FeatureGroup):
     """Runs in the declared right group's framework, which is where the RIGHT join executes."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _pair_features("rjsb")
 
     @classmethod
@@ -129,7 +129,7 @@ class RightBindPolyBase(FeatureGroup):
     """Declared left side of a link whose declared right side derives from it."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsbp_left_key", "rjsbp_left_payload"})
 
     @classmethod
@@ -145,7 +145,7 @@ class RightBindPolyDerived(RightBindPolyBase):
     """Declared right side, and a subclass of the declared left side, so it answers to both sides."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsbp_right_key", "rjsbp_right_payload"})
 
     @classmethod
@@ -158,7 +158,7 @@ class RightBindPolyDerived(RightBindPolyBase):
 
 
 class RightBindPolyChild(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _pair_features("rjsbp")
 
     @classmethod
@@ -174,7 +174,7 @@ class RightBindAncestorBase(FeatureGroup):
     """Declared left side of the RIGHT join, and the base class of an unrelated ancestor of the same child."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsba_left_key", "rjsba_left_payload"})
 
     @classmethod
@@ -188,7 +188,7 @@ class RightBindAncestorBase(FeatureGroup):
 
 class RightBindAncestorRight(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsba_right_key", "rjsba_right_payload"})
 
     @classmethod
@@ -204,7 +204,7 @@ class RightBindAncestorSibling(RightBindAncestorBase):
     """Subclasses the declared left side but runs in the destination framework and joins on its own link."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"rjsba_sibling_key", "rjsba_sibling_payload"})
 
     @classmethod
@@ -217,7 +217,7 @@ class RightBindAncestorSibling(RightBindAncestorBase):
 
 
 class RightBindAncestorChild(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _pair_features("rjsba") | {Feature(name="rjsba_sibling_payload")}
 
     @classmethod

--- a/tests/test_core/test_integration/test_core/test_runner_join_multiple_compute_framework.py
+++ b/tests/test_core/test_integration/test_core/test_runner_join_multiple_compute_framework.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pytest
 from mloda.provider import BaseInputData
 from mloda.provider import DataCreator
@@ -44,7 +44,7 @@ COMPUTE_FRAMEWORKS: set[type[ComputeFramework]] = {
 
 class JoinCfwTest1(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -58,7 +58,7 @@ class JoinCfwTest1(FeatureGroup):
 
 class JoinCfwTest2(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -72,7 +72,7 @@ class JoinCfwTest2(FeatureGroup):
 
 class JoinCfwTest3(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -86,7 +86,7 @@ class JoinCfwTest3(FeatureGroup):
 
 class JoinCfwTest4(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -102,7 +102,7 @@ class JoinCfwTest4(FeatureGroup):
 
 
 class Join2CfwTest(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.int32_of("JoinCfwTest1"), Feature.int32_of("JoinCfwTest2")}
 
     @classmethod
@@ -113,7 +113,7 @@ class Join2CfwTest(FeatureGroup):
 
 
 class Join3CfwTest(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.int32_of("JoinCfwTest1"), Feature.int32_of("JoinCfwTest2"), Feature.int32_of("JoinCfwTest3")}
 
     @classmethod
@@ -129,7 +129,7 @@ class Join3CfwTest(FeatureGroup):
 
 
 class Join4CfwTest(Join3CfwTest):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature.int32_of("JoinCfwTest1"),
             Feature.int32_of("JoinCfwTest2"),
@@ -154,7 +154,7 @@ class MultiIndexJoinTest1(FeatureGroup):
     """Feature group using Pandas framework with 2-column multi-index."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -174,7 +174,7 @@ class MultiIndexJoinTest2(FeatureGroup):
     """Feature group using PolarsLazy framework with 2-column multi-index."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -194,7 +194,7 @@ class MultiIndexJoinTest3(FeatureGroup):
     """Feature group using PyArrow framework with 2-column multi-index."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -214,7 +214,7 @@ class MultiIndexJoinTest4(FeatureGroup):
     """Feature group using PythonDict framework with 2-column multi-index."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -233,7 +233,7 @@ class MultiIndexJoinTest4(FeatureGroup):
 class JoinMultiIndexTest(FeatureGroup):
     """Consumer feature group that uses all 4 multi-index feature groups."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature.int32_of("MultiIndexJoinTest1"),
             Feature.int32_of("MultiIndexJoinTest2"),

--- a/tests/test_core/test_integration/test_core/test_runner_multiple_compute_framework.py
+++ b/tests/test_core/test_integration/test_core/test_runner_multiple_compute_framework.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pyarrow as pa
 import pyarrow.compute as pc
 from mloda.provider import BaseInputData
@@ -23,7 +23,7 @@ from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_
 
 class MultipleCfwTest1(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -37,7 +37,7 @@ class MultipleCfwTest1(FeatureGroup):
 
 class MultipleCfwTest2(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -50,7 +50,7 @@ class MultipleCfwTest2(FeatureGroup):
 
 
 class ChangeCfw(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.int32_of("MultipleCfwTest1")}
 
     @classmethod
@@ -63,7 +63,7 @@ class ChangeCfw(FeatureGroup):
 
 
 class ChangeCfwThird(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         # return {Feature.int32_of("ChangeCfw"), Feature.int32_of("MultipleCfwTest1")}
         return {Feature.int32_of("ChangeCfw")}
 

--- a/tests/test_core/test_integration/test_core/test_runner_one_compute_framework.py
+++ b/tests/test_core/test_integration/test_core/test_runner_one_compute_framework.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pyarrow as pa
 import pyarrow.compute as pc
 from mloda.provider import BaseInputData
@@ -24,7 +24,7 @@ class EngineRunnerTest(FeatureGroup):
         return {cls.f_name: [1, 2, 3]}
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.f_name})
 
 
@@ -37,13 +37,13 @@ class EngineRunnerTest2(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if cls.f_name in str(feature_name):
             return True
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.int32_of(self.f_name2)}
 
     @classmethod
@@ -59,7 +59,7 @@ class EngineRunnerTest2(FeatureGroup):
 class EngineRunnerTest3(FeatureGroup):
     feature_2 = Feature.int32_of("EngineRunnerTest2")
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {self.feature_2}
 
     @classmethod
@@ -82,7 +82,7 @@ class EngineRunnerTest4(FeatureGroup):
         return pa.Table.from_arrays(arrays, schema=schema)
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{cls.get_class_name()}_{cnt}" for cnt in range(4)})
 
 
@@ -92,13 +92,13 @@ class SumFeature(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if "sum_of_" in str(feature_name):
             return True
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_names = options.get("sum")
         return {Feature.int32_of(value) for value in set(feature_names)}
 

--- a/tests/test_core/test_integration/test_core/test_same_framework_join_tfs_ids.py
+++ b/tests/test_core/test_integration/test_core/test_same_framework_join_tfs_ids.py
@@ -2,7 +2,7 @@
 resolves through ExecutionPlan.add_tfs's inner_ep.tfs_ids branch and produces correct joined data.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
@@ -28,7 +28,7 @@ SUMMED_VALUES = [110, 220, 330]
 
 class SftfsLeft(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"sftfs_left_key", "sftfs_left_value"})
 
     @classmethod
@@ -36,7 +36,7 @@ class SftfsLeft(FeatureGroup):
         return {"sftfs_left_key": LEFT_KEYS, "sftfs_left_value": LEFT_VALUES}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("sftfs_left_key",))]
 
     @classmethod
@@ -46,7 +46,7 @@ class SftfsLeft(FeatureGroup):
 
 class SftfsRight(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"sftfs_right_key", "sftfs_right_value"})
 
     @classmethod
@@ -54,7 +54,7 @@ class SftfsRight(FeatureGroup):
         return {"sftfs_right_key": RIGHT_KEYS, "sftfs_right_value": RIGHT_VALUES}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("sftfs_right_key",))]
 
     @classmethod
@@ -63,7 +63,7 @@ class SftfsRight(FeatureGroup):
 
 
 class SftfsChild(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="sftfs_left_key"),
             Feature(name="sftfs_left_value"),

--- a/tests/test_core/test_mask/test_mask_engine.py
+++ b/tests/test_core/test_mask/test_mask_engine.py
@@ -4,7 +4,7 @@ Per-framework mask engine tests live in the framework-specific test directories 
 use the shared MaskEngineTestMixin (see mask_engine_test_mixin.py).
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -110,7 +110,7 @@ class MaskEngineFeatureGroup(FeatureGroup):
     """FeatureGroup that uses the mask engine to apply inline masking."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -152,7 +152,7 @@ class MaskEngineNoMaskFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -195,7 +195,7 @@ class MaskEngineRangeFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "value"})
 
     @classmethod
@@ -243,7 +243,7 @@ class MaskEngineCategoricalFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "status"})
 
     @classmethod
@@ -287,7 +287,7 @@ class MaskEngineMultiMaskFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "value"})
 
     @classmethod
@@ -333,7 +333,7 @@ class MaskEngineBetweenFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "value"})
 
     @classmethod
@@ -377,7 +377,7 @@ class MaskEngineAllOfFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "value"})
 
     @classmethod

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -67,14 +67,14 @@ assert _pyarrow_module.PyArrowTable.is_available() is False, (
 
 from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
 
-from typing import Any, Optional
+from typing import Any
 
 
 class InlinePythonDictCreator(FeatureGroup):
     """Self-contained primary-source FeatureGroup producing PythonDict data."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"inline_value"})
 
     @classmethod

--- a/tests/test_core/test_prepare/identify_seam.py
+++ b/tests/test_core/test_prepare/identify_seam.py
@@ -13,8 +13,6 @@ Exact failure-message wording is out of scope: it is inherently wording-coupled,
 structured facts and reserve exact-string checks for tests whose contract is the wording itself.
 """
 
-from typing import Optional
-
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import Link
@@ -28,8 +26,8 @@ from mloda.core.prepare.resolution_types import EvaluationResult
 def evaluate_or_raise(
     feature: Feature,
     accessible_plugins: FeatureGroupEnvironmentMapping,
-    links: Optional[set[Link]] = None,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    links: set[Link] | None = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> EvaluationResult:
     """Evaluate one feature and raise the typed error on failure, exactly as the engine seam does."""
     return resolve_or_raise(feature, accessible_plugins, links, data_access_collection)
@@ -38,8 +36,8 @@ def evaluate_or_raise(
 def identify_winner(
     feature: Feature,
     accessible_plugins: FeatureGroupEnvironmentMapping,
-    links: Optional[set[Link]] = None,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    links: set[Link] | None = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
     """The winning (feature_group, frameworks) pair, mirroring the removed IdentifyFeatureGroupClass.get()."""
     result = evaluate_or_raise(feature, accessible_plugins, links, data_access_collection)

--- a/tests/test_core/test_prepare/test_abstract_feature_group_not_instantiated.py
+++ b/tests/test_core/test_prepare/test_abstract_feature_group_not_instantiated.py
@@ -10,7 +10,7 @@ These tests are written to FAIL until the abstract-base guard exists.
 """
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -54,7 +54,7 @@ class AbstractWinnerFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == ABSTRACT_WINNER_FEATURE
@@ -65,7 +65,7 @@ class AbstractWinnerFeatureGroup(FeatureGroup):
         """Abstract hook that makes this class uninstantiable."""
         ...
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -83,7 +83,7 @@ class IsolatedAbstractAggBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == ISOLATED_ABSTRACT_AGG_FEATURE
@@ -94,7 +94,7 @@ class IsolatedAbstractAggBase(FeatureGroup):
         """Abstract hook that makes this base uninstantiable."""
         ...
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -131,11 +131,11 @@ class ScopeMismatchUnrelatedFG(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -147,7 +147,7 @@ class ScopeMismatchAbstractBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == SCOPE_MISMATCH_FEATURE
@@ -158,7 +158,7 @@ class ScopeMismatchAbstractBase(FeatureGroup):
         """Abstract hook that makes this base uninstantiable."""
         ...
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -186,7 +186,7 @@ class CapabilityShadowAbstractBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == CAPABILITY_SHADOW_FEATURE
@@ -197,7 +197,7 @@ class CapabilityShadowAbstractBase(FeatureGroup):
         """Abstract hook that makes this base uninstantiable."""
         ...
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_asof_link_disambiguation.py
+++ b/tests/test_core/test_prepare/test_asof_link_disambiguation.py
@@ -18,7 +18,7 @@ PART B drives the real path through ``mloda.run_all`` with the link pinned on
 the LEFT feature, as in production.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -52,22 +52,22 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 class AsofFGa(FeatureGroup):
     """Mock left feature group with a single by-key index column 'k'."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("k",))]
 
 
 class AsofFGb(FeatureGroup):
     """Mock right feature group with a single by-key index column 'k'."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("k",))]
 
 
@@ -237,7 +237,7 @@ class DisambigLeftFeature(FeatureGroup):
     """Left side: emits by-key ``k``, time ``t`` and value ``lv``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"k", "t", "lv"})
 
     @classmethod
@@ -249,7 +249,7 @@ class DisambigRightFeature(FeatureGroup):
     """Right side: emits by-key ``k``, time ``t`` and value ``rv``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"k", "t", "rv"})
 
     @classmethod
@@ -260,7 +260,7 @@ class DisambigRightFeature(FeatureGroup):
 class DisambigBackwardJoinedFeature(FeatureGroup):
     """Parent FG pinning the BACKWARD link on the joining ``lv`` feature."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="lv", link=_disambig_link_backward(), index=Index(("k",))),
             Feature(name="rv", index=Index(("k",))),
@@ -279,7 +279,7 @@ class DisambigBackwardJoinedFeature(FeatureGroup):
 class DisambigForwardJoinedFeature(FeatureGroup):
     """Parent FG pinning the FORWARD link on the joining ``lv`` feature."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="lv", link=_disambig_link_forward(), index=Index(("k",))),
             Feature(name="rv", index=Index(("k",))),

--- a/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
+++ b/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
@@ -15,7 +15,7 @@ groups become global ``FeatureGroup`` subclasses and must not collide with other
 """
 
 from abc import abstractmethod
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import pytest
 
@@ -100,18 +100,18 @@ class _ElimBaseFG(FeatureGroup):
     """
 
     MATCHES: ClassVar[frozenset[str]] = frozenset()
-    DOMAIN_NAME: ClassVar[Optional[str]] = None
-    FRAMEWORK_RULE: ClassVar[Optional[set[type[ComputeFramework]]]] = None
-    SUPPORTED_FRAMEWORKS: ClassVar[Optional[frozenset[str]]] = None
-    INDEX_COLUMNS: ClassVar[Optional[list[Index]]] = None
-    SUPPORTS_INDEX_RESULT: ClassVar[Optional[bool]] = None
+    DOMAIN_NAME: ClassVar[str | None] = None
+    FRAMEWORK_RULE: ClassVar[set[type[ComputeFramework]] | None] = None
+    SUPPORTED_FRAMEWORKS: ClassVar[frozenset[str] | None] = None
+    INDEX_COLUMNS: ClassVar[list[Index] | None] = None
+    SUPPORTS_INDEX_RESULT: ClassVar[bool | None] = None
 
     @classmethod
     def match_feature_group_criteria(
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) in cls.MATCHES
 
@@ -137,14 +137,14 @@ class _ElimBaseFG(FeatureGroup):
         return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return cls.INDEX_COLUMNS
 
     @classmethod
-    def supports_index(cls, index: Index) -> Optional[bool]:
+    def supports_index(cls, index: Index) -> bool | None:
         return cls.SUPPORTS_INDEX_RESULT
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -163,7 +163,7 @@ class ElimValueRejectFG011(_ElimBaseFG):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if str(feature_name) in cls.MATCHES:
             raise PropertyValueRejection(VALUE_REJECT_REASON)
@@ -301,7 +301,7 @@ class ElimLosingRejectorFG011(_ElimBaseFG):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         # Name matches, but the value is rejected: the first pass records the reason as the match fails.
         if str(feature_name) == WIN_WITH_REJECTOR_FEATURE:
@@ -324,7 +324,7 @@ class ElimDomainAndValueRejectFG011(_ElimBaseFG):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         # The value is rejected at the criteria gate, recording the reason before the domain gate is reached.
         if str(feature_name) == DOMAIN_AND_VALUE_REJECT_FEATURE:
@@ -347,7 +347,7 @@ class _ElimReprobeFG011(_ElimBaseFG):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         matched = str(feature_name) in cls.MATCHES
         if matched:
@@ -387,7 +387,7 @@ ELIM_LINK = Link.inner(
 def _fail(
     feature: Feature,
     accessible_plugins: FeatureGroupEnvironmentMapping,
-    links: Optional[set[Link]] = None,
+    links: set[Link] | None = None,
 ) -> FeatureResolutionError:
     """Drive the engine seam and return the raised typed error (carrying ``.result`` and message)."""
     with pytest.raises(FeatureResolutionError) as excinfo:

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -18,8 +18,6 @@ Contract under test (to be implemented by the Green agent):
 All tests are written to FAIL until the feature exists.
 """
 
-from typing import Optional
-
 import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
@@ -58,13 +56,13 @@ class PlainCapabilityFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
         return feature_name == CAPABILITY_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -79,7 +77,7 @@ class RejectBCapabilityFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -94,7 +92,7 @@ class RejectBCapabilityFeatureGroup(FeatureGroup):
     ) -> bool:
         return compute_framework is not CapabilityFwB
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -106,7 +104,7 @@ class RejectAllCapabilityFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -121,7 +119,7 @@ class RejectAllCapabilityFeatureGroup(FeatureGroup):
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -143,7 +141,7 @@ class DualDeclaringFG_782(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -158,7 +156,7 @@ class DualDeclaringFG_782(FeatureGroup):
     ) -> bool:
         return compute_framework is not CapabilityFwB
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_contained_raise_option_isolation.py
+++ b/tests/test_core/test_prepare/test_contained_raise_option_isolation.py
@@ -9,7 +9,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -38,7 +38,7 @@ class OptionIsolationFw845r(ComputeFramework):
     """Dummy compute framework for the option-isolation tests."""
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -67,14 +67,14 @@ def _make_mutating_raise_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) != SHARED_FEATURE:
                 return False
             options.add_to_group(SIDE_EFFECT_KEY, SIDE_EFFECT_VALUE)
             raise RuntimeError(RAISE_MESSAGE)
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return MutatingRaiseFG845r
@@ -95,7 +95,7 @@ def _make_clean_owner_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {OptionIsolationFw845r}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return CleanNameOwnerFG845r
@@ -121,7 +121,7 @@ def _make_mutating_match_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) != SHARED_FEATURE:
                 return False
@@ -129,7 +129,7 @@ def _make_mutating_match_fg() -> type[FeatureGroup]:
                 options.add_to_group(LINKED_KEY, LINKED_VALUE)
             return True
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return MutatingMatchFG845r
@@ -139,11 +139,11 @@ def _make_mutating_match_fg() -> type[FeatureGroup]:
 class _OptionsSnapshot:
     """Plain-data readout of one evaluation. Holds no class and no exception object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     identified_names: tuple[str, ...]
     option_keys: tuple[str, ...]
-    side_effect_value: Optional[str]
-    linked_value: Optional[str]
+    side_effect_value: str | None
+    linked_value: str | None
 
 
 def _evaluate(builders: tuple[Callable[[], type[FeatureGroup]], ...]) -> _OptionsSnapshot:

--- a/tests/test_core/test_prepare/test_contained_rejection_log_no_pinning_object.py
+++ b/tests/test_core/test_prepare/test_contained_rejection_log_no_pinning_object.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -65,7 +65,7 @@ class RejectingValueFGCrlog(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if str(feature_name) != CRLOG_FEATURE:
             return False
@@ -76,7 +76,7 @@ class RejectingValueFGCrlog(FeatureGroup):
             prefix_patterns=[CRLOG_PATTERN],
         )
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_execution_plan_carries_declared_input_feature_names.py
+++ b/tests/test_core/test_prepare/test_execution_plan_carries_declared_input_feature_names.py
@@ -4,7 +4,7 @@ runtime re-call. The dependent feature group's input_features() must run exactly
 mloda.run_all(...) call, not once during planning and again at runtime to populate HookContext.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
@@ -39,14 +39,14 @@ class _CifDependentFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         # A name-only match, bypassing the default is_root()/input_features() matching probe:
         # this test counts input_features() calls, so resolution itself must not call it too.
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == CIF_DEPENDENT_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
         type(self).input_features_calls += 1
         return {CIF_ROOT_FEATURE}
 

--- a/tests/test_core/test_prepare/test_execution_plan_error_messages.py
+++ b/tests/test_core/test_prepare/test_execution_plan_error_messages.py
@@ -10,7 +10,6 @@ Target errors:
 3. Line 874: "Feature group {feature_group} has no matching api data class for feature."
 """
 
-from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -39,7 +38,7 @@ class ApiInputDataFeatureGroupFixture(FeatureGroup):
     """A feature group fixture that uses ApiInputData for testing error messages."""
 
     @classmethod
-    def input_data(cls) -> Optional[ApiInputData]:
+    def input_data(cls) -> ApiInputData | None:
         return ApiInputData()
 
     @classmethod
@@ -47,13 +46,13 @@ class ApiInputDataFeatureGroupFixture(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
         return feature_name == "test_api_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -65,13 +64,13 @@ class NoUuidFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
         return feature_name == "no_uuid_test_feature"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -15,7 +15,7 @@ Follows the construction conventions in test_identify_feature_group_error_messag
 
 import inspect
 from abc import abstractmethod
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 import pytest
 
@@ -698,7 +698,7 @@ class ScopePythonAggregationSource(FeatureGroup):
     """Source data for the Python-surface aggregated-family scope test."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"scope_python_sales"})
 
     @classmethod

--- a/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
@@ -16,7 +16,7 @@ leak into another module's candidate universe in the parallel suite.
 
 import inspect
 import pickle  # nosec B403
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -46,7 +46,7 @@ class PartialRecordsSource_836pr(FeatureGroup):
     """Pandas root source providing the feature the consumer chains off."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({SOURCE_FEATURE_836PR})
 
     @classmethod
@@ -61,7 +61,7 @@ class PartialRecordsSource_836pr(FeatureGroup):
 class PartialRecordsConsumer_836pr(FeatureGroup):
     """Consumes the source feature, so the source resolves as a derived input before the failing request."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_FEATURE_836PR)}
 
     @classmethod

--- a/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import contextvars
 from collections.abc import Iterator
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import pytest
 
@@ -88,7 +88,7 @@ class StrictRecordingFGOs005r(FeatureChainParserMixin, FeatureGroup):
         DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -102,7 +102,7 @@ class MissingOptionRecordingFGOs005r(FeatureChainParserMixin, FeatureGroup):
         DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -118,7 +118,7 @@ class GuardRecordingFGOs005r(FeatureChainParserMixin, FeatureGroup):
         ),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -134,7 +134,7 @@ class FacadeProbeFGOs005r(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
@@ -145,7 +145,7 @@ class FacadeProbeFGOs005r(FeatureGroup):
             return FACADE_SENTINEL_REASON_OS005R
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -159,7 +159,7 @@ def _build_colliding_rejection_groups_os005c() -> tuple[type[FeatureGroup], type
     """
 
     def make(module: str, key: str) -> type[FeatureGroup]:
-        def input_features(self: Any, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self: Any, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
         namespace: dict[str, Any] = {

--- a/tests/test_core/test_prepare/test_forwarded_mismatch_stays_loud.py
+++ b/tests/test_core/test_prepare/test_forwarded_mismatch_stays_loud.py
@@ -9,7 +9,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -37,7 +37,7 @@ class LoudProbeFw845r(ComputeFramework):
     """Dummy compute framework for the forwarded-mismatch seam tests."""
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -94,11 +94,11 @@ def _make_rival_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == LOUD_FEATURE
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return RivalNameOwnerFG845r
@@ -108,7 +108,7 @@ def _make_rival_fg() -> type[FeatureGroup]:
 class _SeamSnapshot:
     """Plain-data readout of one seam evaluation. Holds no class and no exception object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     identified_names: tuple[str, ...]
 
 

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -4,7 +4,7 @@ The formatting lives in mloda/core/prepare/resolution_failure_renderer.py: _rend
 candidate as "ClassName (module.path)" instead of a raw dict/class representation.
 """
 
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import pytest
 
@@ -271,7 +271,7 @@ class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -291,7 +291,7 @@ class StrictMaxWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
+++ b/tests/test_core/test_prepare/test_joinstep_completion_tokens.py
@@ -6,7 +6,7 @@ The cycle guard runs over the finished plan, so it sees join steps and feature g
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 from uuid import UUID, uuid4
 
 import pytest
@@ -79,7 +79,7 @@ class TokenSelfSource(FeatureGroup):
     """Serves both sides of the self join; the requested feature name picks the side."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={SELF_LEFT_PAYLOAD, SELF_RIGHT_PAYLOAD})
 
     @classmethod
@@ -96,7 +96,7 @@ class TokenSelfSource(FeatureGroup):
 class TokenSelfConsumer(FeatureGroup):
     """Consumes both sides of the self join; the options are what the discriminators match on."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=SELF_LEFT_PAYLOAD, options={SELF_SIDE: "left"}),
             Feature(name=SELF_RIGHT_PAYLOAD, options={SELF_SIDE: "right"}),

--- a/tests/test_core/test_prepare/test_joinstep_matched_broad_required_uuids.py
+++ b/tests/test_core/test_prepare/test_joinstep_matched_broad_required_uuids.py
@@ -1,7 +1,7 @@
 """An unrelated, unlinked parent must not skip the missing-Link conflict check by being wrongly
 treated as "served by" a join it isn't genuinely a side of."""
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -16,7 +16,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 class LinkedRootA(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"linked_root_a"})
 
     @classmethod
@@ -30,13 +30,13 @@ class LinkedRootA(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("id",))]
 
 
 class LinkedRootB(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"linked_root_b"})
 
     @classmethod
@@ -50,13 +50,13 @@ class LinkedRootB(FeatureGroup):
         return {PyArrowTable}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("id",))]
 
 
 class OrphanRootC(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"orphan_root_c"})
 
     @classmethod
@@ -70,7 +70,7 @@ class OrphanRootC(FeatureGroup):
 
 class OrphanRootD(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"orphan_root_d"})
 
     @classmethod
@@ -83,7 +83,7 @@ class OrphanRootD(FeatureGroup):
 
 
 class FourParentConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("linked_root_a"),
             Feature("linked_root_b"),
@@ -107,7 +107,7 @@ class FourParentConsumer(FeatureGroup):
 class ThreeParentConsumer(FeatureGroup):
     """A join-served linked pair (zero explicit hops) plus an orphan (one explicit hop)."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("linked_root_a"),
             Feature("linked_root_b"),
@@ -167,7 +167,7 @@ def test_joinstep_matched_raises_for_literal_three_parent_scenario() -> None:
 
 class IndependentJoinPairOneLeft(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"independent_join_pair_one_left"})
 
     @classmethod
@@ -181,13 +181,13 @@ class IndependentJoinPairOneLeft(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("pair_one_id",))]
 
 
 class IndependentJoinPairOneRight(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"independent_join_pair_one_right"})
 
     @classmethod
@@ -199,13 +199,13 @@ class IndependentJoinPairOneRight(FeatureGroup):
         return {PythonDictFramework}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("pair_one_id",))]
 
 
 class IndependentJoinPairTwoLeft(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"independent_join_pair_two_left"})
 
     @classmethod
@@ -219,13 +219,13 @@ class IndependentJoinPairTwoLeft(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("pair_two_id",))]
 
 
 class IndependentJoinPairTwoRight(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"independent_join_pair_two_right"})
 
     @classmethod
@@ -237,14 +237,14 @@ class IndependentJoinPairTwoRight(FeatureGroup):
         return {PythonDictFramework}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("pair_two_id",))]
 
 
 class TwoIndependentJoinsConsumer(FeatureGroup):
     """Both parents are join-served by two separate, unlinked JoinSteps: zero explicit hops at all."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("independent_join_pair_one_left"),
             Feature("independent_join_pair_one_right"),

--- a/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
+++ b/tests/test_core/test_prepare/test_link_planner_plan_characterization.py
@@ -1,7 +1,7 @@
 """Characterizes what the link planner plans, and what it declines to plan."""
 
 from pathlib import Path
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple
 from uuid import UUID
 
 import pyarrow as pa
@@ -101,7 +101,7 @@ class LinkPlanSharedLeft(FeatureGroup):
     """Pinned to the framework the link declares as its left side, with descending keys as an order oracle."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={SHARED_LEFT_PAYLOAD})
 
     @classmethod
@@ -117,7 +117,7 @@ class LinkPlanSharedRight(FeatureGroup):
     """Pinned to the right framework, with keys that only partly overlap the left side."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={SHARED_RIGHT_PAYLOAD})
 
     @classmethod
@@ -136,7 +136,7 @@ def _shared_parents() -> set[Feature]:
 class LinkPlanSharedFlexibleChild(FeatureGroup):
     """Takes either framework, so on its own it would keep the declared orientation."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _shared_parents()
 
     @classmethod
@@ -151,7 +151,7 @@ class LinkPlanSharedFlexibleChild(FeatureGroup):
 class LinkPlanSharedPinnedChild(FeatureGroup):
     """Takes the right framework only, so it forces the shared link into its inverted orientation."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _shared_parents()
 
     @classmethod
@@ -167,7 +167,7 @@ class LinkPlanSelfSource(FeatureGroup):
     """Serves both sides of the self join; the requested feature name picks the side."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={SELF_LEFT_PAYLOAD, SELF_RIGHT_PAYLOAD})
 
     @classmethod
@@ -184,7 +184,7 @@ class LinkPlanSelfSource(FeatureGroup):
 class LinkPlanSelfConsumer(FeatureGroup):
     """Consumes both sides; the options are what the discriminators match on."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=SELF_LEFT_PAYLOAD, options={SELF_SIDE: "left"}),
             Feature(name=SELF_RIGHT_PAYLOAD, options={SELF_SIDE: "right"}),
@@ -286,7 +286,7 @@ def _trek(planned: Planned, left_cfw: type[ComputeFramework], right_cfw: type[Co
     planned.link_trekker.data_ordered[(planned.link, left_cfw, right_cfw)] = trekked
 
 
-def _run(planned: Planned, left_cfw: type[ComputeFramework], right_cfw: type[ComputeFramework]) -> Optional[JoinStep]:
+def _run(planned: Planned, left_cfw: type[ComputeFramework], right_cfw: type[ComputeFramework]) -> JoinStep | None:
     link_fw: LinkFrameworkTrekker = (planned.link, left_cfw, right_cfw)
     return planned.plan.run_link(link_fw, planned.link_trekker, planned.graph, planned.pre_execution_plan)
 

--- a/tests/test_core/test_prepare/test_match_abort_escalation.py
+++ b/tests/test_core/test_prepare/test_match_abort_escalation.py
@@ -13,7 +13,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import ClassVar, Optional, TypeVar
+from typing import ClassVar, TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -64,7 +64,7 @@ class _RaiseReadout:
     message: str
 
 
-def _outcome(call: Callable[[], T]) -> tuple[Optional[T], Optional[_RaiseReadout]]:
+def _outcome(call: Callable[[], T]) -> tuple[T | None, _RaiseReadout | None]:
     """Run call, returning (value, None) or (None, readout of the escaping raise)."""
     try:
         return call(), None
@@ -72,7 +72,7 @@ def _outcome(call: Callable[[], T]) -> tuple[Optional[T], Optional[_RaiseReadout
         return None, _RaiseReadout(is_match_abort(exc), type(exc).__name__, str(exc))
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     value, readout = _outcome(call)
     return value, None if readout is None else f"{readout.type_name}: {readout.message}"
@@ -99,13 +99,13 @@ def _make_marked_raise_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) != MARKED_FEATURE:
                 return False
             raise escalate_match_abort(ValueError(MARKED_MESSAGE))
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return MarkedRaiseFG845e
@@ -131,13 +131,13 @@ def _make_unmarked_raise_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(feature_name) != UNMARKED_FEATURE:
                 return False
             raise ValueError(UNMARKED_MESSAGE)
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return UnmarkedRaiseFG845e
@@ -147,14 +147,14 @@ def _make_unmarked_raise_fg() -> type[FeatureGroup]:
 class _ContainedSnapshot:
     """Plain-data readout of one contained evaluation. Holds no class and no exception object."""
 
-    escaped: Optional[str]
-    failure_kind: Optional[str]
+    escaped: str | None
+    failure_kind: str | None
     eliminated_names: tuple[str, ...]
-    stage: Optional[str]
-    reason: Optional[str]
+    stage: str | None
+    reason: str | None
 
 
-def _evaluate_marked_raise() -> Optional[str]:
+def _evaluate_marked_raise() -> str | None:
     """Evaluate the marked double's own feature; return the escaping raise as 'Type: message', else None."""
     broken_fg = _make_marked_raise_fg()
     try:
@@ -257,7 +257,7 @@ class BothCategoriesMixin845f(FeatureChainParserMixin):
 
     PREFIX_PATTERN = BINDING_PATTERN
     # Annotated exactly as FeatureGroup declares it, so the FeatureGroup subclass below stays consistent.
-    PROPERTY_MAPPING: ClassVar[Optional[dict[str, PropertySpec]]] = {
+    PROPERTY_MAPPING: ClassVar[dict[str, PropertySpec] | None] = {
         BINDING_KEY: property_spec("the key the feature name carries")
     }
 
@@ -282,13 +282,13 @@ def _make_both_categories_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {MatchAbortFw845e}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return BothCategoriesFG845f
 
 
-def _evaluate_both_categories() -> Optional[_RaiseReadout]:
+def _evaluate_both_categories() -> _RaiseReadout | None:
     """Evaluate the both-categories candidate through the seam; read any escaping raise out as plain data."""
     probe_fg = _make_both_categories_fg()
     try:
@@ -310,14 +310,14 @@ def _make_is_root_fg(raiser: Callable[[], None]) -> type[FeatureGroup]:
     class IsRootProbeFG845f(FeatureGroup):
         """Stands in for a group whose input_features cannot answer for this feature name."""
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             raiser()
             return None
 
     return IsRootProbeFG845f
 
 
-def _is_root_outcome(raiser: Callable[[], None]) -> tuple[Optional[bool], Optional[_RaiseReadout]]:
+def _is_root_outcome(raiser: Callable[[], None]) -> tuple[bool | None, _RaiseReadout | None]:
     """(verdict, None) when is_root answers, (None, readout) when the raise escapes it."""
     probe_fg = _make_is_root_fg(raiser)
     try:

--- a/tests/test_core/test_prepare/test_match_abort_marker_robustness.py
+++ b/tests/test_core/test_prepare/test_match_abort_marker_robustness.py
@@ -10,7 +10,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -68,7 +68,7 @@ class SlottedFrameworkError845r(Exception):
     __slots__ = ()
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -97,13 +97,13 @@ def _make_raising_fg(class_name: str, feature_name: str, exc_factory: Callable[[
             cls,
             name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if str(name) != feature_name:
                 return False
             raise exc_factory()
 
-        def input_features(self, options: Options, feature_name_arg: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name_arg: FeatureName) -> set[Feature] | None:
             return None
 
     MarkerProbeFG845r.__name__ = class_name
@@ -115,11 +115,11 @@ def _make_raising_fg(class_name: str, feature_name: str, exc_factory: Callable[[
 class _ContainmentSnapshot:
     """Plain-data readout of one seam evaluation. Holds no class and no exception object."""
 
-    escaped: Optional[str]
-    failure_kind: Optional[str]
+    escaped: str | None
+    failure_kind: str | None
     eliminated_names: tuple[str, ...]
-    stage: Optional[str]
-    reason: Optional[str]
+    stage: str | None
+    reason: str | None
 
 
 def _evaluate_raising_matcher(

--- a/tests/test_core/test_prepare/test_match_data_conflict_stays_loud.py
+++ b/tests/test_core/test_prepare/test_match_data_conflict_stays_loud.py
@@ -10,7 +10,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -38,7 +38,7 @@ class MatchDataFw845r(ComputeFramework):
     """Dummy compute framework for the MatchData conflict tests."""
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -67,8 +67,8 @@ def _make_conflicting_match_data_fg() -> type[FeatureGroup]:
             cls,
             feature_name: str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
-            framework_connection_object: Optional[Any] = None,
+            data_access_collection: DataAccessCollection | None = None,
+            framework_connection_object: Any | None = None,
         ) -> Any:
             if str(feature_name) != CONFLICT_FEATURE:
                 return None
@@ -77,7 +77,7 @@ def _make_conflicting_match_data_fg() -> type[FeatureGroup]:
                 return None
             return GLOBAL_SCOPE_ACCESS
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return ConflictMatchDataFG845r
@@ -98,7 +98,7 @@ def _make_rival_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {MatchDataFw845r}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return MatchDataRivalFG845r
@@ -108,7 +108,7 @@ def _make_rival_fg() -> type[FeatureGroup]:
 class _ConflictSnapshot:
     """Plain-data readout of one evaluation. Holds no class and no exception object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     identified_names: tuple[str, ...]
 
 

--- a/tests/test_core/test_prepare/test_name_source_count_elimination.py
+++ b/tests/test_core/test_prepare/test_name_source_count_elimination.py
@@ -8,7 +8,6 @@ assert, so no failing assert pins it (tests/conftest.py).
 from __future__ import annotations
 
 import gc
-from typing import Optional
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -48,19 +47,19 @@ def _make_min_count_mixin_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {MinCountFw944}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return MinInFeaturesMixinFG944
 
 
-def _resolve(feature_name: str) -> tuple[Optional[str], tuple[str, ...], tuple[tuple[str, str, str], ...]]:
+def _resolve(feature_name: str) -> tuple[str | None, tuple[str, ...], tuple[tuple[str, str, str], ...]]:
     """Evaluate that name: (error type, winner names, (class, stage, reason) per elimination)."""
     feature_group = _make_min_count_mixin_fg()
     feature = Feature(feature_name, Options())
     plugins: FeatureGroupEnvironmentMapping = {feature_group: {MinCountFw944}}
-    error_type: Optional[str] = None
-    result: Optional[EvaluationResult] = None
+    error_type: str | None = None
+    result: EvaluationResult | None = None
     try:
         result = evaluate_or_raise(feature, plugins, None)
     except FeatureResolutionError as exc:

--- a/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
+++ b/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
@@ -7,7 +7,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -43,7 +43,7 @@ class OptionWriteFw932(ComputeFramework):
     pass
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Returns (value, None) or (None, 'Type: message'); no traceback is retained."""
     try:
         return call(), None
@@ -55,7 +55,7 @@ def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
 class _ConflictSnapshot:
     """Readout of one evaluation, holding no class and no exception object."""
 
-    escaped: Optional[str]
+    escaped: str | None
     identified_names: tuple[str, ...]
 
 
@@ -78,8 +78,8 @@ def _make_match_data_fg() -> type[FeatureGroup]:
             cls,
             feature_name: str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
-            framework_connection_object: Optional[Any] = None,
+            data_access_collection: DataAccessCollection | None = None,
+            framework_connection_object: Any | None = None,
         ) -> Any:
             if str(feature_name) != MATCH_DATA_FEATURE:
                 return None
@@ -87,7 +87,7 @@ def _make_match_data_fg() -> type[FeatureGroup]:
                 return None
             return GLOBAL_ACCESS
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return OptionWriteMatchDataFG932
@@ -106,7 +106,7 @@ def _make_match_data_rival_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {OptionWriteFw932}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return OptionWriteMatchDataRivalFG932
@@ -121,7 +121,7 @@ class OptionWriteReader932(OptionWriteReaderFamily932):
 
     @classmethod
     def match_subclass_data_access(
-        cls, data_access: Any, feature_names: list[str], options: Optional[Options] = None
+        cls, data_access: Any, feature_names: list[str], options: Options | None = None
     ) -> Any:
         if isinstance(data_access, DataAccessCollection):
             if GLOBAL_ACCESS in data_access.connections.values():
@@ -142,7 +142,7 @@ def _make_reader_fg() -> type[FeatureGroup]:
 
     class OptionWriteReaderFG932(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return OptionWriteReaderFamily932()
 
         @classmethod
@@ -153,7 +153,7 @@ def _make_reader_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {OptionWriteFw932}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return OptionWriteReaderFG932
@@ -172,7 +172,7 @@ def _make_reader_rival_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {OptionWriteFw932}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return OptionWriteReaderRivalFG932
@@ -182,8 +182,8 @@ def _evaluate(
     feature_name: str,
     options: Options,
     conflict_fg: type[FeatureGroup],
-    rival_fg: Optional[type[FeatureGroup]],
-    data_access: Optional[DataAccessCollection],
+    rival_fg: type[FeatureGroup] | None,
+    data_access: DataAccessCollection | None,
 ) -> _ConflictSnapshot:
     """Evaluates one feature at the match seam and reads the outcome out as plain data."""
     feature = Feature(feature_name, options=options)
@@ -219,7 +219,7 @@ def _evaluate_reader_conflict(with_rival: bool, global_scope: bool, reserved_val
     rival_fg = _make_reader_rival_fg() if with_rival else None
     try:
         group: dict[str, Any] = {RESERVED_KEY: reserved_value}
-        data_access: Optional[DataAccessCollection] = None
+        data_access: DataAccessCollection | None = None
         if global_scope:
             data_access = DataAccessCollection(connections={"option_write_handle_932": GLOBAL_ACCESS})
         else:

--- a/tests/test_core/test_prepare/test_raising_matcher_containment.py
+++ b/tests/test_core/test_prepare/test_raising_matcher_containment.py
@@ -10,7 +10,7 @@ import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -54,11 +54,11 @@ class ContainedNeighborFG845(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {ContainedFw845}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
     try:
         return call(), None
@@ -87,11 +87,11 @@ def _make_raising_matcher_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             raise RuntimeError(RAISE_MESSAGE)
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return RaisingMatcherFG845
@@ -101,13 +101,13 @@ def _make_raising_matcher_fg() -> type[FeatureGroup]:
 class _OwnFeatureSnapshot:
     """Plain-data readout of one own-feature evaluation. Holds no class and no exception object."""
 
-    escaped: Optional[str]
-    failure_kind: Optional[str]
+    escaped: str | None
+    failure_kind: str | None
     eliminated_names: tuple[str, ...]
-    stage: Optional[str]
-    reason: Optional[str]
-    reason_type: Optional[str]
-    message: Optional[str]
+    stage: str | None
+    reason: str | None
+    reason_type: str | None
+    message: str | None
 
 
 def _evaluate_own_feature() -> _OwnFeatureSnapshot:

--- a/tests/test_core/test_prepare/test_required_when_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_required_when_rejection_recording.py
@@ -18,7 +18,6 @@ guard turns the match into a non-match unless its own unique option keys are pre
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Optional
 
 import pytest
 
@@ -56,7 +55,7 @@ class RwrecRequiredWhenFG(FeatureGroup):
         RWREC_COMPANION_KEY: PropertySpec("The alternative to the required key.", context=False, default=None),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -17,7 +17,7 @@ from abc import abstractmethod
 from ast import literal_eval
 from collections.abc import Callable, Iterable, Iterator
 from difflib import get_close_matches
-from typing import Any, ClassVar, Optional, cast, get_args
+from typing import Any, ClassVar, cast, get_args
 
 import pytest
 
@@ -384,7 +384,7 @@ class RendererBareOnlyFG791(CountingFeatureGroup791):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         matched = super().match_feature_group_criteria(feature_name, options, data_access_collection)
         return matched and not options.group
@@ -408,7 +408,7 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
         cls,
         feature_name: str | FeatureName,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         HOOK_COUNTER_791.record(cls.get_class_name(), "match_feature_group_criteria")
         return super().match_feature_group_criteria(feature_name, options, data_access_collection)
@@ -434,12 +434,12 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
         return super().supports_compute_framework(feature_name, options, compute_framework)
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         HOOK_COUNTER_791.record(cls.get_class_name(), "index_columns")
         return None
 
     @classmethod
-    def supports_index(cls, index: Index) -> Optional[bool]:
+    def supports_index(cls, index: Index) -> bool | None:
         HOOK_COUNTER_791.record(cls.get_class_name(), "supports_index")
         return None
 
@@ -458,7 +458,7 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
         HOOK_COUNTER_791.record(cls.get_class_name(), "_strict_validation_rejection_reason")
         return super()._strict_validation_rejection_reason(feature_name, options)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -475,7 +475,7 @@ class RendererMissingOptionFG791(FeatureChainParserMixin, FeatureGroup):
         DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -585,7 +585,7 @@ class RendererValueStageFG791(CountingFeatureGroup791):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         # Name-guarded, so this globally visible class stays inert for every other name it is asked about.
         if not super().match_feature_group_criteria(feature_name, options, data_access_collection):
@@ -627,7 +627,7 @@ class RendererLivePrefixFG791(CountingFeatureGroup791):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         cls._enter_hook("match_feature_group_criteria")
         return cls.feature_name_contains_class_name_as_prefix(str(feature_name))
@@ -665,7 +665,7 @@ class RendererCrossDomainNameFG791(CountingFeatureGroup791):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         cls._enter_hook("match_feature_group_criteria")
         # The two class-identity rules of the default matcher, and the two names the catalog captures for it.
@@ -743,7 +743,7 @@ class ValueRejectingCrossDomainFG791(CountingFeatureGroup791):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         # Name-guarded, so this globally visible class stays inert for every other name it is asked about.
         if not super().match_feature_group_criteria(feature_name, options, data_access_collection):
@@ -765,7 +765,7 @@ class ValueRejectingUnlinkedFG791(CountingFeatureGroup791):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         # Name-guarded, so this globally visible class stays inert for every other name it is asked about.
         if not super().match_feature_group_criteria(feature_name, options, data_access_collection):
@@ -1057,7 +1057,7 @@ def _build_renamed_group() -> type[CountingFeatureGroup791]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             cls._enter_hook("match_feature_group_criteria")
             # The two class-identity rules of the default matcher, both of which read get_class_name().

--- a/tests/test_core/test_prepare/test_resolve_or_raise.py
+++ b/tests/test_core/test_prepare/test_resolve_or_raise.py
@@ -21,8 +21,6 @@ All fixture names carry an ``016`` suffix: test feature groups become global sub
 parallel, so a shared name would leak into another module's candidate universe.
 """
 
-from typing import Optional
-
 import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
@@ -128,7 +126,7 @@ def _built_plugins_for(feature_name: str) -> FeatureGroupEnvironmentMapping:
     return PreFilterPlugins(_frameworks_016(), _collector_for(feature_name)).get_accessible_plugins()
 
 
-def _resolve_feature_016(feature_name: str, scope: Optional[type[FeatureGroup]] = None) -> ResolvedFeature:
+def _resolve_feature_016(feature_name: str, scope: type[FeatureGroup] | None = None) -> ResolvedFeature:
     """Run resolve_feature over the fixture universe of one failure kind."""
     return resolve_feature(
         feature_name,
@@ -181,8 +179,8 @@ RENDER_EXPLOSION_016 = "resolve_or_raise_016 render step exploded"
 def _exploding_evaluate_and_render(
     feature: Feature,
     accessible_plugins: FeatureGroupEnvironmentMapping,
-    links: Optional[set[Link]] = None,
-    data_access_collection: Optional[DataAccessCollection] = None,
+    links: set[Link] | None = None,
+    data_access_collection: DataAccessCollection | None = None,
 ) -> tuple[EvaluationResult, str | None]:
     """Stand-in for the helper pair that always raises, standing for a renderer that blows up."""
     raise RuntimeError(RENDER_EXPLOSION_016)

--- a/tests/test_core/test_prepare/test_run_link_empty_uuid_guard.py
+++ b/tests/test_core/test_prepare/test_run_link_empty_uuid_guard.py
@@ -5,7 +5,7 @@ through run_link's subset branch and produce an empty destination/source uuid se
 unguarded, that empty set later raises an unguarded StopIteration in compute_framework_executor.
 """
 
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -91,7 +91,7 @@ def test_validate_join_step_uuids_accepts_two_genuine_non_empty_sides() -> None:
 
 class WiringJoinLeftFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"wiring_join_left"})
 
     @classmethod
@@ -105,13 +105,13 @@ class WiringJoinLeftFG(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("id",))]
 
 
 class WiringJoinRightFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"wiring_join_right"})
 
     @classmethod
@@ -125,12 +125,12 @@ class WiringJoinRightFG(FeatureGroup):
         return {PyArrowTable}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("id",))]
 
 
 class WiringJoinChild(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("wiring_join_left"), Feature("wiring_join_right")}
 
     @classmethod

--- a/tests/test_core/test_prepare/test_single_pass_exactly_once.py
+++ b/tests/test_core/test_prepare/test_single_pass_exactly_once.py
@@ -23,7 +23,7 @@ parallel, so a shared name would leak into another module's candidate universe.
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Optional, cast
+from typing import Any, ClassVar, cast
 
 import pytest
 
@@ -163,9 +163,9 @@ class CountingSinglePassFG_782(FeatureGroup):
     """Feature group base counting every provider-overridable hook one resolution attempt may reach."""
 
     MATCHES: frozenset[str] = frozenset()
-    DOMAIN_NAME: Optional[str] = None
-    FRAMEWORK_RULE: Optional[set[type[ComputeFramework]]] = None
-    SUPPORTED_FRAMEWORKS: Optional[frozenset[str]] = None
+    DOMAIN_NAME: str | None = None
+    FRAMEWORK_RULE: set[type[ComputeFramework]] | None = None
+    SUPPORTED_FRAMEWORKS: frozenset[str] | None = None
     SUPPORTED_NAMES: frozenset[str] = frozenset()
 
     @classmethod
@@ -173,7 +173,7 @@ class CountingSinglePassFG_782(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         _record(cls.get_class_name(), "match_feature_group_criteria")
         return str(feature_name) in cls.MATCHES
@@ -204,12 +204,12 @@ class CountingSinglePassFG_782(FeatureGroup):
         return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         _record(cls.get_class_name(), "index_columns")
         return None
 
     @classmethod
-    def supports_index(cls, index: Index) -> Optional[bool]:
+    def supports_index(cls, index: Index) -> bool | None:
         _record(cls.get_class_name(), "supports_index")
         _record_index(cls.get_class_name(), index)
         return None
@@ -224,7 +224,7 @@ class CountingSinglePassFG_782(FeatureGroup):
         _record(cls.get_class_name(), "prefix")
         return f"{cls.get_class_name()}_"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -290,7 +290,7 @@ class SinglePassBareOnlyFG_782(CountingSinglePassFG_782):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         matched = super().match_feature_group_criteria(feature_name, options, data_access_collection)
         return matched and not options.group
@@ -311,7 +311,7 @@ class SinglePassReaderFG_782(CountingSinglePassFG_782):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         _record(cls.get_class_name(), "match_feature_group_criteria")
         options.add_to_context(f"{OPTION_PROBE_PREFIX_782}{len(_probe_keys(options))}", "seen")
@@ -327,12 +327,12 @@ class SinglePassLinkFG_782(CountingSinglePassFG_782):
     FRAMEWORK_RULE = {SinglePassFwOne_782}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         _record(cls.get_class_name(), "index_columns")
         return [LEFT_INDEX_782]
 
     @classmethod
-    def supports_index(cls, index: Index) -> Optional[bool]:
+    def supports_index(cls, index: Index) -> bool | None:
         _record(cls.get_class_name(), "supports_index")
         _record_index(cls.get_class_name(), index)
         return False
@@ -350,7 +350,7 @@ class SinglePassStatefulMatchFG_782(CountingSinglePassFG_782):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         _record(cls.get_class_name(), "match_feature_group_criteria")
         if _next_stateful_answer(cls.get_class_name()) > 0:
@@ -565,7 +565,7 @@ class SinglePassStrictFG_782(FeatureChainParserMixin, FeatureGroup):
         cls,
         feature_name: str | FeatureName,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         _record(cls.get_class_name(), "match_feature_group_criteria")
         return super().match_feature_group_criteria(feature_name, options, data_access_collection)
@@ -592,7 +592,7 @@ class SinglePassStrictFG_782(FeatureChainParserMixin, FeatureGroup):
         return super().supports_compute_framework(feature_name, options, compute_framework)
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         _record(cls.get_class_name(), "index_columns")
         return None
 
@@ -611,7 +611,7 @@ class SinglePassStrictFG_782(FeatureChainParserMixin, FeatureGroup):
         _record(cls.get_class_name(), "_strict_validation_rejection_reason")
         return super()._strict_validation_rejection_reason(feature_name, options)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -627,8 +627,8 @@ class Scenario782:
     feature: Feature
     feature_groups: frozenset[type[FeatureGroup]]
     frameworks: frozenset[type[ComputeFramework]] = frozenset({SinglePassFwOne_782})
-    links: Optional[set[Link]] = None
-    data_access_collection: Optional[DataAccessCollection] = None
+    links: set[Link] | None = None
+    data_access_collection: DataAccessCollection | None = None
     # Every accessible candidate the matcher must be asked about, exactly once. Drives the EXACT counter
     # expectation, so a hook that stops being called at all fails just as loudly as one called twice.
     candidates: frozenset[str] = field(default_factory=frozenset)
@@ -687,7 +687,7 @@ def _resolve_error(scenario: Scenario782) -> str:
     return resolved.error
 
 
-def multiple_scenario(scope: Optional[str] = None) -> Scenario782:
+def multiple_scenario(scope: str | None = None) -> Scenario782:
     """Two identified candidates."""
     return Scenario782(
         feature=Feature(MULTIPLE_FEATURE_782, feature_group=scope),
@@ -696,7 +696,7 @@ def multiple_scenario(scope: Optional[str] = None) -> Scenario782:
     )
 
 
-def domain_multiple_scenario(scope: Optional[str] = None) -> Scenario782:
+def domain_multiple_scenario(scope: str | None = None) -> Scenario782:
     """Two identified candidates for a request that CARRIES a domain, so the filter loop asks get_domain."""
     return Scenario782(
         feature=Feature(DOMAIN_MULTIPLE_FEATURE_782, domain=PROBE_DOMAIN_782, feature_group=scope),
@@ -705,7 +705,7 @@ def domain_multiple_scenario(scope: Optional[str] = None) -> Scenario782:
     )
 
 
-def abstract_only_scenario(scope: Optional[str] = None) -> Scenario782:
+def abstract_only_scenario(scope: str | None = None) -> Scenario782:
     """Abstract base matched; its criteria-matched concrete subclass declares no enabled framework."""
     return Scenario782(
         feature=Feature(ABSTRACT_FEATURE_782, feature_group=scope),
@@ -715,7 +715,7 @@ def abstract_only_scenario(scope: Optional[str] = None) -> Scenario782:
     )
 
 
-def capability_scenario(scope: Optional[str] = None) -> Scenario782:
+def capability_scenario(scope: str | None = None) -> Scenario782:
     """The one enabled framework is the one the candidate rejects."""
     return Scenario782(
         feature=Feature(CAPABILITY_FEATURE_782, feature_group=scope),
@@ -724,7 +724,7 @@ def capability_scenario(scope: Optional[str] = None) -> Scenario782:
     )
 
 
-def ordinary_none_scenario(scope: Optional[str] = None) -> Scenario782:
+def ordinary_none_scenario(scope: str | None = None) -> Scenario782:
     """No match: the candidate matches the bare name but rejects the feature's group options."""
     return Scenario782(
         feature=Feature(BARE_ONLY_FEATURE_782, Options(group={"top_k_782": 5}), feature_group=scope),

--- a/tests/test_core/test_prepare/test_subtype_accessor_override_allowed.py
+++ b/tests/test_core/test_prepare/test_subtype_accessor_override_allowed.py
@@ -7,7 +7,7 @@ The matrix-voiding check (subtype_support_matrix raising for a hand-written
 supports_compute_framework override) stays.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -57,7 +57,7 @@ class TestSbrmDerivedAccessorOverrideAllowed:
         assert overriding.canonical_subtype("median") == "sbrm_canon_median"
 
     def test_sbrm_resolve_subtype_override_on_declared_family_takes_effect(self) -> None:
-        def sbrm_resolve(cls: type[FeatureGroup], feature_name: FeatureName | str, options: Options) -> Optional[str]:
+        def sbrm_resolve(cls: type[FeatureGroup], feature_name: FeatureName | str, options: Options) -> str | None:
             return "sbrm_resolved"
 
         overriding = type(

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -28,11 +28,11 @@ def _subdecl_is_positive_int(value: object) -> bool:
     return isinstance(value, int) and value > 0
 
 
-def _subdecl_noop_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdecl_noop_resolver(feature_name: str, options: Options) -> str | None:
     return None
 
 
-def _subdecl_frame_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdecl_frame_resolver(feature_name: str, options: Options) -> str | None:
     frame_type = options.get("subdecl_frame_type")
     frame_unit = options.get("subdecl_frame_unit")
     if frame_type is None or frame_unit is None:
@@ -40,11 +40,11 @@ def _subdecl_frame_resolver(feature_name: str, options: Options) -> Optional[str
     return f"{frame_type}_{frame_unit}"
 
 
-def _subdecl_echo_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdecl_echo_resolver(feature_name: str, options: Options) -> str | None:
     return feature_name
 
 
-def _subdecl_pred_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdecl_pred_resolver(feature_name: str, options: Options) -> str | None:
     value = options.get("subdecl_pred_key")
     if value is None:
         return None
@@ -117,7 +117,7 @@ class SubDeclPlainFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SubDeclFwAlpha, SubDeclFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -134,7 +134,7 @@ class SubDeclFlattenedFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SubDeclFwAlpha, SubDeclFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -143,7 +143,7 @@ class SubDeclEchoFG(FeatureGroup):
 
     SUBTYPES = SubtypeDeclaration(universe={"echo"}, resolver=_subdecl_echo_resolver)
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -163,7 +163,7 @@ class SubDeclPredicateUniverseFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SubDeclFwAlpha, SubDeclFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -183,7 +183,7 @@ class SubDeclValueSpaceFG(FeatureGroup):
         "subdecl_n": property_spec("Predicate-only key.", strict=True, element_validator=_subdecl_is_positive_int),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -238,7 +238,7 @@ class SubDeclHookMatrixPlainFG(FeatureGroup):
     ) -> bool:
         return True
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -678,7 +678,7 @@ def _subdecl_setitem(mapping: Any, key: str, value: Any) -> None:
     mapping[key] = value
 
 
-def _subdecl_raising_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdecl_raising_resolver(feature_name: str, options: Options) -> str | None:
     raise RuntimeError("subdecl resolver boom")
 
 
@@ -695,7 +695,7 @@ class SubDeclRaisingResolverFG(FeatureGroup):
         supported={SubDeclFwBeta.get_class_name(): frozenset()},
     )
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -708,7 +708,7 @@ class SubDeclIntResolverFG(FeatureGroup):
         supported={SubDeclFwBeta.get_class_name(): frozenset()},
     )
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -783,7 +783,7 @@ class TestSubDeclKeyedNumericValueSpace:
             def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
                 return {SubDeclFwAlpha, SubDeclFwBeta}
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return None
 
         options = Options(group={"subdecl_num_bucket": 2})

--- a/tests/test_core/test_prepare/test_subtype_declaration_hardening.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration_hardening.py
@@ -5,7 +5,7 @@ subtype_support_matrix(); supported keys are stringified on ingest; and the
 declaration is hashable even with mappings set.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -21,7 +21,7 @@ SBFIX_UNIVERSE = frozenset({"sum", "median"})
 SBFIX_BOGUS_FRAMEWORK = "SbfixNoSuchFramework"
 
 
-def _sbfix_noop_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _sbfix_noop_resolver(feature_name: str, options: Options) -> str | None:
     return None
 
 
@@ -48,7 +48,7 @@ class SbfixBogusSupportedFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SbfixFwAlpha}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -71,7 +71,7 @@ class SbfixHealthySupportedFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SbfixFwAlpha}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -1,7 +1,7 @@
 """Pinning tests for match-time enforcement of SubtypeDeclaration (issue #639)."""
 
 import re
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import pytest
 
@@ -137,7 +137,7 @@ class SubDeclMatchRankLikeFG(FeatureChainParserMixin, FeatureGroup):
         return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
 
-def _subdeclm_frame_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdeclm_frame_resolver(feature_name: str, options: Options) -> str | None:
     match = re.match(r".*__(rows_\d+)_frame$", feature_name)
     if match is None:
         return None
@@ -160,7 +160,7 @@ class SubDeclMatchFrameSpecFG(StubFeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name).startswith("subdeclm_") and str(feature_name).endswith("_frame")
 
@@ -318,7 +318,7 @@ class TestFrameSpecLikeFamily:
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
 
-def _subdeclm_raising_resolver(feature_name: str, options: Options) -> Optional[str]:
+def _subdeclm_raising_resolver(feature_name: str, options: Options) -> str | None:
     raise RuntimeError("subdeclm resolver boom")
 
 
@@ -335,7 +335,7 @@ class SubDeclMatchRaisingResolverFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_subtype_option_parity.py
+++ b/tests/test_core/test_prepare/test_subtype_option_parity.py
@@ -11,8 +11,6 @@ Defect 2: resolve_subtype promises "never raises", but a malformed
 PREFIX_PATTERN regex propagates re.error out of parse_feature_name.
 """
 
-from typing import Optional
-
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -54,7 +52,7 @@ class SbparWindowFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SbparFwAlpha, SbparFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -78,7 +76,7 @@ class SbparDefaultedFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SbparFwAlpha, SbparFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -102,7 +100,7 @@ class SbparBadPrefixFG(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {SbparFwAlpha, SbparFwBeta}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_dedup_different_parents_e2e.py
@@ -4,7 +4,7 @@ features. Before the fix this either crashes at runtime or silently serves one r
 other's data.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -25,7 +25,7 @@ class DedupParentsRootFG(FeatureGroup):
     """Pandas root exposing two distinct columns."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"dedup_col_x", "dedup_col_y"})
 
     @classmethod
@@ -44,7 +44,7 @@ class DedupParentsConsumerFG(FeatureGroup):
     """PyArrow consumer with two Options-gated requests, each pulling a DIFFERENT Pandas column
     as its own single parent, forcing two same-shaped Pandas->PyArrow transform hops."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         variant = options.get("dedup_variant")
         if variant == "x":
             return {Feature("dedup_col_x")}

--- a/tests/test_core/test_prepare/test_tfs_shared_source_step_e2e.py
+++ b/tests/test_core/test_prepare/test_tfs_shared_source_step_e2e.py
@@ -6,7 +6,7 @@ though both physically live on the same source compute framework instance, leaki
 destination compute framework and, under multiprocessing, downloading the same table twice.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 import pyarrow.compute as pc
@@ -27,7 +27,7 @@ class SharedSourceRootFG(FeatureGroup):
     """Pandas root exposing two columns that are always computed TOGETHER by one step."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"twocol_a", "twocol_b"})
 
     @classmethod
@@ -44,7 +44,7 @@ class SharedSourceConsumerFG(FeatureGroup):
     """PyArrow consumer pulling BOTH root columns in a single request, forcing one
     FeatureGroupStep on the root that produces both columns together."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("twocol_a"), Feature("twocol_b")}
 
     @classmethod

--- a/tests/test_core/test_prepare/test_transform_hop_identity.py
+++ b/tests/test_core/test_prepare/test_transform_hop_identity.py
@@ -4,7 +4,7 @@ that, the dedup dropped one of the two hops, the JoinStep lost its transform-ste
 ``run()`` failed to find its source data.
 """
 
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 import pandas as pd
@@ -29,7 +29,7 @@ class HopIdA(FeatureGroup):
     """Pandas root: the join's declared left side."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"hop_id_jid", "hop_id_a_val", "hop_id_a_helper"})
 
     @classmethod
@@ -41,7 +41,7 @@ class HopIdA(FeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("hop_id_jid",))]
 
 
@@ -49,10 +49,10 @@ class HopIdB(FeatureGroup):
     """PyArrow root (join's declared right side); its own index feature doubles as an option-gated derived one."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"hop_id_bjid", "hop_id_b_val"})
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         if options.get("hop_id_variant") == "other":
             return {Feature("hop_id_a_helper", options=Options({"hop_id_variant": "other"}))}
         return None
@@ -69,7 +69,7 @@ class HopIdB(FeatureGroup):
         return {PyArrowTable}
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("hop_id_bjid",))]
 
     @classmethod
@@ -82,7 +82,7 @@ class HopIdB(FeatureGroup):
 class HopIdC(FeatureGroup):
     """PyArrow consumer of both join sides: forces the join's own transform hop into the plan."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("hop_id_a_val"), Feature("hop_id_b_val")}
 
     @classmethod
@@ -138,7 +138,7 @@ def _optioned_hop_id_bjid_step(session: mlodaAPI) -> FeatureGroupStep:
     )
 
 
-def _describe(step: TransformFrameworkStep) -> tuple[str, str, str, str, Optional[UUID]]:
+def _describe(step: TransformFrameworkStep) -> tuple[str, str, str, str, UUID | None]:
     return (
         step.from_framework.get_class_name(),
         step.to_framework.get_class_name(),
@@ -223,7 +223,7 @@ class TestTransformFrameworkStepIdentityIncludesLinkId:
     """A join's transform hop and a plain feature-group hop of the same shape must not collide."""
 
     @staticmethod
-    def _step(link_id: Optional[UUID]) -> TransformFrameworkStep:
+    def _step(link_id: UUID | None) -> TransformFrameworkStep:
         return TransformFrameworkStep(
             from_framework=PandasDataFrame,
             to_framework=PyArrowTable,
@@ -253,7 +253,7 @@ class TestTransformFrameworkStepIdentityIncludesSourceStepUuid:
     """Hops of the same shape must key on source_step_uuid: different owning steps, or a join hop, must not collide."""
 
     @staticmethod
-    def _step(source_step_uuid: Optional[UUID]) -> TransformFrameworkStep:
+    def _step(source_step_uuid: UUID | None) -> TransformFrameworkStep:
         return TransformFrameworkStep(
             from_framework=PandasDataFrame,
             to_framework=PyArrowTable,

--- a/tests/test_core/test_prepare/test_transform_hop_requires_explicit_link.py
+++ b/tests/test_core/test_prepare/test_transform_hop_requires_explicit_link.py
@@ -2,7 +2,7 @@
 must raise a "missing Links" ValueError at plan-build time, not silently bind only one hop's data.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -14,7 +14,7 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 
 class UnlinkedRootA(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"unlinked_root_a"})
 
     @classmethod
@@ -30,7 +30,7 @@ class UnlinkedRootA(FeatureGroup):
 
 class UnlinkedRootB(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"unlinked_root_b"})
 
     @classmethod
@@ -45,7 +45,7 @@ class UnlinkedRootB(FeatureGroup):
 
 
 class UnlinkedConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("unlinked_root_a"), Feature("unlinked_root_b")}
 
     @classmethod

--- a/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
@@ -8,7 +8,7 @@ so no failing assert pins it (tests/conftest.py).
 from __future__ import annotations
 
 import gc
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -46,21 +46,21 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
             return {InFeaturesFw884}
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return InFeaturesMixinFG884
 
 
-def _resolve(in_features: Any) -> tuple[Optional[str], tuple[str, ...], tuple[tuple[str, str, str], ...]]:
+def _resolve(in_features: Any) -> tuple[str | None, tuple[str, ...], tuple[tuple[str, str, str], ...]]:
     """Evaluate one feature carrying that value: (error type, winner names, (class, stage, reason) per elimination)."""
     feature_group = _make_in_features_mixin_fg()
     options = Options(context={"operation": "op1", DefaultOptionKeys.in_features: in_features})
     feature = Feature(IN_FEATURES_FEATURE_884, options)
     plugins: FeatureGroupEnvironmentMapping = {feature_group: {InFeaturesFw884}}
     try:
-        error_type: Optional[str] = None
-        result: Optional[EvaluationResult] = evaluate_or_raise(feature, plugins, None)
+        error_type: str | None = None
+        result: EvaluationResult | None = evaluate_or_raise(feature, plugins, None)
     except FeatureResolutionError as exc:
         error_type, result = type(exc).__name__, exc.result
     except Exception as exc:  # noqa: BLE001  (an untyped escape is a fact this test wants to report)

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -27,7 +27,6 @@ is merely filtered, so plain pytest.raises is safe for it.
 
 import gc
 import sys
-from typing import Optional
 
 import pytest
 
@@ -80,11 +79,11 @@ def _make_broken_rule_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == ENV_BUILD_FAILURE_FEATURE
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return EnvBuildFailureProbe790
@@ -112,11 +111,11 @@ def _make_value_error_rule_fg() -> type[FeatureGroup]:
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == ENV_BUILD_VALUE_ERROR_FEATURE
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return EnvBuildValueErrorProbe790
@@ -147,17 +146,17 @@ def _make_mloda_typed_error_rule_fg(
             cls,
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             return str(feature_name) == expected_feature_name
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return None
 
     return EnvBuildMlodaTypedErrorProbe790
 
 
-def _capture_engine_build_failure() -> Optional[str]:
+def _capture_engine_build_failure() -> str | None:
     """Drive a real Engine and return the message its environment build raised, or None if it did not raise.
 
     The Engine itself is under test here, not a stand-in: asserting in prose that PreFilterPlugins is what
@@ -277,7 +276,7 @@ def test_diagnose_projects_the_environment_build_failure() -> None:
         feature_name = diagnosis.feature_name
         failed_result = diagnosis.failed_result
         del diagnosis
-        prepare_error: Optional[str] = None
+        prepare_error: str | None = None
         try:
             mlodaAPI.prepare([ENV_BUILD_FAILURE_FEATURE], compute_frameworks={PandasDataFrame})
         except FrameworkDeclarationError:
@@ -425,11 +424,11 @@ class CollectorFilteredProbe850(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_resolution_parity/test_verified_false_positives.py
+++ b/tests/test_core/test_resolution_parity/test_verified_false_positives.py
@@ -13,7 +13,6 @@ divergences are erased wholesale when resolve_feature delegates, so they need no
 
 import inspect
 from abc import abstractmethod
-from typing import Optional
 
 import pytest
 
@@ -66,7 +65,7 @@ class AbstractOnlyProbe753(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == ABSTRACT_ONLY_FEATURE
 
@@ -75,7 +74,7 @@ class AbstractOnlyProbe753(FeatureGroup):
     def _probe_hook_753(cls) -> str:
         """Abstract hook that keeps this probe abstract."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -91,11 +90,11 @@ class ParentProbe753(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == PARENT_CHILD_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 
@@ -119,11 +118,11 @@ class UnavailableOnlyProbe753(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == UNAVAILABLE_FEATURE
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_core/test_runtime/test_child_bootstrap_failure_multiprocessing_e2e.py
+++ b/tests/test_core/test_runtime/test_child_bootstrap_failure_multiprocessing_e2e.py
@@ -3,7 +3,7 @@ not just kill the worker process silently."""
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -14,7 +14,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 class _ChildBootstrapFailureFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"child_bootstrap_failure_col"})
 
     @classmethod

--- a/tests/test_core/test_runtime/test_child_bootstrap_multiprocessing_e2e.py
+++ b/tests/test_core/test_runtime/test_child_bootstrap_multiprocessing_e2e.py
@@ -9,7 +9,7 @@ reliable proxy for in-process ordering.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -22,7 +22,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 class _ChildBootstrapFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"child_bootstrap_e2e_col"})
 
     @classmethod

--- a/tests/test_core/test_runtime/test_exception_preservation.py
+++ b/tests/test_core/test_runtime/test_exception_preservation.py
@@ -21,7 +21,7 @@ and because ``MlodaRunError`` does not yet exist.
 from __future__ import annotations
 
 import threading
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -50,7 +50,7 @@ class ImportErrorFeatureGroup(FeatureGroup):
     """Root FG whose ``calculate_feature`` raises a stdlib ``ImportError``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"exc_import_error_col"})
 
     @classmethod
@@ -70,7 +70,7 @@ class DomainErrorFeatureGroup(FeatureGroup):
     """Root FG whose ``calculate_feature`` raises a ``ValueError`` subclass."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"exc_domain_error_col"})
 
     @classmethod
@@ -86,7 +86,7 @@ class CauseChainFeatureGroup(FeatureGroup):
     """Root FG that raises ``ValueError`` from a ``KeyError`` (``__cause__`` chain)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"exc_cause_chain_col"})
 
     @classmethod
@@ -260,7 +260,7 @@ class UnpicklableErrorFeatureGroup(FeatureGroup):
     """Root FG whose ``calculate_feature`` raises a non-picklable exception."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"exc_unpicklable_col"})
 
     @classmethod

--- a/tests/test_core/test_runtime/test_verified_context_multiprocessing_e2e.py
+++ b/tests/test_core/test_runtime/test_verified_context_multiprocessing_e2e.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -27,7 +27,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 class _VerifiedContextMultiprocessingFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"verified_context_mp_e2e_col"})
 
     @classmethod

--- a/tests/test_core/test_runtime/test_worker_index_multiprocessing_e2e.py
+++ b/tests/test_core/test_runtime/test_worker_index_multiprocessing_e2e.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -25,7 +25,7 @@ _CARRIER = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7
 
 class _WorkerIndexFeatureGroupOne(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"worker_index_e2e_col_one"})
 
     @classmethod
@@ -39,7 +39,7 @@ class _WorkerIndexFeatureGroupOne(FeatureGroup):
 
 class _WorkerIndexFeatureGroupTwo(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"worker_index_e2e_col_two"})
 
     @classmethod

--- a/tests/test_core/test_setup/test_asof_link.py
+++ b/tests/test_core/test_setup/test_asof_link.py
@@ -11,7 +11,7 @@ The implementation does not exist yet, so these tests are expected to FAIL
 (at import / attribute level or assertion level).
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -28,22 +28,22 @@ from mloda.user import Options
 class AsofFGa(FeatureGroup):
     """Mock left feature group with a single by-key index column 'k'."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("k",))]
 
 
 class AsofFGb(FeatureGroup):
     """Mock right feature group with a single by-key index column 'k'."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("k",))]
 
 

--- a/tests/test_core/test_setup/test_graph_builder.py
+++ b/tests/test_core/test_setup/test_graph_builder.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Optional
 from uuid import UUID
 import uuid
 
@@ -20,7 +19,7 @@ class BaseTestGraphFeatureGroup3(BaseTestFeatureGroup1):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if "GraphFeature" in str(feature_name):
             return True
@@ -37,14 +36,14 @@ class BaseTestGraphFeatureGroup4(BaseTestGraphFeatureGroup3):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if "GraphFeatureIndex" in str(feature_name):
             return True
         return False
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         index_1 = Index(tuple(["Index1"]))
         return [index_1]
 

--- a/tests/test_core/test_setup/test_join_spec.py
+++ b/tests/test_core/test_setup/test_join_spec.py
@@ -10,7 +10,7 @@ They will pass once JoinSpec is implemented as a frozen dataclass.
 
 from collections.abc import Callable
 from dataclasses import FrozenInstanceError
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -28,14 +28,14 @@ from mloda.user import Options
 class MockFeatureGroup(FeatureGroup):
     """Minimal feature group for testing JoinSpec."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 
 class AnotherMockFeatureGroup(FeatureGroup):
     """Another feature group for testing equality and hashing."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 

--- a/tests/test_core/test_setup/test_link_discriminator_eq_hash.py
+++ b/tests/test_core/test_setup/test_link_discriminator_eq_hash.py
@@ -9,7 +9,7 @@ See Also:
     - GitHub Issue #1235: Link equality/hash ignore discriminators
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import FeatureName
@@ -24,11 +24,11 @@ from mloda.user import Options
 class DiscriminatorFG(FeatureGroup):
     """Mock feature group with a single index column 'id'."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("id",))]
 
 

--- a/tests/test_core/test_setup/test_link_on_methods.py
+++ b/tests/test_core/test_setup/test_link_on_methods.py
@@ -24,7 +24,7 @@ See Also:
     - GitHub Issue #133: JoinSpec Convenience Function
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -41,22 +41,22 @@ from mloda.user import Options
 class MockFGWithSingleIndex(FeatureGroup):
     """Mock feature group with a single index column."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("id",))]
 
 
 class MockFGWithMultipleIndexes(FeatureGroup):
     """Mock feature group with multiple index options."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [
             Index(("id",)),
             Index(("user_id", "timestamp")),
@@ -67,7 +67,7 @@ class MockFGWithMultipleIndexes(FeatureGroup):
 class MockFGWithNoIndex(FeatureGroup):
     """Mock feature group that returns None for index_columns (default behavior)."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     # Uses default implementation which returns None
@@ -76,22 +76,22 @@ class MockFGWithNoIndex(FeatureGroup):
 class MockFGWithEmptyIndex(FeatureGroup):
     """Mock feature group that returns empty list for index_columns."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return []
 
 
 class AnotherMockFGWithSingleIndex(FeatureGroup):
     """Another mock feature group with a single index - for distinct feature group testing."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("user_id",))]
 
 

--- a/tests/test_core/test_setup/test_link_star.py
+++ b/tests/test_core/test_setup/test_link_star.py
@@ -21,7 +21,7 @@ See Also:
     - GitHub Issue #571: Star-join builder Link.star
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -38,21 +38,21 @@ from mloda.user import Options
 class HubFG(FeatureGroup):
     """Hub feature group for star-join testing."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 
 class SpokeAFG(FeatureGroup):
     """First spoke feature group for star-join testing."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 
 class SpokeBFG(FeatureGroup):
     """Second spoke feature group for star-join testing."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 

--- a/tests/test_core/test_setup/test_polymorphic_link.py
+++ b/tests/test_core/test_setup/test_polymorphic_link.py
@@ -12,7 +12,7 @@ Expected behavior after implementation:
     Link(ConcreteClass, ...) should NOT match BaseClass (reverse fails)
 """
 
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import pytest
 
@@ -31,14 +31,14 @@ from mloda.core.prepare.resolve_links import ResolveLinks
 class BaseGroupA(FeatureGroup):
     """Base class A for testing polymorphic links."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 
 class BaseGroupB(FeatureGroup):
     """Base class B for testing polymorphic links."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 
@@ -63,7 +63,7 @@ class ConcreteGroupB(BaseGroupB):
 class UnrelatedGroup(FeatureGroup):
     """Unrelated group for negative tests."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 
@@ -73,7 +73,7 @@ class UnrelatedGroup(FeatureGroup):
 class GrandparentGroup(FeatureGroup):
     """Three-level hierarchy root."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
 

--- a/tests/test_core/test_setup/test_polymorphic_link_resolution.py
+++ b/tests/test_core/test_setup/test_polymorphic_link_resolution.py
@@ -8,7 +8,7 @@ during the data joining phase. Covers:
 - Asymmetric polymorphic matching (base + external concrete)
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -57,7 +57,7 @@ class ConcreteFeatureGroupA(BaseFeatureGroupA):
     """Concrete implementation of A."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.FEATURE_NAME})
 
     @classmethod
@@ -69,7 +69,7 @@ class ConcreteFeatureGroupB(BaseFeatureGroupB):
     """Concrete implementation of B."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.FEATURE_NAME})
 
     @classmethod
@@ -92,7 +92,7 @@ class AssemblerWithConcreteLinks(FeatureGroup):
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == cls.FEATURE_NAME
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         idx = Index((BaseFeatureGroupA.ROW_INDEX,))
 
         # CONCRETE classes in link
@@ -123,7 +123,7 @@ class AssemblerWithPolymorphicLinks(FeatureGroup):
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == cls.FEATURE_NAME
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         idx = Index((BaseFeatureGroupA.ROW_INDEX,))
 
         # BASE classes in link - polymorphic matching should resolve to concrete
@@ -204,7 +204,7 @@ class AssemblerWithMixedLink(FeatureGroup):
         name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return name == cls.FEATURE_NAME
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         idx = Index((BaseFeatureGroupA.ROW_INDEX,))
 
         # Base class + External concrete class (ApiInputDataFeature has no subclass)

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -44,7 +44,7 @@ class RunResult:
 
     results: list[Any] = field(default_factory=list)
     artifacts: dict[str, Any] = field(default_factory=dict)
-    runner: Optional[ExecutionOrchestrator] = None  # already torn down; only get_result()/get_artifacts() are safe
+    runner: ExecutionOrchestrator | None = None  # already torn down; only get_result()/get_artifacts() are safe
 
 
 class MlodaTestRunner:
@@ -65,15 +65,15 @@ class MlodaTestRunner:
     @staticmethod
     def run_api(
         features: Features,
-        compute_frameworks: Optional[set[type[ComputeFramework]]] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+        compute_frameworks: set[type[ComputeFramework]] | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
         flight_server: Any = None,
-        function_extender: Optional[set[Extender]] = None,
-        links: Optional[set[Link]] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, Any]] = None,
+        function_extender: set[Extender] | None = None,
+        links: set[Link] | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, Any] | None = None,
         cleanup_flight_server: bool = True,
-        plugin_collector: Optional[PluginCollector] = None,
+        plugin_collector: PluginCollector | None = None,
         strict_type_enforcement: bool = False,
     ) -> RunResult:
         """
@@ -127,10 +127,10 @@ class MlodaTestRunner:
     @staticmethod
     def run_api_simple(
         features: Features,
-        compute_frameworks: Optional[set[type[ComputeFramework]]] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+        compute_frameworks: set[type[ComputeFramework]] | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
         flight_server: Any = None,
-        function_extender: Optional[set[Extender]] = None,
+        function_extender: set[Extender] | None = None,
     ) -> list[Any]:
         """
         Simplified runner using mloda.run_all().
@@ -165,13 +165,13 @@ class MlodaTestRunner:
     @staticmethod
     def run_engine(
         features: Features,
-        compute_frameworks: Optional[set[type[ComputeFramework]]] = None,
-        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+        compute_frameworks: set[type[ComputeFramework]] | None = None,
+        parallelization_modes: set[ParallelizationMode] | None = None,
         flight_server: Any = None,
-        function_extender: Optional[set[Extender]] = None,
-        links: Optional[set[Link]] = None,
-        global_filter: Optional[GlobalFilter] = None,
-        api_data: Optional[dict[str, Any]] = None,
+        function_extender: set[Extender] | None = None,
+        links: set[Link] | None = None,
+        global_filter: GlobalFilter | None = None,
+        api_data: dict[str, Any] | None = None,
     ) -> ExecutionOrchestrator:
         """
         Run using Engine + ExecutionOrchestrator for full control over execution.

--- a/tests/test_core/test_tooling/test_mloda_test_runner.py
+++ b/tests/test_core/test_tooling/test_mloda_test_runner.py
@@ -1,6 +1,6 @@
 """MlodaTestRunner.run_api must populate RunResult.runner with the ExecutionOrchestrator."""
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseInputData
 from mloda.provider import DataCreator
@@ -15,7 +15,7 @@ from tests.test_core.test_tooling import MlodaTestRunner
 
 class RunnerFieldRootFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod

--- a/tests/test_examples/sklearn_integration/test_sklearn_example_cells.py
+++ b/tests/test_examples/sklearn_integration/test_sklearn_example_cells.py
@@ -6,7 +6,7 @@ Functions return data/results that can be used in subsequent cells.
 """
 
 from copy import copy
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData
@@ -25,7 +25,7 @@ import pandas as pd
 # Create a DataCreator feature group for our sample data
 class SklearnDataCreator(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"age", "weight", "state", "gender"})
 
     @classmethod
@@ -210,7 +210,7 @@ def cell6_reusability_demo() -> None:
 
     class SecondSklearnDataCreator(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"age", "weight", "state", "gender"})
 
         @classmethod

--- a/tests/test_plugins/api/test_simplified_api_data.py
+++ b/tests/test_plugins/api/test_simplified_api_data.py
@@ -11,7 +11,7 @@ Simplified mloda:
     )
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.user import mloda
 from mloda.provider import FeatureGroup
@@ -34,7 +34,7 @@ from mloda.provider import ApiInputDataFeature
 class SimpleApiFeature(FeatureGroup):
     """A simple feature that consumes mloda data."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Define input features from mloda data."""
         return {
             Feature(name="api_id", index=Index(("api_id",))),
@@ -58,7 +58,7 @@ class SimpleApiFeature(FeatureGroup):
 class MultiKeyApiFeature(FeatureGroup):
     """A feature that consumes data from multiple mloda keys."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Define input features from multiple mloda data sources."""
         # This will require data from both FirstKey and SecondKey
         return {
@@ -84,7 +84,7 @@ class CreatorDataFeature(FeatureGroup):
     """Creates its own data via DataCreator."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"creator_id", "creator_value"})
 
     @classmethod
@@ -99,7 +99,7 @@ class CreatorDataFeature(FeatureGroup):
 class SimplifiedApiJoinFeature(FeatureGroup):
     """Joins simplified mloda data with Creator data using LEFT join."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Define input features with a LEFT join link."""
         # Create the link: LEFT join on api_id = creator_id
         link = Link.left(

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_allow_empty_result_run_all.py
@@ -4,7 +4,7 @@ Consumes the shared EmptyResultRunAllTestBase. A live DuckDB connection is threa
 through ``Feature.options`` + a ``DataAccessCollection`` by the base.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -35,7 +35,7 @@ class TestDuckDBAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
     def compute_framework_name(cls) -> str:
         return "DuckDBFramework"
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """DuckDB requires a connection object."""
         if not hasattr(self, "_connection"):
             self._connection = duckdb.connect()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_asof_merge_engine.py
@@ -6,7 +6,7 @@ test that 'nearest' direction raises ValueError.
 """
 
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -44,7 +44,7 @@ class TestDuckDBAsofMergeEngine(AsofMergeEngineTestBase):
             raise ImportError("DuckDB is not installed")
         return DuckdbRelation
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """DuckDB requires a connection object."""
         if not hasattr(self, "_connection"):
             self._connection = duckdb.connect()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_asof_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_asof_run_all.py
@@ -6,7 +6,7 @@ supports ``ParallelizationMode.SYNC``, so the inherited test method is overridde
 to run SYNC only.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -38,7 +38,7 @@ class TestDuckDBAsofRunAll(AsofRunAllTestBase):
     def compute_framework_name(cls) -> str:
         return "DuckDBFramework"
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """DuckDB requires a connection object."""
         if not hasattr(self, "_connection"):
             self._connection = duckdb.connect()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 import pytest
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
@@ -254,7 +254,7 @@ class TestDuckDBFrameworkMerge(DataFrameTestBase):
         arrow_table = pa.Table.from_pydict(data)
         return DuckdbRelation.from_arrow(self.conn, arrow_table)
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return DuckDB connection object."""
         return self.conn
 

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
@@ -3,7 +3,7 @@ from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 import pytest
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -73,8 +73,8 @@ class ATestDuckDBFeatureGroup(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         """We check for data access collection if any child classes match the data access."""
 
@@ -104,7 +104,7 @@ class ATestDuckDBFeatureGroup(FeatureGroup, MatchData):
 class DuckDBSimpleTransformFeatureGroup(ATestDuckDBFeatureGroup):
     """Simple feature group for testing DuckDB transformations."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Require base features for transformation."""
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
@@ -142,7 +142,7 @@ class DuckDBSimpleTransformFeatureGroup(ATestDuckDBFeatureGroup):
 class DuckDBSecondTransformFeatureGroup(ATestDuckDBFeatureGroup):
     """Second transformation that depends on the first."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("doubled_value")}
 
     @classmethod
@@ -166,7 +166,7 @@ class DuckDBSecondTransformFeatureGroup(ATestDuckDBFeatureGroup):
 class DuckDBAggregationFeatureGroup(ATestDuckDBFeatureGroup):
     """Feature group for testing DuckDB aggregation capabilities."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str in ["avg_value_by_category", "count_by_category"]:
@@ -200,7 +200,7 @@ class DuckDBAggregationFeatureGroup(ATestDuckDBFeatureGroup):
 class CheckData(FeatureGroup):
     """Feature group for testing DuckDB aggregation capabilities."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str in ["pyarrow_avg_value_by_category"]:

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_merge_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pytest
 
 from mloda.user import JoinType
@@ -444,7 +444,7 @@ class TestDuckDBMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
             raise ImportError("DuckDB is not installed")
         return DuckdbRelation
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """DuckDB requires a connection object."""
         if not hasattr(self, "_connection"):
             self._connection = duckdb.connect()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_tfs_connection.py
@@ -3,7 +3,7 @@
 Reproducer for issue #440. PyArrow -> DuckDB TFS path; without the fix the
 destination DuckDBFramework has no connection and `data.project(...)` raises."""
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -34,8 +34,8 @@ class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if duckdb is None or not DuckDBFramework.is_available():
             return None
@@ -50,7 +50,7 @@ class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
                 return conn
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("raw_val")}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_integration.py
@@ -1,6 +1,6 @@
 from mloda.user import Features
 import pytest
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock
 
 from mloda.provider import FeatureGroup
@@ -82,7 +82,7 @@ class IcebergTestDataCreator(FeatureGroup):
     """Test data creator for Iceberg integration tests."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         """Return a DataCreator with the supported feature names."""
         return DataCreator(set(iceberg_test_dict.keys()))
 
@@ -118,8 +118,8 @@ class ATestIcebergFeatureGroup(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         """Check for data access collection if any child classes match the data access."""
 
@@ -150,7 +150,7 @@ class ATestIcebergFeatureGroup(FeatureGroup, MatchData):
 class IcebergSimpleTransformFeatureGroup(FeatureGroup):
     """Simple feature group for testing Iceberg transformations."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Require base features for transformation."""
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
@@ -203,7 +203,7 @@ class IcebergSimpleTransformFeatureGroup(FeatureGroup):
 class IcebergToArrowFeatureGroup(FeatureGroup):
     """Feature group that converts Iceberg data to PyArrow format."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("doubled_value")}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_tfs_connection.py
@@ -6,7 +6,7 @@ the destination FG operates on a pa.Table and verifies that the catalog from
 the DataAccessCollection has been bound on the IcebergFramework instance by
 asserting it from inside calculate_feature via a per-test sentinel."""
 
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -38,12 +38,12 @@ class ConnectionRecordingIcebergFramework(IcebergFramework):
     """Test-only subclass that records the bound catalog so the e2e test can
     assert the setup-time precompute reached this CFW instance."""
 
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         super().set_framework_connection_object(framework_connection_object)
         _observed_catalogs.append(self.framework_connection_object)
 
     @classmethod
-    def pick_connection_from_dac(cls, data_access_collection: Any, options: Optional[Any] = None) -> Optional[Any]:
+    def pick_connection_from_dac(cls, data_access_collection: Any, options: Any | None = None) -> Any | None:
         return IcebergFramework.pick_connection_from_dac(data_access_collection, options)
 
 
@@ -55,8 +55,8 @@ class TfsDoubledIcebergFG(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if pyiceberg is None:
             return None
@@ -73,7 +73,7 @@ class TfsDoubledIcebergFG(FeatureGroup, MatchData):
                 return conn
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("raw_val")}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_asof_merge_engine.py
@@ -5,7 +5,7 @@ Consumes the shared AsofMergeEngineTestBase.
 """
 
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -32,11 +32,11 @@ except ImportError:
 class _TimedeltaAsofFG(FeatureGroup):
     """Mock feature group with a single by-key index column 'k' for asof factory tests."""
 
-    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> set[Any] | None:
         return None
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("k",))]
 
 
@@ -56,7 +56,7 @@ class TestPandasAsofMergeEngine(AsofMergeEngineTestBase):
         dataframe_type: type[Any] = pd.DataFrame
         return dataframe_type
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 
     def test_timedelta_tolerance_filters_far_match_on_datetime_column(self) -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_dataframe.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_dataframe.py
@@ -1,6 +1,6 @@
 import pytest
 import pyarrow as pa
-from typing import Any, Optional
+from typing import Any
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda.user import FeatureName
 from mloda.user import ParallelizationMode
@@ -128,7 +128,7 @@ class TestPandasDataFrameMerge(DataFrameTestBase):
         """Create a pandas DataFrame from a dictionary."""
         return pd.DataFrame.from_dict(data)
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return connection object (None for pandas)."""
         return None
 

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_merge_engine.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.pandas.pandas_merge_engine import PandasMergeEngine
@@ -36,6 +36,6 @@ class TestPandasMergeEngine(MultiIndexMergeEngineTestBase):
         dataframe_type: type[Any] = pd.DataFrame
         return dataframe_type
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Pandas does not require a connection object."""
         return None

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_asof_merge_engine.py
@@ -6,7 +6,7 @@ lazy PolarsLazyMergeEngine (pl.LazyFrame).
 """
 
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -107,7 +107,7 @@ class TestPolarsAsofMergeEngine(_PolarsAsofTzChecks):
             raise ImportError("Polars is not installed")
         return pl.DataFrame
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 
     @classmethod
@@ -130,7 +130,7 @@ class TestPolarsLazyAsofMergeEngine(_PolarsAsofTzChecks):
             raise ImportError("Polars is not installed")
         return pl.LazyFrame
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_dataframe.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_dataframe.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional
+from typing import Any
 import pytest
 import pyarrow as pa
 from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame
@@ -111,7 +111,7 @@ class TestPolarsDataFrameMerge(DataFrameTestBase):
         """Create a polars DataFrame from a dictionary."""
         return pl.DataFrame(data)
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return connection object (None for polars)."""
         return None
 

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_integration.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda.provider import FeatureGroup
@@ -75,7 +75,7 @@ class PolarsLazySimpleTransformFeatureGroup(FeatureGroup):
         """Support both lazy and eager Polars frameworks."""
         return {PolarsDataFrame, PolarsLazyDataFrame}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Require base features for transformation."""
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
@@ -116,7 +116,7 @@ class SecondTransformFeatureGroup(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PolarsLazyDataFrame}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("doubled_value")}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_merge_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pytest
 
 from mloda.provider import BaseMergeEngine
@@ -34,6 +34,6 @@ class TestPolarsLazyMergeEngine(MultiIndexMergeEngineTestBase):
             raise ImportError("Polars is not installed")
         return pl.LazyFrame
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Polars does not require a connection object."""
         return None

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_merge_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pytest
 
 from mloda.user import JoinType
@@ -392,5 +392,5 @@ class TestPolarsMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
         dataframe_type: type[Any] = pl.DataFrame
         return dataframe_type
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_asof_merge_engine.py
@@ -6,7 +6,7 @@ under test and the interchange format used by the DataConverter.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -42,7 +42,7 @@ class TestPyArrowAsofMergeEngine(AsofMergeEngineTestBase):
         table_type: type[Any] = pa.Table
         return table_type
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 
     def test_nearest_direction(self) -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pytest
 
 from mloda.provider import BaseMergeEngine
@@ -82,7 +82,7 @@ class TestPyArrowMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
         table_type: type[Any] = pa.Table
         return table_type
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """PyArrow does not require a connection object."""
         return None
 

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import pytest
 import pyarrow as pa
 
@@ -86,7 +86,7 @@ class TestPyArrowTableMerge(DataFrameTestBase):
         """Create a pyarrow Table from a dictionary."""
         return pa.table(data)
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return connection object (None for pyarrow)."""
         return None
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result_run_all.py
@@ -8,7 +8,7 @@ backend. A zero-column ``{}`` result raises ``EmptyResultError`` (the ``allow_em
 opt-in is retired).
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -85,7 +85,7 @@ class EmptyResultNoneAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"empty_result_none_allowed_col"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_asof_merge_engine.py
@@ -5,7 +5,7 @@ Consumes the shared AsofMergeEngineTestBase. PythonDict's native format is a
 columnar dict; the DataConverter routes through PyArrow, so PyArrow must be available.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -40,7 +40,7 @@ class TestPythonDictAsofMergeEngine(AsofMergeEngineTestBase):
     def framework_type(cls) -> type[Any]:
         return dict
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 
     def test_nearest_direction(self) -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
@@ -12,7 +12,7 @@ Not to be confused with the legacy ``test_python_dict_framework.py`` which still
 row-wise contract; that module is superseded by this one under the columnar model.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -216,7 +216,7 @@ class _ColumnarZeroRowFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """Root FG returning a schema-bearing zero-row columnar dict, with NO opt-in flag."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"columnar_zero_row_col"})
 
     @classmethod
@@ -232,7 +232,7 @@ class _ColumnarZeroColumnFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """Root FG returning a schema-less ``{}`` (zero columns), with NO opt-in flag."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"columnar_zero_column_col"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_list_dict_filter_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_list_dict_filter_run_all.py
@@ -6,7 +6,7 @@ combined with a final/global filter works.
 engine and ``_validate_filter_columns`` always see a columnar ``dict[str, list[Any]]``.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.provider import BaseInputData
@@ -25,7 +25,7 @@ class ListDictRootFeatureGroup(FeatureGroup):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"x", "y"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_malformed_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_malformed_result_run_all.py
@@ -19,7 +19,7 @@ This test is expected to FAIL against the current implementation because ``{"fea
 accepted and returned instead of raising.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -44,7 +44,7 @@ class _ScalarValuedResultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"scalar_result_col"})
 
     @classmethod
@@ -61,7 +61,7 @@ class _MultiScalarValuedResultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """Root FeatureGroup returning a multi-column scalar-valued dict ``{"a": 1, "b": 2}``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"multi_scalar_result_col"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 import pytest
 
 from mloda.user import JoinType
@@ -319,6 +319,6 @@ class TestPythonDictMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
         """Return dict type (PythonDict uses a columnar dict)."""
         return dict
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """PythonDict does not require a connection object."""
         return None

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_one_to_many_join_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_one_to_many_join_run_all.py
@@ -5,7 +5,7 @@ preserves one-to-many fan-out: a unique-key left joined to a duplicate-key right
 must yield one row per matching right row, not collapse to the last one.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -40,7 +40,7 @@ class OneToManyLeftFeature(FeatureGroup):
     """Left side: one row per user (unique join keys)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"user_id", "uname"})
 
     @classmethod
@@ -56,7 +56,7 @@ class OneToManyRightFeature(FeatureGroup):
     """Right side: many rows per user (duplicate join keys)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"user_id", "amount"})
 
     @classmethod
@@ -71,7 +71,7 @@ class OneToManyRightFeature(FeatureGroup):
 class OneToManyJoinedFeature(FeatureGroup):
     """Parent consuming the one-to-many join; encodes each joined row as 'uname|amount'."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         link = _one_to_many_link()
         return {
             Feature(name="uname", link=link, index=Index(("user_id",))),

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_result_rows_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_result_rows_run_all.py
@@ -1,6 +1,6 @@
 """End-to-end test: ``result_rows`` unwraps a PythonDict ``mloda.run_all`` result (issue 717)."""
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
@@ -19,7 +19,7 @@ class ResultRowsRootFeatureGroup(FeatureGroup):
     """Root PythonDict FeatureGroup emitting a two-row columnar dict for ``result_rows``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"result_rows_e2e_col"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_allow_empty_result_run_all.py
@@ -6,7 +6,7 @@ thread it through ``Feature.options`` + a ``DataAccessCollection``, mirroring ho
 integration tests pass the SparkSession to ``run_all``.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -31,6 +31,6 @@ class TestSparkAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
     def compute_framework_name(cls) -> str:
         return "SparkFramework"
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Spark requires the shared SparkSession as its connection object."""
         return self._spark_session

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_integration.py
@@ -21,7 +21,7 @@ The tests use a shared SparkSession fixture to avoid Java gateway conflicts and
 ensure proper resource management across all test methods.
 """
 
-from typing import Any, Optional
+from typing import Any
 import pytest
 
 from mloda.provider import MatchData
@@ -99,8 +99,8 @@ class ATestSparkFeatureGroup(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         """Check for data access collection if any child classes match the data access."""
 
@@ -130,7 +130,7 @@ class ATestSparkFeatureGroup(FeatureGroup, MatchData):
 class SparkSimpleTransformFeatureGroup(ATestSparkFeatureGroup):
     """Simple feature group for testing Spark transformations."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Require base features for transformation."""
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
@@ -168,7 +168,7 @@ class SparkSimpleTransformFeatureGroup(ATestSparkFeatureGroup):
 class SparkSecondTransformFeatureGroup(ATestSparkFeatureGroup):
     """Second transformation that depends on the first."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("doubled_value")}
 
     @classmethod
@@ -192,7 +192,7 @@ class SparkSecondTransformFeatureGroup(ATestSparkFeatureGroup):
 class SparkAggregationFeatureGroup(ATestSparkFeatureGroup):
     """Feature group for testing Spark aggregation capabilities."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str in ["avg_value_by_category", "count_by_category"]:
@@ -230,7 +230,7 @@ class SparkAggregationFeatureGroup(ATestSparkFeatureGroup):
 class CheckData(FeatureGroup):
     """Feature group for testing cross-framework transformation (Spark to PyArrow)."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str in ["pyarrow_avg_value_by_category"]:
@@ -467,7 +467,7 @@ class TestSparkIntegrationWithMlodaAPI:
         class SparkErrorFeatureGroup(ATestSparkFeatureGroup):
             """Feature group that intentionally causes an error."""
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature("value")}
 
             @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_tfs_connection.py
@@ -1,6 +1,6 @@
 """End-to-end TFS connection-propagation test for Spark."""
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -35,8 +35,8 @@ class TfsDoubledSparkFG(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if not PYSPARK_AVAILABLE:
             return None
@@ -51,7 +51,7 @@ class TfsDoubledSparkFG(FeatureGroup, MatchData):
                 return conn
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("raw_val")}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_allow_empty_result_run_all.py
@@ -6,7 +6,7 @@ transformer requires pyarrow, so the class is guarded with a skipif on ``pa``.
 """
 
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -35,7 +35,7 @@ class TestSqliteAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
     def compute_framework_name(cls) -> str:
         return "SqliteFramework"
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """SQLite requires a connection object."""
         if not hasattr(self, "_connection"):
             self._connection = sqlite3.connect(":memory:")

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_asof_merge_engine.py
@@ -8,7 +8,7 @@ into a SqliteRelation routes through PyArrow, so PyArrow must be available.
 
 import sqlite3
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -43,7 +43,7 @@ class TestSqliteAsofMergeEngine(AsofMergeEngineTestBase):
     def framework_type(cls) -> type[Any]:
         return SqliteRelation
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         if not hasattr(self, "_connection"):
             self._connection = sqlite3.connect(":memory:")
             self._connection.create_function("REGEXP", 2, _regexp)

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_asof_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_asof_run_all.py
@@ -8,7 +8,7 @@ guarded with a skipif on ``pa``.
 """
 
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -38,7 +38,7 @@ class TestSqliteAsofRunAll(AsofRunAllTestBase):
     def compute_framework_name(cls) -> str:
         return "SqliteFramework"
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """SQLite requires a connection object."""
         if not hasattr(self, "_connection"):
             self._connection = sqlite3.connect(":memory:")

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -186,7 +186,7 @@ class TestSqliteFrameworkMerge(DataFrameTestBase):
         arrow_table = pa.Table.from_pydict(data)
         return SqliteRelation.from_arrow(self.conn, arrow_table)
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return self.conn
 
     def _create_test_framework(self) -> Any:

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_integration.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -54,8 +54,8 @@ class ATestSqliteFeatureGroup(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if not SqliteFramework.is_available():
             return None
@@ -81,7 +81,7 @@ class ATestSqliteFeatureGroup(FeatureGroup, MatchData):
 
 
 class SqliteSimpleTransformFeatureGroup(ATestSqliteFeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str == "doubled_value":
@@ -111,7 +111,7 @@ class SqliteSimpleTransformFeatureGroup(ATestSqliteFeatureGroup):
 
 
 class SqliteSecondTransformFeatureGroup(ATestSqliteFeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("doubled_value")}
 
     @classmethod
@@ -132,7 +132,7 @@ class SqliteSecondTransformFeatureGroup(ATestSqliteFeatureGroup):
 
 
 class SqliteAggregationFeatureGroup(ATestSqliteFeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str in ["avg_value_by_category", "count_by_category"]:
@@ -164,7 +164,7 @@ class SqliteAggregationFeatureGroup(ATestSqliteFeatureGroup):
 
 
 class SqliteCheckData(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_name_str = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
 
         if feature_name_str in ["pyarrow_avg_value_by_category_sqlite"]:

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_merge_engine.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -360,7 +360,7 @@ class TestSqliteMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
     def framework_type(cls) -> type[Any]:
         return SqliteRelation
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         if not hasattr(self, "_connection"):
             self._connection = sqlite3.connect(":memory:")
             self._connection.create_function("REGEXP", 2, _regexp)

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_tfs_connection.py
@@ -1,7 +1,7 @@
 """End-to-end TFS connection-propagation test for SQLite."""
 
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -27,8 +27,8 @@ class TfsDoubledSqliteFG(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if feature_name not in cls.feature_names_supported():
             return None
@@ -41,7 +41,7 @@ class TfsDoubledSqliteFG(FeatureGroup, MatchData):
                 return conn
         return None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature("raw_val")}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/test_asof_capability_matrix.py
+++ b/tests/test_plugins/compute_framework/base_implementations/test_asof_capability_matrix.py
@@ -6,7 +6,7 @@ Keep ``ASOF_CAPABILITY_MATRIX`` in sync with docs/docs/in_depth/join_data.md.
 
 import sqlite3
 from datetime import datetime, timedelta
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import pytest
 
@@ -82,7 +82,7 @@ class BackendSpec:
         name: str,
         engine_class: type[BaseMergeEngine] | None,
         framework_type: type[Any] | None,
-        connection_factory: Callable[[], Optional[Any]],
+        connection_factory: Callable[[], Any | None],
         missing: bool,
     ) -> None:
         self.name = name

--- a/tests/test_plugins/compute_framework/base_implementations/tfs_connection_e2e_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/tfs_connection_e2e_mixin.py
@@ -6,7 +6,7 @@ through `mloda.run_all` so each SQL framework gets the same coverage as the
 original DuckDB reproducer."""
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -22,7 +22,7 @@ class TfsRawValPyArrowSource(FeatureGroup):
     test exercises the same PyArrow -> <SQL framework> TFS edge."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"raw_val"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/test_cross_group_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_cross_group_link_orientation.py
@@ -3,7 +3,7 @@
 Both must end up on a single orientation and see the joined columns.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -27,7 +27,7 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 
 class OrientParentLeft(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -41,7 +41,7 @@ class OrientParentLeft(FeatureGroup):
 
 class OrientParentRight(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -62,7 +62,7 @@ def _column_names(data: Any) -> list[str]:
 class OrientChildFlexible(FeatureGroup):
     """Supports both frameworks, so on its own it would keep the left orientation."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name=OrientParentLeft.get_class_name()), Feature(name=OrientParentRight.get_class_name())}
 
     @classmethod
@@ -86,7 +86,7 @@ class OrientChildFlexible(FeatureGroup):
 class OrientChildPandasOnly(FeatureGroup):
     """Supports only the right framework, so on its own it would invert the link."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name=OrientParentLeft.get_class_name()), Feature(name=OrientParentRight.get_class_name())}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/test_inverted_link_merge_sides.py
+++ b/tests/test_plugins/compute_framework/test_inverted_link_merge_sides.py
@@ -3,7 +3,7 @@
 Asymmetric key sets and differing index column names make a swapped merge observable.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -26,7 +26,7 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 
 class AsymLeftSource(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"asym_left_key", "asym_left_payload"})
 
     @classmethod
@@ -40,7 +40,7 @@ class AsymLeftSource(FeatureGroup):
 
 class AsymRightSource(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"asym_right_key", "asym_right_payload"})
 
     @classmethod
@@ -55,7 +55,7 @@ class AsymRightSource(FeatureGroup):
 class AsymJoinChild(FeatureGroup):
     """Only the right framework is supported, which inverts the declared link orientation."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="asym_left_key"),
             Feature(name="asym_left_payload"),

--- a/tests/test_plugins/compute_framework/test_link_star_integration.py
+++ b/tests/test_plugins/compute_framework/test_link_star_integration.py
@@ -8,7 +8,7 @@ exercise the joins the engine actually performs and assert on concrete joined
 cell values.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup, FeatureSet, BaseInputData, DataCreator
 from mloda.user import Feature, FeatureName, Index, Link, JoinSpec, JoinType, Options, PluginCollector, mloda
@@ -21,11 +21,11 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 
 class StarHubFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "hub_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -35,11 +35,11 @@ class StarHubFG(FeatureGroup):
 
 class StarSpokeAFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "spoke_a_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -49,11 +49,11 @@ class StarSpokeAFG(FeatureGroup):
 
 class StarSpokeBFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "spoke_b_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -68,7 +68,7 @@ class StarConsumerFG(FeatureGroup):
     before this group runs, so the merged frame is what ``calculate_feature`` sees.
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="hub_value"),
             Feature(name="spoke_a_value"),
@@ -88,11 +88,11 @@ class StarConsumerFG(FeatureGroup):
 
 class StarLeftHubFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "left_hub_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -102,11 +102,11 @@ class StarLeftHubFG(FeatureGroup):
 
 class StarLeftSpokeAFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "left_spoke_a_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -118,11 +118,11 @@ class StarLeftSpokeBFG(FeatureGroup):
     """Spoke B is intentionally missing row_id 3 so INNER drops it and LEFT keeps it."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "left_spoke_b_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -138,7 +138,7 @@ class StarLeftConsumerFG(FeatureGroup):
     that spoke B does not supply.
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="left_hub_value"),
             Feature(name="left_spoke_a_value"),
@@ -156,11 +156,11 @@ class StarLeftConsumerFG(FeatureGroup):
 
 class StarOuterHubFG(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "outer_hub_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -172,11 +172,11 @@ class StarOuterSpokeAFG(FeatureGroup):
     """Spoke carries row_id 4 (which the hub lacks) and lacks row_id 1 (which the hub has)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"row_id", "outer_spoke_a_value"})
 
     @classmethod
-    def index_columns(cls) -> Optional[list[Index]]:
+    def index_columns(cls) -> list[Index] | None:
         return [Index(("row_id",))]
 
     @classmethod
@@ -191,7 +191,7 @@ class StarOuterConsumerFG(FeatureGroup):
     ``row_id`` through, so no possibly-null column is string-concatenated.
     """
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name="outer_hub_value"),
             Feature(name="outer_spoke_a_value"),

--- a/tests/test_plugins/compute_framework/test_method_decorators.py
+++ b/tests/test_plugins/compute_framework/test_method_decorators.py
@@ -5,7 +5,7 @@ These tests ensure that methods accessing module-level imports are implemented a
 """
 
 import inspect
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -15,8 +15,8 @@ from mloda_plugins.compute_framework.base_implementations.pandas.pandas_merge_en
 
 # Optional imports for polars
 _pl: Any = None
-_PolarsDataFrame: Optional[type[Any]] = None
-_PolarsLazyDataFrame: Optional[type[Any]] = None
+_PolarsDataFrame: type[Any] | None = None
+_PolarsLazyDataFrame: type[Any] | None = None
 try:
     import polars as _pl
     from mloda_plugins.compute_framework.base_implementations.polars.dataframe import (
@@ -30,7 +30,7 @@ except ImportError:
 
 # Optional imports for duckdb
 _duckdb: Any = None
-_DuckDBFramework: Optional[type[Any]] = None
+_DuckDBFramework: type[Any] | None = None
 try:
     import duckdb as _duckdb
     from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import (
@@ -41,7 +41,7 @@ except ImportError:
 
 # Optional imports for spark
 _SparkSession: Any = None
-_SparkFramework: Optional[type[Any]] = None
+_SparkFramework: type[Any] | None = None
 try:
     from pyspark.sql import SparkSession as _SparkSessionImport
     from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (

--- a/tests/test_plugins/compute_framework/test_multi_link_same_cfw.py
+++ b/tests/test_plugins/compute_framework/test_multi_link_same_cfw.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -23,7 +23,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 
 class ReadFGS1(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -33,7 +33,7 @@ class ReadFGS1(FeatureGroup):
 
 class AggFGS1(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"agg_sum_s1", "agg_count_s1", "agg_avg_s1"})
 
     @classmethod
@@ -43,7 +43,7 @@ class AggFGS1(FeatureGroup):
 
 
 class ConsumerFGS1(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=ReadFGS1.get_class_name()),
             Feature(name="agg_sum_s1", options={"agg_type": "sum"}),
@@ -61,7 +61,7 @@ class ConsumerFGS1(FeatureGroup):
 
 class BaseAggS2(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -83,7 +83,7 @@ class AvgAggS2(BaseAggS2):
 
 class ReadFGS2(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -92,7 +92,7 @@ class ReadFGS2(FeatureGroup):
 
 
 class ConsumerFGS2(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=ReadFGS2.get_class_name()),
             Feature(name=SumAggS2.get_class_name()),
@@ -110,7 +110,7 @@ class ConsumerFGS2(FeatureGroup):
 
 class ReadFGS3(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -120,7 +120,7 @@ class ReadFGS3(FeatureGroup):
 
 class SumFGS3(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -130,7 +130,7 @@ class SumFGS3(FeatureGroup):
 
 class CountFGS3(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -140,7 +140,7 @@ class CountFGS3(FeatureGroup):
 
 class AvgFGS3(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -149,7 +149,7 @@ class AvgFGS3(FeatureGroup):
 
 
 class ConsumerFGS3(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=ReadFGS3.get_class_name()),
             Feature(name=SumFGS3.get_class_name()),

--- a/tests/test_plugins/compute_framework/test_non_root_merges_multiple_cfwy.py
+++ b/tests/test_plugins/compute_framework/test_non_root_merges_multiple_cfwy.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -22,7 +22,7 @@ from mloda.user import mloda
 
 class NonCfwRootJoinTestFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -36,7 +36,7 @@ class NonCfwRootJoinTestFeature(FeatureGroup):
 
 class NonCfwRootJoinTestFeatureB(NonCfwRootJoinTestFeature):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -55,7 +55,7 @@ class SecondNonCfwRootJoinTestFeature(NonCfwRootJoinTestFeature):
 
 
 class GroupedNonCfwRootJoinTestFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         if options.get("test_non_root_merge_multiple_join"):
             return {Feature(name="NonCfwRootJoinTestFeature"), Feature(name="NonCfwRootJoinTestFeatureB")}
 
@@ -76,7 +76,7 @@ class GroupedNonCfwRootJoinTestFeature(FeatureGroup):
 
 
 class GroupedSecondNonCfwRootJoinTestFeature(GroupedNonCfwRootJoinTestFeature):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name="SecondNonCfwRootJoinTestFeature")}
 
     @classmethod
@@ -90,7 +90,7 @@ class GroupedSecondNonCfwRootJoinTestFeature(GroupedNonCfwRootJoinTestFeature):
 
 
 class Call2GroupedNonCfwRootJoinTestFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=GroupedNonCfwRootJoinTestFeature.get_class_name()),
             Feature(name=GroupedSecondNonCfwRootJoinTestFeature.get_class_name()),

--- a/tests/test_plugins/compute_framework/test_non_root_merges_one_cfw.py
+++ b/tests/test_plugins/compute_framework/test_non_root_merges_one_cfw.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -20,7 +20,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 
 class NonRootJoinTestFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -30,7 +30,7 @@ class NonRootJoinTestFeature(FeatureGroup):
 
 class NonRootJoinTestFeatureB(NonRootJoinTestFeature):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -43,7 +43,7 @@ class SecondNonRootJoinTestFeature(NonRootJoinTestFeature):
 
 
 class GroupedNonRootJoinTestFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         if options.get("test_non_root_merge_multiple_join"):
             return {Feature(name="NonRootJoinTestFeature"), Feature(name="NonRootJoinTestFeatureB")}
 
@@ -59,7 +59,7 @@ class GroupedNonRootJoinTestFeature(FeatureGroup):
 
 
 class GroupedSecondNonRootJoinTestFeature(GroupedNonRootJoinTestFeature):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name="SecondNonRootJoinTestFeature")}
 
     @classmethod
@@ -72,7 +72,7 @@ class GroupedSecondNonRootJoinTestFeature(GroupedNonRootJoinTestFeature):
 
 
 class Call2GroupedNonRootJoinTestFeature(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=GroupedNonRootJoinTestFeature.get_class_name()),
             Feature(name=GroupedSecondNonRootJoinTestFeature.get_class_name()),

--- a/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
+++ b/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
@@ -6,7 +6,7 @@ the request to one source (Feature("subject_token", feature_group=SourceA))
 resolves it uniquely, so the derived feature group can compute its result.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -28,7 +28,7 @@ class Source508A(FeatureGroup):
     """Source A: provides the shared "subject_token" plus "scoping_value_a"."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"subject_token", "scoping_value_a"})
 
     @classmethod
@@ -43,7 +43,7 @@ class Source508B(FeatureGroup):
     """Source B: also provides the shared "subject_token" plus "scoping_value_b"."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"subject_token", "scoping_value_b"})
 
     @classmethod
@@ -57,7 +57,7 @@ class Source508B(FeatureGroup):
 class Derived508Scoped(FeatureGroup):
     """Derived FG: reads scoping_value_a and subject_token scoped to Source A."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("scoping_value_a"),
             Feature("subject_token", feature_group=Source508A),
@@ -73,7 +73,7 @@ class Derived508Scoped(FeatureGroup):
 class Derived508Unscoped(FeatureGroup):
     """Derived FG requesting subject_token WITHOUT scope (ambiguous by design)."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("scoping_value_a"),
             Feature("subject_token"),
@@ -131,7 +131,7 @@ class Source508CounterA(FeatureGroup):
     calls = 0
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"subject_token", "counter_value_a"})
 
     @classmethod
@@ -147,7 +147,7 @@ class Source508CounterB(FeatureGroup):
     """Source B, providing the shared subject_token plus counter_value_b (creates ambiguity)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"subject_token", "counter_value_b"})
 
     @classmethod
@@ -161,7 +161,7 @@ class Source508CounterB(FeatureGroup):
 class Derived508CounterScoped(FeatureGroup):
     """Derived FG: reads counter_value_a and subject_token scoped to Source A."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("counter_value_a"),
             Feature("subject_token", feature_group=Source508CounterA),
@@ -213,7 +213,7 @@ class Source508IndepA(FeatureGroup):
     """Source A: provides subject_token plus value_a."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"subject_token", "value_a"})
 
     @classmethod
@@ -228,7 +228,7 @@ class Source508IndepB(FeatureGroup):
     """Source B: provides subject_token plus value_b."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"subject_token", "value_b"})
 
     @classmethod
@@ -242,7 +242,7 @@ class Source508IndepB(FeatureGroup):
 class Derived508IndepA(FeatureGroup):
     """Derived FG A: reads value_a and subject_token scoped to Source A."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("value_a"),
             Feature("subject_token", feature_group=Source508IndepA),
@@ -258,7 +258,7 @@ class Derived508IndepA(FeatureGroup):
 class Derived508IndepB(FeatureGroup):
     """Derived FG B: reads value_b and subject_token scoped to Source B."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature("value_b"),
             Feature("subject_token", feature_group=Source508IndepB),

--- a/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
@@ -3,7 +3,7 @@
 A second consumer sharing the same link does not change that outcome.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -46,7 +46,7 @@ class SharedAppendSource(FeatureGroup):
     """Serves both sides of the append; each side is pinned to a different framework."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(
             supports_features={"stack_left_key", "stack_left_payload", "stack_right_key", "stack_right_payload"}
         )
@@ -73,7 +73,7 @@ def _append_sides() -> set[Feature]:
 class SharedAppendPandasConsumer(FeatureGroup):
     """Resolves to the right framework only, so it differs from the left index feature."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _append_sides()
 
     @classmethod
@@ -89,7 +89,7 @@ class SharedAppendPandasConsumer(FeatureGroup):
 class SharedAppendFlexibleConsumer(FeatureGroup):
     """Second consumer of the same link, kept unpinned so only the link is shared."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return _append_sides()
 
     @classmethod

--- a/tests/test_plugins/compute_framework/test_sibling_steps_share_one_cfw.py
+++ b/tests/test_plugins/compute_framework/test_sibling_steps_share_one_cfw.py
@@ -3,7 +3,7 @@ Both outputs must survive when the two steps overlap in time.
 """
 
 import threading
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -29,7 +29,7 @@ late_writer_stored_data = threading.Event()
 
 class SharedSiblingParent(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -44,7 +44,7 @@ class SharedSiblingParent(FeatureGroup):
 class SiblingEarlyWriter(FeatureGroup):
     """Stores its frame first, then holds its step open until the sibling has stored too."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name=SharedSiblingParent.get_class_name())}
 
     @classmethod
@@ -65,7 +65,7 @@ class SiblingEarlyWriter(FeatureGroup):
 class SiblingLateWriter(FeatureGroup):
     """Takes its input before the sibling writes, then stores its own frame last."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name=SharedSiblingParent.get_class_name())}
 
     @classmethod

--- a/tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py
+++ b/tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py
@@ -3,7 +3,7 @@
 Resolution reconciles the two orientations at once, so both children see the joined columns.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -52,7 +52,7 @@ def _add_joined_column(data: Any, name: str) -> Any:
 
 class SwappedParentLeft(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -66,7 +66,7 @@ class SwappedParentLeft(FeatureGroup):
 
 class SwappedParentRight(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={cls.get_class_name()})
 
     @classmethod
@@ -81,7 +81,7 @@ class SwappedParentRight(FeatureGroup):
 class SwappedChildPandasLeft(FeatureGroup):
     """Pins the left parent to pandas and the right parent to pyarrow."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=SwappedParentLeft.get_class_name(), compute_framework="PandasDataFrame"),
             Feature(name=SwappedParentRight.get_class_name(), compute_framework="PyArrowTable"),
@@ -99,7 +99,7 @@ class SwappedChildPandasLeft(FeatureGroup):
 class SwappedChildPyArrowLeft(FeatureGroup):
     """Pins the same two parents the other way round, so the link is recorded in both orientations."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=SwappedParentLeft.get_class_name(), compute_framework="PyArrowTable"),
             Feature(name=SwappedParentRight.get_class_name(), compute_framework="PandasDataFrame"),

--- a/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
@@ -9,7 +9,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import Counter
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -56,7 +56,7 @@ class AsofMergeEngineTestBase(ABC):
         pass
 
     @abstractmethod
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return framework connection object, or None if not needed."""
         pass
 

--- a/tests/test_plugins/compute_framework/test_tooling/asof/asof_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/asof/asof_run_all_test_base.py
@@ -20,7 +20,7 @@ This module is intentionally NOT collected as tests (no ``Test`` prefix).
 
 import sqlite3
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -137,8 +137,8 @@ class _AsofMatchData(MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if feature_name not in cls.feature_names_supported():
             return None
@@ -159,7 +159,7 @@ class AsofLeftFeature(FeatureGroup, _AsofMatchData):
     """Left side of the ASOF join: emits by-key ``k``, time ``t`` and value ``lv``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"k", "t", "lv"})
 
     @classmethod
@@ -175,7 +175,7 @@ class AsofRightFeature(FeatureGroup, _AsofMatchData):
     """Right side of the ASOF join: emits by-key ``k``, time ``t`` and value ``rv``."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"k", "t", "rv"})
 
     @classmethod
@@ -190,7 +190,7 @@ class AsofRightFeature(FeatureGroup, _AsofMatchData):
 class AsofJoinedFeature(FeatureGroup, _AsofMatchData):
     """Parent feature group that requires the ASOF merge of the two leaf groups."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         link = _asof_link()
         return {
             Feature(name="lv", link=link, index=Index(("k",))),
@@ -223,7 +223,7 @@ class AsofRunAllTestBase(ABC):
         """Return the compute framework name string for ``compute_frameworks=[...]``."""
         pass
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return a framework connection object, or None when none is needed."""
         return None
 

--- a/tests/test_plugins/compute_framework/test_tooling/dataframe_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/dataframe_test_base.py
@@ -6,7 +6,7 @@ for merge operations across all compute frameworks.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from mloda.user import Index
 from mloda.user import JoinType
@@ -45,7 +45,7 @@ class DataFrameTestBase(ABC):
         pass
 
     @abstractmethod
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return framework connection object, or None if not needed."""
         pass
 
@@ -68,7 +68,7 @@ class DataFrameTestBase(ABC):
         actual = len(result)
         assert actual == expected, f"Expected {expected} rows, got {actual}"
 
-    def _assert_result_equals(self, result: Any, expected: Any, sort_columns: Optional[list[str]] = None) -> None:
+    def _assert_result_equals(self, result: Any, expected: Any, sort_columns: list[str] | None = None) -> None:
         """Perform framework-aware equality check."""
         if sort_columns is not None:
             result = result.sort(sort_columns)

--- a/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
@@ -34,7 +34,7 @@ remains as an override point but is False for every built-in framework.
 This module is intentionally NOT collected as tests (no ``Test`` prefix).
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -75,8 +75,8 @@ class _EmptyResultMatchData(MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         if feature_name not in cls.feature_names_supported():
             return None
@@ -92,7 +92,7 @@ class EmptyResultDefaultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """Root FeatureGroup that yields a schema-bearing zero-row result under default behavior."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"empty_result_default_col"})
 
     @classmethod
@@ -110,7 +110,7 @@ class EmptyResultAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """Root FeatureGroup that yields a schema-bearing zero-row result (one empty column)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"empty_result_allowed_col"})
 
     @classmethod
@@ -132,7 +132,7 @@ class EmptyResultSchemalessAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchDa
     """
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"empty_result_schemaless_col"})
 
     @classmethod
@@ -149,7 +149,7 @@ class EmptyResultNoneFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     """Root FeatureGroup whose ``calculate_feature`` returns ``None`` (state A)."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(supports_features={"empty_result_none_col"})
 
     @classmethod

--- a/tests/test_plugins/compute_framework/test_tooling/merge_link.py
+++ b/tests/test_plugins/compute_framework/test_tooling/merge_link.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import AsOfJoinConfig, JoinSpec, JoinType, Link
 from mloda.provider import FeatureGroup
@@ -17,7 +15,7 @@ def make_merge_link(
     jointype: JoinType,
     left_index: Index,
     right_index: Index,
-    asof_config: Optional[AsOfJoinConfig] = None,
+    asof_config: AsOfJoinConfig | None = None,
 ) -> Link:
     """Build a minimal Link carrying jointype + indexes (+ optional asof_config) for unit tests."""
     return Link(

--- a/tests/test_plugins/compute_framework/test_tooling/multi_index/multi_index_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/multi_index/multi_index_test_base.py
@@ -8,7 +8,7 @@ for multi-index merge operations across all compute frameworks.
 import collections
 import math
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 import logging
 
 import pytest
@@ -80,7 +80,7 @@ class MultiIndexMergeEngineTestBase(ABC):
         pass
 
     @abstractmethod
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return framework connection object, or None if not needed."""
         pass
 
@@ -98,7 +98,7 @@ class MultiIndexMergeEngineTestBase(ABC):
         self,
         scenario_key: str,
         merge_method: str,
-        additional_assertions: Optional[Callable[[list[dict[str, Any]], MergeScenario], None]] = None,
+        additional_assertions: Callable[[list[dict[str, Any]], MergeScenario], None] | None = None,
     ) -> None:
         """
         Run a merge test using a predefined scenario.

--- a/tests/test_plugins/compute_framework/test_tooling/multi_index/test_data_converter.py
+++ b/tests/test_plugins/compute_framework/test_tooling/multi_index/test_data_converter.py
@@ -6,7 +6,7 @@ any compute framework format by leveraging the existing transformer infrastructu
 All conversions go through PyArrow as an intermediate format.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import ComputeFrameworkTransformer
 from mloda.user import PluginLoader
@@ -43,7 +43,7 @@ class DataConverter:
         self,
         data: list[dict[str, Any]],
         target_framework_type: type[Any],
-        connection: Optional[Any] = None,
+        connection: Any | None = None,
     ) -> Any:
         """
         Convert test data (List[Dict]) to target framework format.

--- a/tests/test_plugins/compute_framework/test_tooling/policy_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/policy_run_all_test_base.py
@@ -12,7 +12,7 @@ base that concrete per-framework conformance suites build on.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import pytest
 
@@ -100,7 +100,7 @@ class PolicyRunAllTestBase(ABC):
         """Return the compute framework name string for ``compute_frameworks=[...]``."""
         pass
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         """Return a framework connection object, or None when none is needed."""
         return None
 
@@ -109,7 +109,7 @@ class PolicyRunAllTestBase(ABC):
         """FeatureGroup classes whose ``get_class_name()`` keys the connection in options."""
         return set()
 
-    def _feature_and_dac(self, feature_name: str) -> tuple[Feature, Optional[DataAccessCollection]]:
+    def _feature_and_dac(self, feature_name: str) -> tuple[Feature, DataAccessCollection | None]:
         conn = self.get_connection()
         if conn is not None:
             feature = Feature(
@@ -127,7 +127,7 @@ class PolicyRunAllTestBase(ABC):
         expectation: PolicyExpectation,
         mode: ParallelizationMode,
         flight_server: Any,
-    ) -> Optional[list[Any]]:
+    ) -> list[Any] | None:
         feature, dac = self._feature_and_dac(feature_name)
 
         if isinstance(expectation, PolicyRaises):

--- a/tests/test_plugins/compute_framework/test_tooling/test_dataframe_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/test_dataframe_test_base.py
@@ -7,7 +7,7 @@ duplicated merge tests across all framework test files (Pandas, Polars, PyArrow,
 
 import pytest
 from abc import ABC
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock, MagicMock
 
 from mloda.user import Index
@@ -25,7 +25,7 @@ class ConcreteTestClass(DataFrameTestBase):
     def create_dataframe(self, data: dict[str, Any]) -> Any:
         return {"mocked_df": data}
 
-    def get_connection(self) -> Optional[Any]:
+    def get_connection(self) -> Any | None:
         return None
 
 
@@ -100,7 +100,7 @@ class TestDataFrameTestBaseHelpers:
             def create_dataframe(self, data: dict[str, Any]) -> Any:
                 return data
 
-            def get_connection(self) -> Optional[Any]:
+            def get_connection(self) -> Any | None:
                 return None
 
         concrete = MockFrameworkTestClass()

--- a/tests/test_plugins/extender/test_feature_group_matched_hook.py
+++ b/tests/test_plugins/extender/test_feature_group_matched_hook.py
@@ -5,7 +5,7 @@ HookContext population (run_id/carrier/worker_index/plan_*), and deny-before-mat
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -29,7 +29,7 @@ class _MatchHookRootFeatureGroup(FeatureGroup):
     """Root feature group: single resolved feature for the basic FEATURE_GROUP_MATCHED assertions."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_root_col"})
 
     @classmethod
@@ -43,7 +43,7 @@ class _MatchHookRootFeatureGroup(FeatureGroup):
 
 class _MatchHookColOneFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_col_one"})
 
     @classmethod
@@ -57,7 +57,7 @@ class _MatchHookColOneFeatureGroup(FeatureGroup):
 
 class _MatchHookColTwoFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_col_two"})
 
     @classmethod
@@ -71,7 +71,7 @@ class _MatchHookColTwoFeatureGroup(FeatureGroup):
 
 class _MatchVetoFeatureGroupA(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_veto_col_a"})
 
     @classmethod
@@ -85,7 +85,7 @@ class _MatchVetoFeatureGroupA(FeatureGroup):
 
 class _MatchVetoFeatureGroupB(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_veto_col_b"})
 
     @classmethod
@@ -101,7 +101,7 @@ class _MatchDepthRootFeatureGroup(FeatureGroup):
     """Root of a two-level input_features() chain, for the plan_depth assertions."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_depth_root_col"})
 
     @classmethod
@@ -116,7 +116,7 @@ class _MatchDepthRootFeatureGroup(FeatureGroup):
 class _MatchDepthDerivedFeatureGroup(FeatureGroup):
     """Requested top-level; declares the root feature group's column as its one input feature."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(f"{_MARKER}_depth_root_col")}
 
     @classmethod
@@ -163,12 +163,12 @@ class _MatchListCapturingExtender(Extender):
         return result
 
 
-def _require_int(value: Optional[int]) -> int:
+def _require_int(value: int | None) -> int:
     assert value is not None
     return value
 
 
-def _feature_name_from_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Optional[str]:
+def _feature_name_from_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str | None:
     """Best-effort: find the Feature being resolved among the wrapped resolution's arguments."""
     for value in (*args, *kwargs.values()):
         name = getattr(value, "name", None)

--- a/tests/test_plugins/extender/test_hook_context_inputs.py
+++ b/tests/test_plugins/extender/test_hook_context_inputs.py
@@ -8,7 +8,7 @@ degrade-and-log-once fallback.
 
 import gc
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -137,7 +137,7 @@ class TestPlainStringDeclaredInputs:
         class _PlainStrInputsFeatureGroup(FeatureGroup):
             """input_features declares plain str names, not Feature objects."""
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
                 return {"base_amount", "currency"}
 
             @classmethod
@@ -167,7 +167,7 @@ class TestBatchedFeatureSetDeclaredInputsUnion:
         class _BatchedInputFeatureGroup(FeatureGroup):
             """input_features returns one Feature per requested feature_name."""
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                 return {Feature(f"src_{str(feature_name)}")}
 
             @classmethod
@@ -197,7 +197,7 @@ class TestDeclaredInputsReresolvedAfterOptionDefaultsMaterialize:
 
             PROPERTY_MAPPING = {"source": PropertySpec("Source column.", context=True, default="default_source")}
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
                 value = options.get("source")
                 if value is None:
                     raise ValueError("unmaterialized")
@@ -230,7 +230,7 @@ class TestFeatureNamesAndInputFeaturesArePlainStr:
         class _StrTypedFeatureNamesFeatureGroup(FeatureGroup):
             """input_features declares a Feature object, not a plain str."""
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
                 return {Feature("src")}
 
             @classmethod
@@ -268,7 +268,7 @@ class TestDeclaredInputsResolvedOncePerStep:
             def __init__(self) -> None:
                 type(self).init_calls += 1
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
                 type(self).input_features_calls += 1
                 return {"x"}
 
@@ -545,7 +545,7 @@ class TestDeclaredInputMemoAttributesGuarded:
         class _MemolessInputFeatureGroup(FeatureGroup):
             """input_features declares a plain str name."""
 
-            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+            def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
                 return {"x"}
 
             @classmethod

--- a/tests/test_plugins/extender/test_hook_context_run_id_carrier_e2e.py
+++ b/tests/test_plugins/extender/test_hook_context_run_id_carrier_e2e.py
@@ -1,7 +1,7 @@
 """E2E tests for run_id/carrier plumbing through the real mlodaAPI SYNC execution path,
 down to HookContext."""
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
 from mloda.core.abstract_plugins.hook_context import HookContext
@@ -15,7 +15,7 @@ _CARRIER = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7
 
 class _RunIdCarrierFeatureGroupOne(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"run_id_carrier_e2e_col_one"})
 
     @classmethod
@@ -29,7 +29,7 @@ class _RunIdCarrierFeatureGroupOne(FeatureGroup):
 
 class _RunIdCarrierFeatureGroupTwo(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"run_id_carrier_e2e_col_two"})
 
     @classmethod

--- a/tests/test_plugins/extender/test_hook_context_verified_context_e2e.py
+++ b/tests/test_plugins/extender/test_hook_context_verified_context_e2e.py
@@ -2,7 +2,7 @@
 real mlodaAPI SYNC execution path, down to HookContext. Also proves Options can never override
 the seam's values."""
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
 from mloda.core.abstract_plugins.hook_context import HookContext
@@ -15,7 +15,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 class _VerifiedContextFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"verified_context_e2e_col"})
 
     @classmethod
@@ -48,7 +48,7 @@ class _ContextCapturingExtender(Extender):
         return result
 
 
-def _prepare_session(options: Optional[dict[str, Any]] = None) -> mlodaAPI:
+def _prepare_session(options: dict[str, Any] | None = None) -> mlodaAPI:
     return mloda.prepare(
         [Feature(name="verified_context_e2e_col", options=options)],
         compute_frameworks=["PythonDictFramework"],

--- a/tests/test_plugins/extender/test_join_hook.py
+++ b/tests/test_plugins/extender/test_join_hook.py
@@ -7,7 +7,7 @@ keys, so their join_keys is None.
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -25,7 +25,7 @@ _MARKER = "joinhook051"
 
 class _JoinHookLeftFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_left_id", f"{_MARKER}_left_value"})
 
     @classmethod
@@ -39,7 +39,7 @@ class _JoinHookLeftFeatureGroup(FeatureGroup):
 
 class _JoinHookRightFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_right_id", f"{_MARKER}_right_value"})
 
     @classmethod
@@ -52,7 +52,7 @@ class _JoinHookRightFeatureGroup(FeatureGroup):
 
 
 class _JoinHookConsumerFeatureGroup(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=f"{_MARKER}_left_value"),
             Feature(name=f"{_MARKER}_right_value"),
@@ -271,7 +271,7 @@ class TestDenyWithFallback:
 
 class _JoinHookStarHubFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_star_row_id", f"{_MARKER}_star_hub_value"})
 
     @classmethod
@@ -285,7 +285,7 @@ class _JoinHookStarHubFeatureGroup(FeatureGroup):
 
 class _JoinHookStarSpokeAFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_star_row_id", f"{_MARKER}_star_spoke_a_value"})
 
     @classmethod
@@ -299,7 +299,7 @@ class _JoinHookStarSpokeAFeatureGroup(FeatureGroup):
 
 class _JoinHookStarSpokeBFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_star_row_id", f"{_MARKER}_star_spoke_b_value"})
 
     @classmethod
@@ -312,7 +312,7 @@ class _JoinHookStarSpokeBFeatureGroup(FeatureGroup):
 
 
 class _JoinHookStarConsumerFeatureGroup(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {
             Feature(name=f"{_MARKER}_star_hub_value"),
             Feature(name=f"{_MARKER}_star_spoke_a_value"),
@@ -366,7 +366,7 @@ class TestJoinHookFiresOncePerMergeInStarTopology:
 
 class _JoinHookAppendLeftFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_append_left_id", f"{_MARKER}_append_left_value"})
 
     @classmethod
@@ -380,7 +380,7 @@ class _JoinHookAppendLeftFeatureGroup(FeatureGroup):
 
 class _JoinHookAppendRightFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({f"{_MARKER}_append_right_id", f"{_MARKER}_append_right_value"})
 
     @classmethod
@@ -393,7 +393,7 @@ class _JoinHookAppendRightFeatureGroup(FeatureGroup):
 
 
 class _JoinHookAppendConsumerFeatureGroup(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         link = Link.append(
             JoinSpec(_JoinHookAppendLeftFeatureGroup, Index((f"{_MARKER}_append_left_id",))),
             JoinSpec(_JoinHookAppendRightFeatureGroup, Index((f"{_MARKER}_append_right_id",))),

--- a/tests/test_plugins/feature_group/experimental/dynamic_feature_group_factory/test_dynamic_feature_group_factory.py
+++ b/tests/test_plugins/feature_group/experimental/dynamic_feature_group_factory/test_dynamic_feature_group_factory.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
 from mloda.user import Options
@@ -112,22 +112,22 @@ class TestDynamicFeatureGroupFactory:
             cls: type[FeatureGroup],
             feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
             if isinstance(feature_name, FeatureName):
                 feature_name = str(feature_name)
             return "custom" in feature_name
 
-        def custom_input_features(self: Any, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def custom_input_features(self: Any, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return {Feature(name="custom_input_feature")}
 
         def custom_compute_framework_rule() -> set[type[ComputeFramework]]:
             return {PandasDataFrame}
 
-        def custom_index_columns() -> Optional[list[Index]]:
+        def custom_index_columns() -> list[Index] | None:
             return [Index(("a",)), Index(("b", "c"))]
 
-        def custom_supports_index(cls, index: Index) -> Optional[bool]:  # type: ignore
+        def custom_supports_index(cls, index: Index) -> bool | None:  # type: ignore
             return index.is_multi_index() is False
 
         properties: dict[str, Any] = {
@@ -178,7 +178,7 @@ class TestDynamicFeatureGroupFactory:
         Test case for creating a dynamic feature group using SourceInputFeatureComposite with a simple string.
         """
 
-        def custom_input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:  # type: ignore
+        def custom_input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:  # type: ignore
             return SourceInputFeatureComposite.input_features(options, feature_name)
 
         properties: dict[str, Any] = {
@@ -214,7 +214,7 @@ class TestDynamicFeatureGroupFactory:
         Test case for creating a dynamic feature group using SourceInputFeatureComposite inheriting from SourceInputFeature.
         """
 
-        def custom_input_features(self: Any, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        def custom_input_features(self: Any, options: Options, feature_name: FeatureName) -> set[Feature] | None:
             return SourceInputFeatureComposite.input_features(options, feature_name)
 
         properties: dict[str, Any] = {

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_base_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_base_missing_value_feature_group.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Any, Optional
+from typing import Any
 
 from mloda.user import Feature
 from mloda.user import FeatureName
@@ -30,8 +30,8 @@ class ConcreteMissingValueFeatureGroup(MissingValueFeatureGroup):
         data: Any,
         imputation_method: str,
         in_features: list[str],
-        constant_value: Optional[Any] = None,
-        group_by_features: Optional[list[str]] = None,
+        constant_value: Any | None = None,
+        group_by_features: list[str] | None = None,
     ) -> Any:
         return data
 

--- a/tests/test_plugins/feature_group/experimental/test_source_input_features/test_input_features.py
+++ b/tests/test_plugins/feature_group/experimental/test_source_input_features/test_input_features.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -51,7 +51,7 @@ class InputFeatureMergeTest(SourceInputFeature):
 class TestInputFeatures:
     class FeatureInputCreatorTest(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({cls.get_class_name()})
 
         @classmethod

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
@@ -20,7 +20,7 @@ omitted as redundant.
 """
 
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 import pyarrow as pa
 import pytest
@@ -63,7 +63,7 @@ def test_pyarrow_tz_aware_time_range_filter() -> None:
 
     class PyArrowTzAwareSource(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"temperature", DefaultOptionKeys.reference_time})
 
         @classmethod
@@ -120,7 +120,7 @@ def test_pyarrow_tz_aware_time_range_filter_with_validity_window() -> None:
 
     class PyArrowTzAwareValiditySource(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"temperature", DefaultOptionKeys.reference_time, "valid_time"})
 
         @classmethod
@@ -175,7 +175,7 @@ def test_python_dict_tz_aware_time_range_filter() -> None:
 
     class PythonDictTzAwareSource(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"temperature", DefaultOptionKeys.reference_time})
 
         @classmethod
@@ -220,7 +220,7 @@ def test_polars_tz_aware_time_range_filter() -> None:
 
     class PolarsTzAwareSource(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return DataCreator({"temperature", DefaultOptionKeys.reference_time})
 
         @classmethod

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_time_window_with_global_filter.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_time_window_with_global_filter.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from mloda.user import mloda
 from mloda.provider import FeatureGroup
@@ -32,7 +32,7 @@ class TestTimeWindowWithGlobalFilter:
         # with a wider date range than we'll filter to
         class TestTimeDataCreator(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
+            def input_data(cls) -> BaseInputData | None:
                 return DataCreator(
                     {
                         "temperature",
@@ -197,7 +197,7 @@ class TestTimeWindowWithGlobalFilter:
         # with the custom time filter feature name
         class TestCustomTimeDataCreator(FeatureGroup):
             @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
+            def input_data(cls) -> BaseInputData | None:
                 return DataCreator({"temperature", "humidity", custom_time_filter})
 
             @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_classes/test_input_classes.py
+++ b/tests/test_plugins/feature_group/input_data/test_classes/test_input_classes.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData
@@ -7,7 +7,7 @@ from mloda_plugins.feature_group.input_data.read_db import ReadDB
 
 class DBInputDataTestFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadDB()
 
     @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_init_reader_hoist.py
+++ b/tests/test_plugins/feature_group/input_data/test_init_reader_hoist.py
@@ -2,7 +2,7 @@
 
 Contract:
 
-    BaseInputData.init_reader(self, options: Optional[Options]) -> tuple[BaseInputData, Any]
+    BaseInputData.init_reader(self, options: Options | None) -> tuple[BaseInputData, Any]
     is concrete; ReadDB, ReadFile, and ReadDocument have no overrides.
 
     Semantics of the hoisted implementation:

--- a/tests/test_plugins/feature_group/input_data/test_input_data.py
+++ b/tests/test_plugins/feature_group/input_data/test_input_data.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -14,7 +14,7 @@ from tests.test_core.test_integration.test_core.test_runner_one_compute_framewor
 
 class InputDataTestFeatureGroup(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(
             supports_features={
                 "InputDataTestFeatureGroup_id",

--- a/tests/test_plugins/feature_group/input_data/test_read.py
+++ b/tests/test_plugins/feature_group/input_data/test_read.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional
+from typing import Any
 
 import tempfile
 import sqlite3
@@ -108,7 +108,7 @@ class TestTwoReader:
 
         class ReadFileFeatureWithIndex(ReadFileFeature):
             @classmethod
-            def index_columns(cls) -> Optional[list[Index]]:
+            def index_columns(cls) -> list[Index] | None:
                 return [Index(("id",))]
 
             @classmethod
@@ -116,7 +116,7 @@ class TestTwoReader:
                 cls,
                 feature_name: FeatureName | str,
                 options: Options,
-                data_access_collection: Optional[DataAccessCollection] = None,
+                data_access_collection: DataAccessCollection | None = None,
             ) -> bool:
                 # Feature is only valid for this test
                 if options.get("test_agg_feature") is None:
@@ -132,7 +132,7 @@ class TestTwoReader:
 
         class DBInputDataTestFeatureGroupWithIndex(DBInputDataTestFeatureGroup):
             @classmethod
-            def index_columns(cls) -> Optional[list[Index]]:
+            def index_columns(cls) -> list[Index] | None:
                 return [Index(("id",))]
 
             @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_read_db_error_messages.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_db_error_messages.py
@@ -1,6 +1,6 @@
 """Tests for improved error messages in ReadDB."""
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -19,11 +19,11 @@ class ConcreteReadDB(ReadDB):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
     @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_read_file_error_messages.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_file_error_messages.py
@@ -1,7 +1,5 @@
 """Tests for improved error messages in ReadFile."""
 
-from typing import Optional
-
 import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
@@ -19,11 +17,11 @@ class ConcreteReadFile(ReadFile):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return False
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None
 
 

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
@@ -1,7 +1,7 @@
 import csv
 import os
 import tempfile
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -34,7 +34,7 @@ class OverwrittenReadCsvInputDataTestFeatureGroup(ReadFileFeature):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         if isinstance(feature_name, FeatureName):
             feature_name = str(feature_name)
@@ -75,7 +75,7 @@ class TestInputData:
 
     @classmethod
     def get_features(
-        cls, features: list[str], path: Optional[str] = None, additional_options: dict[str, Any] = {}
+        cls, features: list[str], path: str | None = None, additional_options: dict[str, Any] = {}
     ) -> list[str | Feature]:
         _feature_list: list[str | Feature] = []
         for feature in features:
@@ -361,7 +361,7 @@ class TestSameClassFGLinkWithDifferentDataSources:
 
             class ReadFileWithIndex(ReadFileFeature):
                 @classmethod
-                def index_columns(cls) -> Optional[list[Index]]:
+                def index_columns(cls) -> list[Index] | None:
                     return [Index(("id",))]
 
                 @classmethod
@@ -369,7 +369,7 @@ class TestSameClassFGLinkWithDifferentDataSources:
                     cls,
                     feature_name: FeatureName | str,
                     options: Options,
-                    data_access_collection: Optional[DataAccessCollection] = None,
+                    data_access_collection: DataAccessCollection | None = None,
                 ) -> bool:
                     if options.get("discriminator_test") is None:
                         return False
@@ -384,7 +384,7 @@ class TestSameClassFGLinkWithDifferentDataSources:
                 _path_a: str = path_a
                 _path_b: str = path_b
 
-                def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+                def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                     _path_a = options.get("left_csv_path")
                     _path_b = options.get("right_csv_path")
                     link = Link.inner(
@@ -451,7 +451,7 @@ class TestSameClassFGLinkWithDifferentDataSources:
 
             class ReadFileWithIndexNoDisc(ReadFileFeature):
                 @classmethod
-                def index_columns(cls) -> Optional[list[Index]]:
+                def index_columns(cls) -> list[Index] | None:
                     return [Index(("id",))]
 
                 @classmethod
@@ -459,7 +459,7 @@ class TestSameClassFGLinkWithDifferentDataSources:
                     cls,
                     feature_name: FeatureName | str,
                     options: Options,
-                    data_access_collection: Optional[DataAccessCollection] = None,
+                    data_access_collection: DataAccessCollection | None = None,
                 ) -> bool:
                     if options.get("no_disc_test") is None:
                         return False
@@ -474,7 +474,7 @@ class TestSameClassFGLinkWithDifferentDataSources:
                 _path_a: str = path_a
                 _path_b: str = path_b
 
-                def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+                def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
                     _path_a = options.get("left_csv_path")
                     _path_b = options.get("right_csv_path")
                     link = Link.inner(

--- a/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
@@ -4,7 +4,7 @@ Base implementation for aggregated feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -58,7 +58,7 @@ class ChainedContextFeatureGroupTest(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[Any] = None,
+        data_access_collection: Any | None = None,
     ) -> bool:
         """Check if feature name matches the expected pattern and aggregation type."""
 
@@ -72,7 +72,7 @@ class ChainedContextFeatureGroupTest(FeatureGroup):
 
         return True
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         features = set()
 
         # String-based feature extraction

--- a/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -41,7 +41,7 @@ class PropagateContextFeatureGroupTest(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[Any] = None,
+        data_access_collection: Any | None = None,
     ) -> bool:
         if not FeatureChainParser.match_configuration_feature_chain_parser(
             feature_name=feature_name,
@@ -53,7 +53,7 @@ class PropagateContextFeatureGroupTest(FeatureGroup):
 
         return True
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         features = set()
 
         # Children inherit consumer group options by default; CONTEXT stays local and flows

--- a/tests/test_plugins/integration_plugins/chainer/test_list_valued_options_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_list_valued_options_e2e.py
@@ -5,7 +5,7 @@ TypeError and that element order is preserved via tuple conversion.
 """
 
 import ast
-from typing import Any, Optional
+from typing import Any
 
 from mloda.provider import ComputeFramework
 from mloda.provider import FeatureGroup
@@ -29,7 +29,7 @@ class ListValuedTestDataCreator(FeatureGroup):
     """Creates test data with three columns."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"col_a", "col_b", "col_c"})
 
     @classmethod
@@ -68,7 +68,7 @@ class ListValuedFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[Any] = None,
+        data_access_collection: Any | None = None,
     ) -> bool:
         _name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
         return FeatureChainParser.match_configuration_feature_chain_parser(
@@ -77,7 +77,7 @@ class ListValuedFeatureGroup(FeatureGroup):
             property_mapping=cls.PROPERTY_MAPPING,
         )
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         source_features = options.get_in_features()
         return set(source_features)
 

--- a/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
@@ -11,7 +11,7 @@ validation moments for free:
    the element_validator, at the call site (class-definition time).
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -43,7 +43,7 @@ class PropertySpecE2EDataCreator(FeatureGroup):
     """Root data provider supplying a numeric base column."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"property_spec_e2e_base"})
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/features_for_testing.py
+++ b/tests/test_plugins/integration_plugins/features_for_testing.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 import os
 
 
@@ -22,7 +22,7 @@ except ImportError:
 class MixedCfwFeature(FeatureGroup):
     file_path = f"{os.getcwd()}/tests/test_plugins/feature_group/src/dataset/creditcard_2023_short.csv"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_set = set()
 
         py_arrow_features = ["id", "V1", "V2"]
@@ -62,7 +62,7 @@ class MixedCfwFeature(FeatureGroup):
 class DuplicateFeatureSetup(MixedCfwFeature):
     file_path = f"{os.getcwd()}/tests/test_plugins/feature_group/src/dataset/creditcard_2023_short.csv"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         feature_set = set()
 
         py_arrow_features = ["id", "V1", "V2"]

--- a/tests/test_plugins/integration_plugins/test_api_link_join.py
+++ b/tests/test_plugins/integration_plugins/test_api_link_join.py
@@ -7,7 +7,7 @@ Three features:
 3. JoinedFeature (custom) - depends on both with a join
 """
 
-from typing import Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
 from mloda.user import FeatureName
@@ -30,7 +30,7 @@ class CreatorDataFeature(FeatureGroup):
     """Creates its own data via DataCreator."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"creator_id", "creator_value"})
 
     @classmethod
@@ -48,7 +48,7 @@ class CreatorDataFeature(FeatureGroup):
 class LeftJoinedFeature(FeatureGroup):
     """Joins mloda data with Creator data using LEFT join."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Define input features with a LEFT join link."""
 
         # Create the link: LEFT join on api_id = creator_id
@@ -76,7 +76,7 @@ class LeftJoinedFeature(FeatureGroup):
 class AppendedFeature(FeatureGroup):
     """Appends mloda data with Creator data (stacks vertically)."""
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         """Define input features with an APPEND link."""
 
         # Create the link: APPEND stacks data vertically

--- a/tests/test_plugins/integration_plugins/test_context_isolated_feature_sets_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_context_isolated_feature_sets_e2e.py
@@ -19,7 +19,7 @@ plugin registry.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 import pandas as pd
 
@@ -61,7 +61,7 @@ class ContextIsoSourceGroup(FeatureGroup):
         cls.invocation_count = 0
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({SOURCE_NAME})
 
     @classmethod
@@ -93,7 +93,7 @@ class _ContextIsoConsumerBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == cls.FEATURE_NAME
 
@@ -101,7 +101,7 @@ class _ContextIsoConsumerBase(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PandasDataFrame}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, inherit_context_keys={"tenant"})}
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/test_data_creator.py
+++ b/tests/test_plugins/integration_plugins/test_data_creator.py
@@ -2,7 +2,7 @@
 TestDataCreator classes for creating test data in different compute frameworks.
 """
 
-from typing import Any, Optional
+from typing import Any
 import pandas as pd
 
 from mloda.provider import FeatureGroup
@@ -34,7 +34,7 @@ class ATestDataCreator(FeatureGroup):
     }
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         """Return a DataCreator with the supported feature names."""
         return DataCreator(set(cls.get_raw_data().keys()))
 

--- a/tests/test_plugins/integration_plugins/test_dual_option_consumption_warning.py
+++ b/tests/test_plugins/integration_plugins/test_dual_option_consumption_warning.py
@@ -22,7 +22,7 @@ with other tests in the global plugin registry.
 from __future__ import annotations
 
 import logging
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 import pandas as pd
 import pytest
@@ -62,7 +62,7 @@ class DualWarn579SourceGroup(FeatureGroup):
         cls.seen_options = []
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({SOURCE_NAME})
 
     @classmethod
@@ -85,7 +85,7 @@ class DualWarn579CleanSourceGroup(FeatureGroup):
     """Upstream root group WITHOUT the mode key in its PROPERTY_MAPPING."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({CLEAN_SOURCE_NAME})
 
     @classmethod
@@ -108,7 +108,7 @@ class _DualWarn579ConsumerBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == cls.FEATURE_NAME
 
@@ -132,7 +132,7 @@ class DualWarn579ConsumerGroup(_DualWarn579ConsumerBase):
         MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 consumer group", context=False),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME)}
 
 
@@ -149,7 +149,7 @@ class DualWarn579StringConsumerGroup(_DualWarn579ConsumerBase):
         MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 string consumer group", context=False),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
         return {SOURCE_NAME}
 
 
@@ -167,11 +167,11 @@ class DualWarn579RepeatConsumerGroup(_DualWarn579ConsumerBase):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) in {cls.FEATURE_NAME, cls.SECOND_FEATURE_NAME}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME)}
 
 
@@ -184,7 +184,7 @@ class DualWarn579CleanConsumerGroup(_DualWarn579ConsumerBase):
         MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 clean consumer group", context=False),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(CLEAN_SOURCE_NAME)}
 
 
@@ -196,7 +196,7 @@ class DualWarn579ExcludeConsumerGroup(_DualWarn579ConsumerBase):
         MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 exclude consumer group", context=False),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, forward_group_exclude={MODE_KEY})}
 
 
@@ -214,7 +214,7 @@ class DualWarn579SharedConsumerAGroup(_DualWarn579ConsumerBase):
         MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 shared consumer A group", context=False),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {_dualwarn579_shared_child["child"]}
 
 
@@ -226,7 +226,7 @@ class DualWarn579SharedConsumerBGroup(_DualWarn579ConsumerBase):
         MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 shared consumer B group", context=False),
     }
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {_dualwarn579_shared_child["child"]}
 
 
@@ -235,7 +235,7 @@ class DualWarn579UndeclaredConsumerGroup(_DualWarn579ConsumerBase):
 
     FEATURE_NAME = "dualwarn579_undeclared_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME)}
 
 

--- a/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
@@ -14,7 +14,7 @@ other tests in the global plugin registry.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -47,7 +47,7 @@ class NameMis579SourceGroup(FeatureGroup):
     """Root group providing the source column via DataCreator."""
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({SOURCE_NAME})
 
     @classmethod
@@ -122,7 +122,7 @@ class NameMis579ConsumerGroup(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PandasDataFrame}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(CHAINED_CHILD_NAME)}
 
     @classmethod
@@ -153,7 +153,7 @@ class NameMis579StringConsumerGroup(FeatureGroup):
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PandasDataFrame}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Any] | None:
         return {CHAINED_CHILD_NAME}
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/test_input_feature_option_forwarding_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_input_feature_option_forwarding_e2e.py
@@ -20,7 +20,7 @@ plugin registry.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 import pandas as pd
 
@@ -60,7 +60,7 @@ class ForwardingE2ESourceGroup(FeatureGroup):
         cls.invocation_count = 0
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({SOURCE_NAME})
 
     @classmethod
@@ -93,7 +93,7 @@ class _ForwardingE2EConsumerBase(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return str(feature_name) == cls.FEATURE_NAME
 
@@ -116,7 +116,7 @@ class ForwardingE2EDefaultConsumer(_ForwardingE2EConsumerBase):
 
     FEATURE_NAME = "forwarding_e2e_579_default_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME)}
 
 
@@ -125,7 +125,7 @@ class ForwardingE2EAllowlistConsumer(_ForwardingE2EConsumerBase):
 
     FEATURE_NAME = "forwarding_e2e_579_allowlist_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, forward_group={"backend"})}
 
 
@@ -134,7 +134,7 @@ class ForwardingE2EIsolatedConsumer(_ForwardingE2EConsumerBase):
 
     FEATURE_NAME = "forwarding_e2e_579_isolated_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, forward_group=False)}
 
 
@@ -143,7 +143,7 @@ class ForwardingE2EExcludeConsumer(_ForwardingE2EConsumerBase):
 
     FEATURE_NAME = "forwarding_e2e_579_exclude_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, forward_group_exclude={"top_k"})}
 
 
@@ -152,7 +152,7 @@ class ForwardingE2EContextConsumer(_ForwardingE2EConsumerBase):
 
     FEATURE_NAME = "forwarding_e2e_579_context_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, inherit_context_keys={"tenant"})}
 
 
@@ -167,7 +167,7 @@ class ForwardingE2EDedupConsumer(_ForwardingE2EConsumerBase):
 
     FEATURE_NAME = "forwarding_e2e_579_dedup_consumer"
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(SOURCE_NAME, forward_group_exclude={"top_k"})}
 
     def set_feature_name(self, config: Options, feature_name: FeatureName) -> FeatureName:

--- a/tests/test_plugins/integration_plugins/test_validate_features/example_validator.py
+++ b/tests/test_plugins/integration_plugins/test_validate_features/example_validator.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from pandera import Column, Check
 
@@ -33,7 +33,7 @@ class ExamplePanderaValidator(BaseValidator):
 
 class BaseValidateOutputFeaturesBase(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/test_validate_features/test_validate_input_features.py
+++ b/tests/test_plugins/integration_plugins/test_validate_features/test_validate_input_features.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from pandera import Check, Column
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class BaseValidateInputFeaturesBase(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -36,7 +36,7 @@ class SimpleValidateInputFeatures(FeatureGroup):
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         return {cls.get_class_name(): [1, 2, 3]}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name="BaseValidateInputFeaturesBase", options=options)}
 
     @classmethod
@@ -52,7 +52,7 @@ class CustomValidateInputFeatures(FeatureGroup):
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         return {cls.get_class_name(): [1, 2, 3]}  # dummy return
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name="BaseValidateInputFeaturesBase", options=options)}
 
     @classmethod

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -161,13 +161,14 @@ class TestExtrasConsistency:
 class TestRuffConfig:
     """Validate that ruff lint rules enforce modern Python typing conventions."""
 
-    def test_up006_and_up007_rules_configured(self) -> None:
-        """UP006 (PEP 585 builtins) and UP007 (PEP 604 unions) must be enforced."""
+    def test_modern_typing_rules_configured(self) -> None:
+        """UP006 (PEP 585 builtins), UP007 (PEP 604 unions), and UP045 (PEP 604 Optional rewrite) must be enforced."""
         with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
             data: dict[str, Any] = tomllib.load(f)
         extend_select = data.get("tool", {}).get("ruff", {}).get("lint", {}).get("extend-select", [])
         assert "UP006" in extend_select, "ruff must enforce UP006 (use builtin generics instead of typing generics)"
-        assert "UP007" in extend_select, "ruff must enforce UP007 (use X | Y instead of Union/Optional)"
+        assert "UP007" in extend_select, "ruff must enforce UP007 (use X | Y instead of Union)"
+        assert "UP045" in extend_select, "ruff must enforce UP045 (use X | None instead of Optional)"
 
     def test_no_redundant_typing_generics_in_source(self) -> None:
         """Source files must not import redundant typing generics that UP006/UP007 replace."""
@@ -184,6 +185,20 @@ class TestRuffConfig:
                     if found:
                         violations.append(f"{py_file.relative_to(PROJECT_ROOT)}:{i} imports {found}")
         assert not violations, "Redundant typing imports found:\n" + "\n".join(violations)
+
+    def test_no_optional_typing_usage_in_source(self) -> None:
+        """Source and test files must not use Optional-style annotations that UP045 replaces."""
+        needle = "Optional" + "["
+        source_dirs = [PROJECT_ROOT / "mloda", PROJECT_ROOT / "mloda_plugins", PROJECT_ROOT / "tests"]
+        violations: list[str] = []
+        for source_dir in source_dirs:
+            for py_file in source_dir.rglob("*.py"):
+                for i, line in enumerate(_read_text(py_file).splitlines(), start=1):
+                    if needle in line:
+                        violations.append(f"{py_file.relative_to(PROJECT_ROOT)}:{i}")
+        assert not violations, f"Found {len(violations)} {needle}...] usages (showing up to 20):\n" + "\n".join(
+            violations[:20]
+        )
 
 
 class TestPackagingConfig:


### PR DESCRIPTION
## Summary

Selects ruff's UP045 rule and rewrites `Optional[X]` to `X | None` across `mloda/`, `mloda_plugins/`, and `tests/`, so the typing convention CLAUDE.md/AGENTS.md already document is actually enforced (previously UP007 only covered `Union[...]`, not `Optional[...]`).

A handful of annotations used a quoted forward reference, e.g. `Optional["SomeClass"]`. A mechanical rewrite of those to `"SomeClass" | None` evaluates eagerly at import time and raises `TypeError`, since `typing.Optional` defers string forward references but the `|` operator does not. Those cases are instead rewritten to a self-contained, fully-quoted union string (or left unquoted where the referenced type was never actually a forward reference), so correctness does not depend on the containing module carrying `from __future__ import annotations`. This keeps the fix safe across the whole supported Python range (3.10 through 3.14, with 3.15 landing in the CI matrix once released).

One dataclass's fields are intentionally left unquoted and undeferred, since an existing test reads its fields via `__annotations__` directly and expects live objects rather than strings.

A couple of documentation snippets and one example notebook cell that quoted or used the old `Optional[...]` signatures directly are updated to match.

## Type of change

- [x] Refactor / maintenance (chore:)

## Checklist

- [x] tox passes locally (tests, ruff format --check, ruff check, mypy --strict, bandit, license check)
- [x] Tests added/updated: `pyproject.toml`'s `extend-select` is now asserted to include UP045, and a repo-wide scan asserts no `Optional[...]` usage remains in `mloda/`, `mloda_plugins/`, or `tests/`
- [x] Documentation updated where relevant
- [x] PR title follows Conventional Commits

Closes #1283