### PR TITLE
docs: sweep old-style typing out of in_depth guides and examples

### DIFF
--- a/docs/docs/chapter1/extender.md
+++ b/docs/docs/chapter1/extender.md
@@ -9,7 +9,7 @@ In the following example, we will reuse the previous feature group example and d
 We will create a DokuExtender class to monitor and log the time taken for the calculate_feature function of the feature group to execute.
 #### 1. Define the Extender
 ```python
-from typing import Set, Any
+from typing import Any
 import time
 from mloda.steward import Extender, ExtenderHook
 import logging
@@ -21,7 +21,7 @@ A simple DokuExtender class:
 
 ```python
 class DokuExtender(Extender):
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
         start = time.time()
@@ -73,7 +73,7 @@ class MetricsExtender(Extender):
     def __init__(self) -> None:
         self.raise_on_error = False  # failures log a warning instead of breaking
 
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
@@ -96,7 +96,7 @@ Read it *after* calling `func(*args, **kwargs)` in your own `__call__` to also s
 from mloda.steward import Extender, ExtenderHook, HookContext
 
 class FactsExtender(Extender):
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:

--- a/docs/docs/examples/base_usage.py
+++ b/docs/docs/examples/base_usage.py
@@ -135,7 +135,7 @@ def _(mo):
     ```python
     class FeatureGroup(ABC):
 
-        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
 
             # In principle, the resolver checks if the feature group depends on another input feature
             # -> then adds it to the chain of features which need to be resolved
@@ -147,9 +147,9 @@ def _(mo):
         @classmethod
         def match_feature_group_criteria(
             cls,
-            feature_name: Union[FeatureName, str],
+            feature_name: FeatureName | str,
             options: Options,
-            data_access_collection: Optional[DataAccessCollection] = None,
+            data_access_collection: DataAccessCollection | None = None,
         ) -> bool:
     ```
 

