### PR TITLE
fix: return first occurrence instead of raising for duplicate columns in dtype extraction

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -7,7 +7,10 @@ from mloda.provider import ComputeFramework
 from mloda.provider import BaseFilterEngine
 from mloda.provider import OutputSchema
 from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_filter_engine import IcebergFilterEngine
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import arrow_schema_output_schema
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import (
+    arrow_schema_field_type,
+    arrow_schema_output_schema,
+)
 
 try:
     from pyiceberg.catalog import Catalog
@@ -155,9 +158,10 @@ class IcebergFramework(ComputeFramework):
                 return None
             return str(field.field_type)
         if pa is not None and isinstance(data, pa.Table):
-            if column_name in data.schema.names:
-                return str(data.schema.field(column_name).type)
-            return None
+            arrow_type = arrow_schema_field_type(data.schema, column_name)
+            if arrow_type is None:
+                return None
+            return str(arrow_type)
         return None
 
     def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
@@ -191,9 +195,10 @@ class IcebergFramework(ComputeFramework):
                 return DataType.DECIMAL
             return None
         if pa is not None and isinstance(data, pa.Table):
-            if column_name not in data.schema.names:
+            arrow_type = arrow_schema_field_type(data.schema, column_name)
+            if arrow_type is None:
                 return None
-            return DataType.from_arrow_type_safe(data.schema.field(column_name).type)
+            return DataType.from_arrow_type_safe(arrow_type)
         return None
 
     def _output_schema(self, data: Any) -> OutputSchema | None:

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
@@ -39,6 +39,14 @@ def arrow_schema_output_schema(schema: Any) -> OutputSchema | None:
     return tuple((name, seen[name]) for name in sorted(seen, key=str))
 
 
+def arrow_schema_field_type(schema: Any, column_name: str) -> Any | None:
+    """Return column_name's arrow type from its first occurrence; unlike schema.field(), never raises on duplicates."""
+    for name, arrow_type in zip(schema.names, schema.types):
+        if name == column_name:
+            return arrow_type
+    return None
+
+
 class PyArrowTable(ComputeFramework):
     @staticmethod
     def is_available() -> bool:
@@ -83,14 +91,16 @@ class PyArrowTable(ComputeFramework):
         return set(data.schema.names)
 
     def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
-        if column_name in data.schema.names:
-            return str(data.schema.field(column_name).type)
-        return None
+        arrow_type = arrow_schema_field_type(data.schema, column_name)
+        if arrow_type is None:
+            return None
+        return str(arrow_type)
 
     def _extract_column_data_type(self, data: Any, column_name: str) -> DataType | None:
-        if column_name not in data.schema.names:
+        arrow_type = arrow_schema_field_type(data.schema, column_name)
+        if arrow_type is None:
             return None
-        return DataType.from_arrow_type_safe(data.schema.field(column_name).type)
+        return DataType.from_arrow_type_safe(arrow_type)
 
     def _output_schema(self, data: Any) -> OutputSchema | None:
         if isinstance(data, dict):

--- a/tests/test_plugins/compute_framework/base_implementations/dtype_extraction_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/dtype_extraction_test_mixin.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.user import DataType
 
 
 class DtypeExtractionTestMixin:
@@ -81,4 +82,94 @@ class DtypeExtractionTestMixin:
         assert dtype is not None
         assert not ComputeFramework._is_numeric_dtype(str(dtype).lower()), (
             f"string dtype '{dtype}' incorrectly classified as numeric"
+        )
+
+
+class DuplicateColumnDtypeExtractionTestMixin:
+    """Shared tests for _extract_column_dtype/_extract_column_data_type on duplicate-column data.
+
+    Opt-in, not part of DtypeExtractionTestMixin's abstract fixture contract: only frameworks
+    that can represent two columns sharing a name (PyArrow, and Iceberg's post-transform
+    PyArrow branch) mix this in. Pandas/Polars/DuckDB/Sqlite/Spark cannot construct this shape.
+
+    The mixin is intentionally named without a ``Test`` prefix so pytest does not collect it
+    standalone. Framework subclasses pick up the test methods by inheritance.
+    """
+
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        """Return a compute framework instance.
+
+        Override in framework-specific test class.
+        """
+        raise NotImplementedError
+
+    @pytest.fixture
+    def dtype_duplicate_column_data(self) -> Any:
+        """Return a pa.Table with two columns named "dup_col": first int, second string.
+
+        Override in framework-specific test class.
+        """
+        raise NotImplementedError
+
+    @pytest.fixture
+    def dtype_duplicate_column_data_reversed(self) -> Any:
+        """Return a pa.Table with two columns named "dup_col": first string, second int.
+
+        Override in framework-specific test class. The reversed order pins first-occurrence
+        semantics: an implementation that merely prefers the numeric column would pass the
+        int-first fixture but fail this one.
+        """
+        raise NotImplementedError
+
+    def test_extract_duplicate_column_dtype_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """A duplicate column name must not raise; the first occurrence's dtype wins."""
+        dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data, "dup_col")
+        assert dtype is not None, "_extract_column_dtype returned None for a duplicate column"
+        assert ComputeFramework._is_numeric_dtype(str(dtype).lower()), (
+            f"duplicate column dtype '{dtype}' should match the first (int) occurrence"
+        )
+
+    def test_extract_duplicate_column_data_type_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """A duplicate column name must not raise; _extract_column_data_type returns the first occurrence."""
+        data_type = framework_instance._extract_column_data_type(dtype_duplicate_column_data, "dup_col")
+        assert data_type is not None, "_extract_column_data_type returned None for a duplicate column"
+        assert data_type == DataType.INT64, (
+            f"duplicate column data type '{data_type}' should match the first (int) occurrence"
+        )
+
+    def test_extract_duplicate_column_dtype_reversed_order_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data_reversed: Any
+    ) -> None:
+        """Reversing which column comes first proves first-occurrence wins, not "prefers numeric"."""
+        dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data_reversed, "dup_col")
+        assert dtype is not None, "_extract_column_dtype returned None for a duplicate column"
+        assert ComputeFramework._is_string_dtype(str(dtype).lower()), (
+            f"duplicate column dtype '{dtype}' should match the first (string) occurrence"
+        )
+
+    def test_extract_duplicate_column_data_type_reversed_order_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data_reversed: Any
+    ) -> None:
+        """Reversing which column comes first proves first-occurrence wins, not "prefers numeric"."""
+        data_type = framework_instance._extract_column_data_type(dtype_duplicate_column_data_reversed, "dup_col")
+        assert data_type is not None, "_extract_column_data_type returned None for a duplicate column"
+        assert data_type == DataType.STRING, (
+            f"duplicate column data type '{data_type}' should match the first (string) occurrence"
+        )
+
+    def test_extract_column_dtype_consistent_with_output_schema(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """_extract_column_dtype must agree with _output_schema's first-occurrence handling."""
+        output_schema = framework_instance._output_schema(dtype_duplicate_column_data)
+        assert output_schema is not None, "_output_schema returned None for a duplicate column table"
+        schema_dtype = dict(output_schema)["dup_col"]
+        extracted_dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data, "dup_col")
+        assert schema_dtype == extracted_dtype, (
+            f"_output_schema reports '{schema_dtype}' but _extract_column_dtype reports '{extracted_dtype}'"
         )

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from unittest.mock import Mock, patch
 from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework import IcebergFramework
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.user import DataType
 from mloda.user import FeatureName
 from mloda.user import ParallelizationMode
@@ -301,6 +302,31 @@ class TestIcebergDtypeExtractionPyArrow(DtypeExtractionTestMixin):
     @pytest.fixture
     def dtype_sample_data(self) -> Any:
         return pa.table({"int_col": [1, 2, 3], "str_col": ["a", "b", "c"], "float_col": [1.0, 2.0, 3.0]})