--- a/docs/docs/examples/mloda_basics/3_ml_data_feature_feature_groups.py
+++ b/docs/docs/examples/mloda_basics/3_ml_data_feature_feature_groups.py
@@ -107,7 +107,7 @@ def _(mo):
 
     ```python
     # This could be:
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {OrderAmount, Datetime, ID}
     ```
     """)
@@ -140,9 +140,9 @@ def _(mo):
     ```python
     @classmethod
     def match_feature_group_criteria(
-        feature_name: Union[FeatureName, str],
+        feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None
+        data_access_collection: DataAccessCollection | None = None
         )
         ...
     ```

--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
@@ -140,7 +140,7 @@ def _(mo):
     ```python
     class ReadFileFeature(FeatureGroup):
         @classmethod
-        def input_data(cls) -> Optional[BaseInputData]:
+        def input_data(cls) -> BaseInputData | None:
             return ReadFile()
 
         @classmethod
@@ -324,13 +324,13 @@ def _(mo):
     class mlodaAPI:
         def __init__(
             self,
-            requested_features: Union[Features, list[Union[Feature, str]]],
-            compute_frameworks: Union[Set[Type[ComputeFramework]], Optional[list[str]]] = None,
-            links: Optional[Set[Link]] = None,
-            data_access_collection: Optional[DataAccessCollection] = None,
-            global_filter: Optional[GlobalFilter] = None,
-            api_input_data_collection: Optional[ApiInputDataCollection] = None,
-            plugin_collector: Optional[PluginCollector] = None,
+            requested_features: Features | list[Feature | str],
+            compute_frameworks: set[type[ComputeFramework]] | list[str] | None = None,
+            links: set[Link] | None = None,
+            data_access_collection: DataAccessCollection | None = None,
+            global_filter: GlobalFilter | None = None,
+            api_input_data_collection: ApiInputDataCollection | None = None,
+            plugin_collector: PluginCollector | None = None,
         ) -> None:
 
     data = mlodamloda.run_all(requested_feature,...)
@@ -379,7 +379,7 @@ def _(mo):
 
     ```python
     class OrgLoggingExtender(Extender):
-        def wraps(self) -> Set[ExtenderHook]:
+        def wraps(self) -> set[ExtenderHook]:
             # Function to be wrapped by the Extender
             return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
 
@@ -394,7 +394,7 @@ def _(mo):
     ```python
     class LogSizeOfData(Extender):
 
-        def wraps(self) -> Set[ExtenderHook]:
+        def wraps(self) -> set[ExtenderHook]:
             # Function to be wrapped by the Extender
             return {ExtenderHook.VALIDATE_INPUT_FEATURE}
 

--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
@@ -329,7 +329,7 @@ def _(mo):
             links: set[Link] | None = None,
             data_access_collection: DataAccessCollection | None = None,
             global_filter: GlobalFilter | None = None,
-            api_input_data_collection: ApiInputDataCollection | None = None,
+            api_data: dict[str, dict[str, Any]] | None = None,
             plugin_collector: PluginCollector | None = None,
         ) -> None:
 

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -164,7 +164,7 @@ As a side note, the ReadFileFeature was also used for the global scope automatis
 To use it, we can simply:
 
 ```python
-from typing import Any, List
+from typing import Any
 from pathlib import Path
 
 from mloda.user import mloda
@@ -177,7 +177,7 @@ from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
 file_path = os.getcwd()
 file_path += "/docs/docs/in_depth"
 
-feature_list: List[Feature | str] = []
+feature_list: list[Feature | str] = []
 feature_list.append(
     Feature(
         name="AExample",
@@ -215,8 +215,6 @@ Use cases:
 The following example shows a simple ApiData setup.
 
 ```python
-from typing import List
-
 from mloda.user import mloda
 from mloda.user.pandas import PandasDataFrame
 

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -147,7 +147,7 @@ In this case, we need to provide the specific reader class: CsvReader.
 # This feature is already implemented as plugin, so do not run it again. This will raise intentional errors.
 class ReadFileFeature(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return ReadFile()
 
     @classmethod
@@ -164,7 +164,7 @@ As a side note, the ReadFileFeature was also used for the global scope automatis
 To use it, we can simply:
 
 ```python
-from typing import Optional, Any, List
+from typing import Any, List
 from pathlib import Path
 
 from mloda.user import mloda
@@ -263,7 +263,7 @@ class AFeatureInputCreator(FeatureGroup):
 
     # Define input_data with using DataCreator
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({"AFeatureInputCreator"})
 
     # Define the data this feature creates
@@ -297,8 +297,6 @@ This is one of the key aspects in how we achieve to split data from processes.
 
 In the following example, we will use data from another feature.
 ```python
-from typing import Set
-
 from mloda.user import mloda
 from mloda.provider import FeatureGroup, FeatureSet
 from mloda.user import Options, FeatureName, Feature, PluginCollector
@@ -310,7 +308,7 @@ _in_features = "in_features"
 # First, we create a class, which uses input features from another class
 class AInputFeatureGroup(FeatureGroup):
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
 
         # We use the source to make this feature flexible.
         # One could give here different feature names via the configuration.
@@ -371,7 +369,7 @@ from mloda.provider import ApiInputDataFeature
 
 class JoinedFeature(FeatureGroup):
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         # Create a LEFT join between mloda data and Creator data
         link = Link.left(
             (ApiInputDataFeature, Index(("api_id",))),

--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -30,7 +30,7 @@ The following example demonstrates how to implement and test an artifact.
 Here, we create a `FeatureGroup` with a configured `BaseArtifact`.
 
 ```python
-from typing import Type, Any, Optional
+from typing import Any
 from mloda.provider import FeatureGroup, FeatureSet, BaseArtifact, DataCreator, BaseInputData
 
 
@@ -40,7 +40,7 @@ class BaseExampleArtifactFeature(FeatureGroup):
         return DataCreator({cls.get_class_name()})
 
     @staticmethod
-    def artifact() -> Type[BaseArtifact] | None:
+    def artifact() -> type[BaseArtifact] | None:
         return BaseArtifact
 
     @classmethod
@@ -151,7 +151,7 @@ from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import Sk
 
 class MySklearnFeatureGroup(FeatureGroup):
     @staticmethod
-    def artifact() -> Type[BaseArtifact] | None:
+    def artifact() -> type[BaseArtifact] | None:
         return SklearnArtifact
 
     @classmethod

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -184,8 +184,8 @@ class DuckDBFeatureGroup(FeatureGroup, MatchData):
         cls,
         feature_name: str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-        framework_connection_object: Optional[Any] = None,
+        data_access_collection: DataAccessCollection | None = None,
+        framework_connection_object: Any | None = None,
     ) -> Any:
         # Logic to determine if this matcher handles DuckDB connections
         if framework_connection_object and isinstance(framework_connection_object, duckdb.DuckDBPyConnection):
@@ -234,8 +234,8 @@ class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
 
     @classmethod
     def match_data_access(cls, feature_name: str, options: Options,
-                         data_access_collection: Optional[DataAccessCollection] = None,
-                         framework_connection_object: Optional[Any] = None) -> Any:
+                         data_access_collection: DataAccessCollection | None = None,
+                         framework_connection_object: Any | None = None) -> Any:
         # MatchData for connection object matching
         if framework_connection_object and isinstance(framework_connection_object, duckdb.DuckDBPyConnection):
             return framework_connection_object

--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -19,7 +19,7 @@ Example: Input Feature Validation Using Custom Validators
 ###### Simple validator
 
 ```python
-from typing import Any, Optional, Set
+from typing import Any
 from mloda.user import mloda
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Options, FeatureName, Feature
@@ -28,7 +28,7 @@ from mloda.user.pyarrow import PyArrowTable
 
 class DocBaseValidateInputFeaturesBase(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -42,7 +42,7 @@ class DocSimpleValidateInputFeatures(FeatureGroup):
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         return {cls.get_class_name(): [1, 2, 3]}
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature(name="DocBaseValidateInputFeaturesBase", options=options)}
 
     @classmethod
@@ -146,7 +146,7 @@ import time
 
 
 class DokuValidateInputFeatureExtender(Extender):
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.VALIDATE_INPUT_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
@@ -187,7 +187,7 @@ from mloda.user import Options
 
 class DocBaseValidateOutputFeaturesBase(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name()})
 
     @classmethod
@@ -242,7 +242,7 @@ We can of course also use an extender.
 
 ```python
 class ValidateOutputFeatureExtender(Extender):
-    def wraps(self) -> Set[ExtenderHook]:
+    def wraps(self) -> set[ExtenderHook]:
         return {ExtenderHook.VALIDATE_OUTPUT_FEATURE}
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:

--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -7,7 +7,7 @@ mloda supports optional data type declarations on Features, enabling runtime val
 Use typed constructors to declare the expected data type:
 
 ```python
-from typing import Any, Optional
+from typing import Any
 from mloda.user import Feature
 
 # Typed features: Will be validated at runtime
@@ -97,7 +97,7 @@ In strict mode, only exact type matches or standard widening conversions are all
 Enforcement is driven by a single override point on `ComputeFramework`:
 
 ```python
-def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
     ...
 ```
 
@@ -126,7 +126,7 @@ from mloda.provider import ComputeFramework
 
 
 class MyFramework(ComputeFramework):
-    def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
+    def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
         native = data.schema.field(column_name).type  # framework-specific access
         if native == ...:
             return DataType.INT64

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -69,7 +69,6 @@ The new `Options` class separates parameters into two categories:
 
 ```python
 from mloda.user import Options
-from typing import Optional
 
 # New Options architecture
 options = Options(
@@ -265,7 +264,7 @@ Override when you need to add additional input features (e.g., time filter):
 
 ```py
 class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         # Try string-based parsing first
         _, in_feature = FeatureChainParser.parse_feature_name(str(feature_name), [self.PREFIX_PATTERN])
         if in_feature is not None:
@@ -387,7 +386,7 @@ def match_feature_group_criteria(cls, feature_name, options, data_access_collect
 Handle both string-based and configuration-based features:
 
 ```py
-def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
     """Extract source feature from either configuration-based options or string parsing."""
 
     # Try string-based parsing first
@@ -505,14 +504,12 @@ on a requested feature travels down self-resolving chains (for example
 `price__mean_imputed__sum_aggr`) to the end of the chain without any ceremony:
 
 ```python
-from typing import Optional
-
 from mloda.provider import FeatureGroup
 from mloda.user import Feature, FeatureName, Options
 
 
 class GraphAnswer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         # The child inherits ALL of the consumer's group options by default.
         return {Feature("knowledge_graph")}
 ```
@@ -633,7 +630,7 @@ Use `resolve_multi_column_feature()` to automatically discover columns:
 
 ```py
 class MultiColumnConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         # Request base feature without ~N suffix
         return {Feature("category__onehot_encoded")}
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -51,8 +51,8 @@ Parameters:
 
 -   event_from (datetime): Start of the time range (with timezone).
 -   event_to (datetime): End of the time range (with timezone).
--   valid_from (Optional[datetime]): Start of the validity period (optional, with timezone).
--   valid_to (Optional[datetime]): End of the validity period (optional, with timezone).
+-   valid_from (datetime | None): Start of the validity period (optional, with timezone).
+-   valid_to (datetime | None): End of the validity period (optional, with timezone).
 -   max_exclusive (bool): If True, the upper bounds (event_to, valid_to) are treated as exclusive.
 -   event_time_column: The column name containing event timestamps. Default is "reference_time".
 -   validity_time_column: The column name containing validity timestamps. Default is "time_travel".
@@ -115,12 +115,12 @@ Further, the feature is a data creator, so we create the data here itself.
 ```python
 from mloda.user import mloda
 from mloda.provider import FeatureGroup, FeatureSet, ComputeFramework, BaseInputData, DataCreator
-from typing import Any, Union, Set, Type, Optional
+from typing import Any
 from mloda.user.pyarrow import PyArrowTable
 
 class ExampleOrderFilter(FeatureGroup):
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator({cls.get_class_name(), "example_order_id"})
 
     @classmethod

--- a/docs/docs/in_depth/framework-connection-object.md
+++ b/docs/docs/in_depth/framework-connection-object.md
@@ -43,9 +43,9 @@ The base `ComputeFramework` class provides methods to manage connection objects:
 class ComputeFramework(ABC):
     def __init__(self) -> None:
         # Connection object for frameworks that need persistent connections
-        self.framework_connection_object: Optional[Any] = None
+        self.framework_connection_object: Any | None = None
     
-    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
         """
         Some compute frameworks (e.g., DuckDB, Spark) require sharing their connection
         with merge engines to ensure data consistency. Override this method in
@@ -64,7 +64,7 @@ Framework transformers receive the connection object as a parameter:
 
 ```py
 @classmethod
-def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
     """
     Transform data from the secondary framework to the primary framework.
     
@@ -154,7 +154,7 @@ When implementing a new compute framework that requires a connection object:
 
 1. **Override `set_framework_connection_object`**:
 ```py
-def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
     if framework_connection_object is not None:
         if not isinstance(framework_connection_object, ExpectedConnectionType):
             raise ValueError(f"Expected connection type, got {type(framework_connection_object)}")
@@ -170,7 +170,7 @@ When implementing transformers for stateful frameworks:
 1. **Accept the connection object parameter**:
 ```py
 @classmethod
-def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
     # Implementation here
 ```
 

--- a/docs/docs/in_depth/framework-transformers.md
+++ b/docs/docs/in_depth/framework-transformers.md
@@ -174,7 +174,7 @@ To create a custom transformer for a new pair of frameworks:
 Example of a two-way transformer:
 
 ```python
-from typing import Any, Optional
+from typing import Any
 
 class CustomTransformer(BaseTransformer):
     @classmethod
@@ -199,7 +199,7 @@ class CustomTransformer(BaseTransformer):
         return other_framework.from_custom(data)
 
     @classmethod
-    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
         # Convert from OtherFramework to CustomFramework
         return custom_framework.from_other(data)
 ```

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -240,7 +240,7 @@ fgs = get_feature_group_docs(compute_framework="PandasDataFrame")
 - **plugin_collector** (`PluginCollector`, optional): Filter using the plugin collector's applicability check.
 - **registered_only** (`bool`, default `False`): If `True`, only document classes in the collector's injected registry, else the default registry.
 