+
+    @pytest.fixture
+    def dtype_duplicate_column_data(self) -> Any:
+        table = pa.table({"dup_col": [1, 2, 3]})
+        return table.append_column("dup_col", pa.array(["x", "y", "z"]))
+
+    def test_extract_duplicate_column_dtype_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """A duplicate column name must not raise; the first occurrence's dtype wins."""
+        dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data, "dup_col")
+        assert dtype is not None, "_extract_column_dtype returned None for a duplicate column"
+        assert ComputeFramework._is_numeric_dtype(str(dtype).lower()), (
+            f"duplicate column dtype '{dtype}' should match the first (int) occurrence"
+        )
+
+    def test_extract_duplicate_column_data_type_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """A duplicate column name must not raise; _extract_column_data_type returns the first occurrence."""
+        data_type = framework_instance._extract_column_data_type(dtype_duplicate_column_data, "dup_col")
+        assert data_type is not None, "_extract_column_data_type returned None for a duplicate column"
+        assert data_type == DataType.INT64, (
+            f"duplicate column data type '{data_type}' should match the first (int) occurrence"
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 from unittest.mock import Mock, patch
 from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework import IcebergFramework
-from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.user import DataType
 from mloda.user import FeatureName
 from mloda.user import ParallelizationMode
@@ -13,6 +12,7 @@ from tests.test_plugins.compute_framework.base_implementations.datatype_validato
 )
 from tests.test_plugins.compute_framework.base_implementations.dtype_extraction_test_mixin import (
     DtypeExtractionTestMixin,
+    DuplicateColumnDtypeExtractionTestMixin,
 )
 from tests.test_plugins.compute_framework.base_implementations.empty_result_test_mixin import (
     EmptyResultFrameworkTestMixin,
@@ -292,7 +292,7 @@ class TestIcebergDtypeExtraction(DtypeExtractionTestMixin):
 @pytest.mark.skipif(
     pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
 )
-class TestIcebergDtypeExtractionPyArrow(DtypeExtractionTestMixin):
+class TestIcebergDtypeExtractionPyArrow(DtypeExtractionTestMixin, DuplicateColumnDtypeExtractionTestMixin):
     """Pin _extract_column_dtype for the post-transform PyArrow shape, not just a native IcebergTable."""
 
     @pytest.fixture
@@ -308,25 +308,10 @@ class TestIcebergDtypeExtractionPyArrow(DtypeExtractionTestMixin):
         table = pa.table({"dup_col": [1, 2, 3]})
         return table.append_column("dup_col", pa.array(["x", "y", "z"]))
 
-    def test_extract_duplicate_column_dtype_returns_first_occurrence(
-        self, framework_instance: Any, dtype_duplicate_column_data: Any
-    ) -> None:
-        """A duplicate column name must not raise; the first occurrence's dtype wins."""
-        dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data, "dup_col")
-        assert dtype is not None, "_extract_column_dtype returned None for a duplicate column"
-        assert ComputeFramework._is_numeric_dtype(str(dtype).lower()), (
-            f"duplicate column dtype '{dtype}' should match the first (int) occurrence"
-        )
-
-    def test_extract_duplicate_column_data_type_returns_first_occurrence(
-        self, framework_instance: Any, dtype_duplicate_column_data: Any
-    ) -> None:
-        """A duplicate column name must not raise; _extract_column_data_type returns the first occurrence."""
-        data_type = framework_instance._extract_column_data_type(dtype_duplicate_column_data, "dup_col")
-        assert data_type is not None, "_extract_column_data_type returned None for a duplicate column"
-        assert data_type == DataType.INT64, (
-            f"duplicate column data type '{data_type}' should match the first (int) occurrence"
-        )
+    @pytest.fixture
+    def dtype_duplicate_column_data_reversed(self) -> Any:
+        table = pa.table({"dup_col": ["x", "y", "z"]})
+        return table.append_column("dup_col", pa.array([1, 2, 3]))
 
 
 @pytest.mark.skipif(

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -2,7 +2,9 @@ from typing import Any
 import pytest
 import pyarrow as pa
 
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.provider import EmptyResultError
+from mloda.user import DataType
 from mloda.user import FeatureName
 from mloda.user import ParallelizationMode
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
@@ -111,6 +113,31 @@ class TestPyArrowDtypeExtraction(DtypeExtractionTestMixin):
     @pytest.fixture
     def dtype_sample_data(self) -> Any:
         return pa.table({"int_col": [1, 2, 3], "str_col": ["a", "b", "c"], "float_col": [1.0, 2.0, 3.0]})
+
+    @pytest.fixture
+    def dtype_duplicate_column_data(self) -> Any:
+        table = pa.table({"dup_col": [1, 2, 3]})
+        return table.append_column("dup_col", pa.array(["x", "y", "z"]))
+
+    def test_extract_duplicate_column_dtype_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """A duplicate column name must not raise; the first occurrence's dtype wins."""
+        dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data, "dup_col")
+        assert dtype is not None, "_extract_column_dtype returned None for a duplicate column"
+        assert ComputeFramework._is_numeric_dtype(str(dtype).lower()), (
+            f"duplicate column dtype '{dtype}' should match the first (int) occurrence"
+        )
+
+    def test_extract_duplicate_column_data_type_returns_first_occurrence(
+        self, framework_instance: Any, dtype_duplicate_column_data: Any
+    ) -> None:
+        """A duplicate column name must not raise; _extract_column_data_type returns the first occurrence."""
+        data_type = framework_instance._extract_column_data_type(dtype_duplicate_column_data, "dup_col")
+        assert data_type is not None, "_extract_column_data_type returned None for a duplicate column"
+        assert data_type == DataType.INT64, (
+            f"duplicate column data type '{data_type}' should match the first (int) occurrence"
+        )
 
 
 class TestPyArrowDictInterchangeOutputSchema(DictInterchangeOutputSchemaTestMixin):

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -2,9 +2,7 @@ from typing import Any
 import pytest
 import pyarrow as pa
 