-**Returns:** `List[FeatureGroupInfo]` sorted by name.
+**Returns:** `list[FeatureGroupInfo]` sorted by name.
 
 ##### get_compute_framework_docs
 
@@ -263,7 +263,7 @@ available_frameworks = get_compute_framework_docs(available_only=True)
 - **available_only** (`bool`, default `False`): By default all frameworks are listed (with `is_available` as the flag); set `available_only=True` to filter to available frameworks only.
 - **registered_only** (`bool`, default `False`): If `True`, only document classes in the default registry.
 
-**Returns:** `List[ComputeFrameworkInfo]` sorted by name.
+**Returns:** `list[ComputeFrameworkInfo]` sorted by name.
 
 ##### get_extender_docs
 
@@ -286,5 +286,5 @@ extenders = get_extender_docs(wraps="formula")
 - **wraps** (`str`, optional): Filter by wrapped function type (case-insensitive exact match).
 - **registered_only** (`bool`, default `False`): If `True`, only document classes in the default registry.
 
-**Returns:** `List[ExtenderInfo]` sorted by name.
+**Returns:** `list[ExtenderInfo]` sorted by name.
 

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -235,7 +235,7 @@ fgs = get_feature_group_docs(compute_framework="PandasDataFrame")
 
 - **name** (`str`, optional): Filter by name (case-insensitive partial match).
 - **search** (`str`, optional): Search in description (case-insensitive partial match).
-- **compute_framework** (`str | Type[ComputeFramework]`, optional): Filter by compute framework.
+- **compute_framework** (`str | type[ComputeFramework]`, optional): Filter by compute framework.
 - **version_contains** (`str`, optional): Filter by version substring.
 - **plugin_collector** (`PluginCollector`, optional): Filter using the plugin collector's applicability check.
 - **registered_only** (`bool`, default `False`): If `True`, only document classes in the collector's injected registry, else the default registry.

--- a/docs/docs/in_depth/multiple_result_columns.md
+++ b/docs/docs/in_depth/multiple_result_columns.md
@@ -56,7 +56,7 @@ Use the `resolve_multi_column_feature()` utility to automatically discover all c
 
 ```py
 class MultiColumnConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.not_typed("MultiColumnFeature")}
 
     @classmethod
@@ -86,7 +86,7 @@ For backwards compatibility, you can still access columns manually:
 
 ```py
 class MultiColumnConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {Feature.not_typed("MultiColumnFeature")}
 
     @classmethod
@@ -108,7 +108,7 @@ You can declare a dependency on a specific sub-column directly, without needing 
 
 ```py
 class SpecificSubColumnConsumer(FeatureGroup):
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         # Depend on ONLY base_feature~1, not all columns
         return {Feature("base_feature~1")}
 
@@ -147,8 +147,8 @@ def identify_naming_convention(
     self,
     selected_feature_names: Sequence[FeatureName],
     column_names: set[str],
-    ordering: Optional[str] = None,
-    request_feature_order: Optional[list[str]] = None,
+    ordering: str | None = None,
+    request_feature_order: list[str] | None = None,
 ) -> set[str] | list[str]: ...
 ```
 