-from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.provider import EmptyResultError
-from mloda.user import DataType
 from mloda.user import FeatureName
 from mloda.user import ParallelizationMode
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
@@ -20,6 +18,7 @@ from tests.test_plugins.compute_framework.base_implementations.dict_interchange_
 )
 from tests.test_plugins.compute_framework.base_implementations.dtype_extraction_test_mixin import (
     DtypeExtractionTestMixin,
+    DuplicateColumnDtypeExtractionTestMixin,
 )
 from tests.test_plugins.compute_framework.base_implementations.empty_result_test_mixin import (
     EmptyResultFrameworkTestMixin,
@@ -103,8 +102,8 @@ class TestPyArrowTableMerge(DataFrameTestBase):
         pass
 
 
-class TestPyArrowDtypeExtraction(DtypeExtractionTestMixin):
-    """Test PyArrowTable._extract_column_dtype using shared mixin."""
+class TestPyArrowDtypeExtraction(DtypeExtractionTestMixin, DuplicateColumnDtypeExtractionTestMixin):
+    """Test PyArrowTable._extract_column_dtype using shared mixins."""
 
     @pytest.fixture
     def framework_instance(self) -> Any:
@@ -119,25 +118,10 @@ class TestPyArrowDtypeExtraction(DtypeExtractionTestMixin):
         table = pa.table({"dup_col": [1, 2, 3]})
         return table.append_column("dup_col", pa.array(["x", "y", "z"]))
 
-    def test_extract_duplicate_column_dtype_returns_first_occurrence(
-        self, framework_instance: Any, dtype_duplicate_column_data: Any
-    ) -> None:
-        """A duplicate column name must not raise; the first occurrence's dtype wins."""
-        dtype = framework_instance._extract_column_dtype(dtype_duplicate_column_data, "dup_col")
-        assert dtype is not None, "_extract_column_dtype returned None for a duplicate column"
-        assert ComputeFramework._is_numeric_dtype(str(dtype).lower()), (
-            f"duplicate column dtype '{dtype}' should match the first (int) occurrence"
-        )
-
-    def test_extract_duplicate_column_data_type_returns_first_occurrence(
-        self, framework_instance: Any, dtype_duplicate_column_data: Any
-    ) -> None:
-        """A duplicate column name must not raise; _extract_column_data_type returns the first occurrence."""
-        data_type = framework_instance._extract_column_data_type(dtype_duplicate_column_data, "dup_col")
-        assert data_type is not None, "_extract_column_data_type returned None for a duplicate column"
-        assert data_type == DataType.INT64, (
-            f"duplicate column data type '{data_type}' should match the first (int) occurrence"
-        )
+    @pytest.fixture
+    def dtype_duplicate_column_data_reversed(self) -> Any:
+        table = pa.table({"dup_col": ["x", "y", "z"]})
+        return table.append_column("dup_col", pa.array([1, 2, 3]))
 
 
 class TestPyArrowDictInterchangeOutputSchema(DictInterchangeOutputSchemaTestMixin):


### PR DESCRIPTION
## What and why

`_extract_column_dtype` and `_extract_column_data_type` on `PyArrowTable` and on `IcebergFramework`'s pa.Table branch looked up a column with a two-step `name in schema.names` check followed by `schema.field(name)`. For a table with two columns sharing a name, the membership check passes but `schema.field(name)` raises `KeyError` instead of returning a value, so dtype extraction crashed instead of degrading gracefully.

## Fix

Add `arrow_schema_field_type`, a single zip-scan helper next to the existing `arrow_schema_output_schema` (which already handles duplicates correctly for `_output_schema`), and use it in all four affected methods. Both now return the first occurrence for a duplicate column name, consistent with `_output_schema`'s existing handling.

## Tests

Added a `DuplicateColumnDtypeExtractionTestMixin` (mirroring the existing `DuplicateColumnOutputSchemaTestMixin` pattern) covering both frameworks: first-occurrence in normal and reversed column order (to prove first-occurrence semantics rather than "prefers numeric"), plus a check that `_extract_column_dtype` agrees with `_output_schema` on the same data.

Closes #1347