--- a/tests/test_docs_stale_typing.py
+++ b/tests/test_docs_stale_typing.py
@@ -1,0 +1,43 @@
+"""Stale old-style typing forms swept from docs/docs/in_depth pages and marimo example scripts.
+
+The old-style Union, Optional, Set, and Type generics predate the PEP 604/585 syntax (X | Y, X | None,
+set[X], type[X]) and none of these words legitimately appear bracketed in this doc tree otherwise, so a raw
+text scan over the whole file (fenced code, prose, and inline code alike) is enough: no AST or fence parsing needed.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.docs_corpus import DOCS_ROOT, REPO_ROOT, doc_files, doc_id
+
+STALE_TOKENS = ("Union", "Optional", "Set", "Type")
+
+TOKEN_PATTERNS: dict[str, re.Pattern[str]] = {token: re.compile(rf"\b{token}\[") for token in STALE_TOKENS}
+
+# Marimo notebook scripts whose mo.md(r\"\"\"...\"\"\") prose blocks carry the same stale forms.
+EXAMPLE_FILES = [
+    REPO_ROOT / "docs" / "docs" / "examples" / "base_usage.py",
+    REPO_ROOT / "docs" / "docs" / "examples" / "mloda_basics" / "3_ml_data_feature_feature_groups.py",
+    REPO_ROOT / "docs" / "docs" / "examples" / "mloda_basics" / "4_ml_data_providers_user_steward.py",
+]
+
+TARGET_FILES = doc_files(DOCS_ROOT / "in_depth") + EXAMPLE_FILES
+
+
+def _stale_token_counts(path: Path) -> dict[str, int]:
+    """Count occurrences of each stale typing token in path's raw text, omitting zero counts."""
+    text = path.read_text(encoding="utf-8")
+    counts = {token: len(pattern.findall(text)) for token, pattern in TOKEN_PATTERNS.items()}
+    return {token: count for token, count in counts.items() if count}
+
+
+@pytest.mark.parametrize("path", TARGET_FILES, ids=[doc_id(path) for path in TARGET_FILES])
+def test_no_stale_typing_forms_remain(path: Path) -> None:
+    counts = _stale_token_counts(path)
+    found = ", ".join(f"{token}[ x{count}" for token, count in counts.items())
+    assert not counts, (
+        f"{doc_id(path)} still uses old-style typing form(s): {found}. "
+        f"Replace with PEP 604/585 syntax (X | Y, X | None, set[X], type[X])."
+    )

--- a/tests/test_docs_stale_typing.py
+++ b/tests/test_docs_stale_typing.py
@@ -1,8 +1,7 @@
-"""Stale old-style typing forms swept from docs/docs/in_depth pages and marimo example scripts.
+"""Old-style Union/Optional/Set/Type generics swept from docs/docs/in_depth and the marimo examples.
 
-The old-style Union, Optional, Set, and Type generics predate the PEP 604/585 syntax (X | Y, X | None,
-set[X], type[X]) and none of these words legitimately appear bracketed in this doc tree otherwise, so a raw
-text scan over the whole file (fenced code, prose, and inline code alike) is enough: no AST or fence parsing needed.
+None of these words legitimately appear bracketed elsewhere in this doc tree, so a raw text scan is
+enough to catch them, no fence parsing needed.
 """
 
 import re
@@ -27,7 +26,6 @@ TARGET_FILES = doc_files(DOCS_ROOT / "in_depth") + EXAMPLE_FILES
 
 
 def _stale_token_counts(path: Path) -> dict[str, int]:
-    """Count occurrences of each stale typing token in path's raw text, omitting zero counts."""
     text = path.read_text(encoding="utf-8")
     counts = {token: len(pattern.findall(text)) for token, pattern in TOKEN_PATTERNS.items()}
     return {token: count for token, count in counts.items() if count}

--- a/tests/test_docs_stale_typing.py
+++ b/tests/test_docs_stale_typing.py
@@ -1,4 +1,4 @@
-"""Old-style Union/Optional/Set/Type generics swept from docs/docs/in_depth and the marimo examples.
+"""Old-style Union/Optional/Set/Type/List generics swept from docs/docs and the marimo examples.
 
 None of these words legitimately appear bracketed elsewhere in this doc tree, so a raw text scan is
 enough to catch them, no fence parsing needed.
@@ -11,18 +11,15 @@ import pytest
 
 from tests.docs_corpus import DOCS_ROOT, REPO_ROOT, doc_files, doc_id
 
-STALE_TOKENS = ("Union", "Optional", "Set", "Type")
+STALE_TOKENS = ("Union", "Optional", "Set", "Type", "List")
 
 TOKEN_PATTERNS: dict[str, re.Pattern[str]] = {token: re.compile(rf"\b{token}\[") for token in STALE_TOKENS}
 
-# Marimo notebook scripts whose mo.md(r\"\"\"...\"\"\") prose blocks carry the same stale forms.
-EXAMPLE_FILES = [
-    REPO_ROOT / "docs" / "docs" / "examples" / "base_usage.py",
-    REPO_ROOT / "docs" / "docs" / "examples" / "mloda_basics" / "3_ml_data_feature_feature_groups.py",
-    REPO_ROOT / "docs" / "docs" / "examples" / "mloda_basics" / "4_ml_data_providers_user_steward.py",
-]
+# Every marimo notebook script under docs/docs/examples, whose mo.md(r\"\"\"...\"\"\") prose blocks
+# carry the same stale forms as the markdown docs.
+EXAMPLE_FILES = sorted((DOCS_ROOT / "examples").rglob("*.py"))
 
-TARGET_FILES = doc_files(DOCS_ROOT / "in_depth") + EXAMPLE_FILES
+TARGET_FILES = doc_files() + EXAMPLE_FILES
 
 
 def _stale_token_counts(path: Path) -> dict[str, int]:
@@ -38,4 +35,14 @@ def test_no_stale_typing_forms_remain(path: Path) -> None:
     assert not counts, (
         f"{doc_id(path)} still uses old-style typing form(s): {found}. "
         f"Replace with PEP 604/585 syntax (X | Y, X | None, set[X], type[X])."
+    )
+
+
+def test_ml_data_providers_snippet_matches_real_mlodaapi_signature() -> None:
+    """The illustrative __init__ docstring must not document a parameter mlodaAPI never had."""
+    path = REPO_ROOT / "docs" / "docs" / "examples" / "mloda_basics" / "4_ml_data_providers_user_steward.py"
+    text = path.read_text(encoding="utf-8")
+    assert "api_input_data_collection" not in text, (
+        f"{doc_id(path)} documents a non-existent mlodaAPI.__init__ parameter "
+        f"'api_input_data_collection'; the real parameter (mloda/core/api/request.py) is 'api_data'."
     )


### PR DESCRIPTION
## Summary

Sweeps stale Python typing syntax (`Union[...]`, `Optional[...]`, `Set[...]`, `Type[...]`, and the related `List[...]`) out of `docs/docs/in_depth/`, `docs/docs/chapter1/`, and the marimo example notebooks under `docs/docs/examples/`. These snippets live inside markdown fences and `mo.md()` docstrings, so ruff's UP006/UP007/UP045 rules never see them even though the real source they document moved to modern forms (`X | None`, `set[...]`, `type[...]`, `list[...]`) long ago.

- Converts every stale snippet to the modern equivalent.
- Corrects a few snippets that had drifted from the real, current signature (a documented `mlodaAPI.__init__` parameter that no longer exists, some stale `List[...]` return types).
- Adds `tests/test_docs_stale_typing.py`, a static regression guard that scans the whole `docs/docs` tree (markdown and example scripts) for these stale forms so they cannot silently reappear.

## Test plan

- [x] `pytest tests/test_docs_stale_typing.py -v` (47 passed)
- [x] `tox` (full gate: pytest, ruff format/check, mypy --strict, bandit, license check) passes

Closes #1351