### PR TITLE
fix: attribute bundled plugin transitive optional-dependency failures correctly

### DIFF
--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -302,12 +302,20 @@ class PluginLoader:
 
         try:
             module = importlib.import_module(full_module_name)
-        except ModuleNotFoundError as e:
-            if e.name and (e.name == self.base_package or e.name.startswith(self.base_package + ".")):
-                raise
+        except ImportError as e:
             root = e.name.split(".")[0] if e.name else None
-            if root in OPTIONAL_PLUGIN_DEPENDENCIES:
-                logger.debug("Skipping plugin %s: missing optional dependency %s", full_module_name, e.name)
+            if root == self.base_package:
+                raise
+            tb_roots = [
+                r
+                for r in OPTIONAL_PLUGIN_DEPENDENCIES
+                if full_module_name != r and not full_module_name.startswith(f"{r}.")
+            ]
+            blamed_root = next((r for r in tb_roots if _traceback_blames_root(e, r)), None)
+            if root in OPTIONAL_PLUGIN_DEPENDENCIES or blamed_root is not None:
+                logger.debug(
+                    "Skipping plugin %s: missing optional dependency %s", full_module_name, e.name or blamed_root
+                )
                 return
             raise
 

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -306,12 +306,7 @@ class PluginLoader:
             root = e.name.split(".")[0] if e.name else None
             if root == self.base_package:
                 raise
-            tb_roots = [
-                r
-                for r in OPTIONAL_PLUGIN_DEPENDENCIES
-                if full_module_name != r and not full_module_name.startswith(f"{r}.")
-            ]
-            blamed_root = next((r for r in tb_roots if _traceback_blames_root(e, r)), None)
+            blamed_root = next((r for r in OPTIONAL_PLUGIN_DEPENDENCIES if _traceback_blames_root(e, r)), None)
             if root in OPTIONAL_PLUGIN_DEPENDENCIES or blamed_root is not None:
                 logger.debug(
                     "Skipping plugin %s: missing optional dependency %s", full_module_name, e.name or blamed_root

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/conftest.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/conftest.py
@@ -1,4 +1,6 @@
+import importlib
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
@@ -11,3 +13,11 @@ def reset_plugin_loader_cache() -> Iterator[None]:
     PluginLoader.reset_cache()
     yield
     PluginLoader.reset_cache()
+
+
+def _write_broken_optional_root_package(base_dir: Path, pkg_name: str, missing_subdep: str) -> None:
+    """Build an installed-but-incomplete package: its __init__.py imports a nonexistent module."""
+    pkg_dir = base_dir / pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(f"import {missing_subdep}\n")
+    importlib.invalidate_caches()

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_entry_points.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_entry_points.py
@@ -32,6 +32,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import _write_broken_optional_root_package
+
 import mloda.core.abstract_plugins.plugin_loader.plugin_loader as plugin_loader_module
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -84,14 +86,6 @@ def _write_root_module(base_dir: Path, module_name: str, source: str = "") -> No
     """Write a standalone top-level module (not inside a package), so importing a missing name
     from it raises plain ImportError rather than ModuleNotFoundError."""
     (base_dir / f"{module_name}.py").write_text(textwrap.dedent(source))
-
-
-def _write_broken_optional_root_package(base_dir: Path, pkg_name: str, missing_subdep: str) -> None:
-    """Build an installed-but-incomplete package: its __init__.py imports a nonexistent module."""
-    pkg_dir = base_dir / pkg_name
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text(f"import {missing_subdep}\n")
-    importlib.invalidate_caches()
 
 
 def _import_error_fg_manifest_source(root_module: str, class_name: str) -> str:

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
@@ -1,8 +1,11 @@
 import importlib
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+from conftest import _write_broken_optional_root_package
 
 import mloda.core.abstract_plugins.plugin_loader.plugin_loader as plugin_loader_module
 from mloda.core.abstract_plugins.components.input_data.base_input_data import (
@@ -14,20 +17,29 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRe
 from mloda.user import PluginLoader
 
 
-def _write_broken_optional_root_package(base_dir: Path, pkg_name: str, missing_subdep: str) -> None:
-    """An installed package whose own __init__.py import fails."""
-    pkg_dir = base_dir / pkg_name
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text(f"import {missing_subdep}\n")
-    importlib.invalidate_caches()
-
-
 def _write_fake_base_package(base_dir: Path, base_pkg_name: str, submodule_name: str, imports: str) -> None:
     """A fake base package standing in for mloda_plugins."""
     pkg_dir = base_dir / base_pkg_name
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text("")
     (pkg_dir / f"{submodule_name}.py").write_text(f"import {imports}\n")
+    importlib.invalidate_caches()
+
+
+def _write_root_module(base_dir: Path, module_name: str) -> None:
+    """A standalone top-level module (not a package), so importing a missing name from it raises
+    plain ImportError rather than ModuleNotFoundError."""
+    (base_dir / f"{module_name}.py").write_text("")
+
+
+def _write_fake_base_package_bad_from_import(
+    base_dir: Path, base_pkg_name: str, submodule_name: str, root_module: str
+) -> None:
+    """A fake base package submodule doing `from <root_module> import missing_name`."""
+    pkg_dir = base_dir / base_pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / f"{submodule_name}.py").write_text(f"from {root_module} import missing_name\n")
     importlib.invalidate_caches()
 
 
@@ -272,3 +284,95 @@ class TestLoadPluginTransitiveOptionalDependency:
         loader._load_plugin(submodule)
 
         assert f"{base_pkg}.{submodule}" not in loader.plugins
+
+
+class TestLoadPluginPlainImportError:
+    def test_declared_optional_root_catches_plain_import_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A plain ImportError (not ModuleNotFoundError) from an existing declared-optional root
+        must be skipped, proving the ImportError widening isn't limited to ModuleNotFoundError."""
+        root_module = "pltest_importerror_root"
+        _write_root_module(tmp_path, root_module)
+
+        base_pkg = "pltest_importerror_base_pkg"
+        submodule = "bad_from_import"
+        _write_fake_base_package_bad_from_import(tmp_path, base_pkg, submodule, root_module)
+
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(
+            plugin_loader_module,
+            "OPTIONAL_PLUGIN_DEPENDENCIES",
+            plugin_loader_module.OPTIONAL_PLUGIN_DEPENDENCIES | frozenset({root_module}),
+        )
+
+        loader = PluginLoader()
+        loader.base_package = base_pkg
+
+        with caplog.at_level(logging.DEBUG, logger=plugin_loader_module.__name__):
+            loader._load_plugin(submodule)
+
+        assert f"{base_pkg}.{submodule}" not in loader.plugins
+        debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+        assert any(root_module in message for message in debug_messages), (
+            f"expected a DEBUG message naming the missing root, got: {debug_messages}"
+        )
+
+    def test_undeclared_root_import_error_still_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plain ImportError whose root is declared nowhere must still propagate, proving the
+        propagation path isn't narrower than ImportError."""
+        root_module = "pltest_undeclared_importerror_root"
+        _write_root_module(tmp_path, root_module)
+
+        base_pkg = "pltest_undeclared_importerror_base_pkg"
+        submodule = "bad_from_import"
+        _write_fake_base_package_bad_from_import(tmp_path, base_pkg, submodule, root_module)
+
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        loader = PluginLoader()
+        loader.base_package = base_pkg
+
+        with pytest.raises(ImportError) as exc_info:
+            loader._load_plugin(submodule)
+        assert not isinstance(exc_info.value, ModuleNotFoundError)
+
+
+class TestLoadGroupContinuesPastSkippedPlugin:
+    def test_broken_optional_dependency_plugin_does_not_abort_group_scan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One bundled plugin hitting a skippable optional-dependency failure must not abort the
+        rest of the group scan, proving load_all_plugins()'s DoD through the real load_group path."""
+        optional_root_pkg = "pltest_group_optional_dep"
+        missing_subdep = "pltest_group_missing_subdep"
+        _write_broken_optional_root_package(tmp_path, optional_root_pkg, missing_subdep)
+
+        base_pkg = "pltest_group_fake_base_pkg"
+        group_name = "mygroup"
+        base_dir = tmp_path / base_pkg
+        base_dir.mkdir()
+        (base_dir / "__init__.py").write_text("")
+        group_dir = base_dir / group_name
+        group_dir.mkdir()
+        (group_dir / "__init__.py").write_text("")
+        (group_dir / "broken.py").write_text(f"import {optional_root_pkg}\n")
+        (group_dir / "good.py").write_text("")
+        importlib.invalidate_caches()
+
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(
+            plugin_loader_module,
+            "OPTIONAL_PLUGIN_DEPENDENCIES",
+            plugin_loader_module.OPTIONAL_PLUGIN_DEPENDENCIES | frozenset({optional_root_pkg}),
+        )
+
+        loader = PluginLoader()
+        loader.base_package = base_pkg
+
+        loader.load_group(group_name)
+
+        assert f"{base_pkg}.{group_name}.broken" not in loader.plugins
+        assert f"{base_pkg}.{group_name}.good" in loader.plugins

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
@@ -1,7 +1,10 @@
+import importlib
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import mloda.core.abstract_plugins.plugin_loader.plugin_loader as plugin_loader_module
 from mloda.core.abstract_plugins.components.input_data.base_input_data import (
     _collect_filtered_subclasses,  # noqa: F401
     get_all_filtered_subclasses,
@@ -9,6 +12,23 @@ from mloda.core.abstract_plugins.components.input_data.base_input_data import (
 from mloda.core.abstract_plugins.plugin_loader.plugin_loader import OPTIONAL_PLUGIN_DEPENDENCIES
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.user import PluginLoader
+
+
+def _write_broken_optional_root_package(base_dir: Path, pkg_name: str, missing_subdep: str) -> None:
+    """Build an installed-but-incomplete package: its __init__.py imports a nonexistent module."""
+    pkg_dir = base_dir / pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(f"import {missing_subdep}\n")
+    importlib.invalidate_caches()
+
+
+def _write_fake_base_package(base_dir: Path, base_pkg_name: str, submodule_name: str, imports: str) -> None:
+    """Build a fake base package (standing in for mloda_plugins) with one submodule importing `imports`."""
+    pkg_dir = base_dir / base_pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / f"{submodule_name}.py").write_text(f"import {imports}\n")
+    importlib.invalidate_caches()
 
 
 class TestPluginLoader:
@@ -223,3 +243,32 @@ class TestPluginLoader:
     def test_optional_plugin_dependencies_has_no_orphaned_opentelemetry_entry(self) -> None:
         """opentelemetry was only imported by OtelExtender, deleted on this branch; nothing imports it now."""
         assert "opentelemetry" not in OPTIONAL_PLUGIN_DEPENDENCIES
+
+
+class TestLoadPluginTransitiveOptionalDependency:
+    def test_transitive_missing_dependency_inside_declared_optional_root_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A declared-optional root whose OWN import fails must be skipped by _load_plugin, mirroring
+        the already-fixed load_entry_points traceback fallback."""
+        optional_root_pkg = "pltest_transroot_optional_dep"
+        missing_subdep = "pltest_transroot_missing_subdep"
+        _write_broken_optional_root_package(tmp_path, optional_root_pkg, missing_subdep)
+
+        base_pkg = "pltest_fake_base_pkg"
+        submodule = "broken_consumer"
+        _write_fake_base_package(tmp_path, base_pkg, submodule, optional_root_pkg)
+
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(
+            plugin_loader_module,
+            "OPTIONAL_PLUGIN_DEPENDENCIES",
+            plugin_loader_module.OPTIONAL_PLUGIN_DEPENDENCIES | frozenset({optional_root_pkg}),
+        )
+
+        loader = PluginLoader()
+        loader.base_package = base_pkg
+
+        loader._load_plugin(submodule)
+
+        assert f"{base_pkg}.{submodule}" not in loader.plugins

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
@@ -15,7 +15,7 @@ from mloda.user import PluginLoader
 
 
 def _write_broken_optional_root_package(base_dir: Path, pkg_name: str, missing_subdep: str) -> None:
-    """Build an installed-but-incomplete package: its __init__.py imports a nonexistent module."""
+    """An installed package whose own __init__.py import fails."""
     pkg_dir = base_dir / pkg_name
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text(f"import {missing_subdep}\n")
@@ -23,7 +23,7 @@ def _write_broken_optional_root_package(base_dir: Path, pkg_name: str, missing_s
 
 
 def _write_fake_base_package(base_dir: Path, base_pkg_name: str, submodule_name: str, imports: str) -> None:
-    """Build a fake base package (standing in for mloda_plugins) with one submodule importing `imports`."""
+    """A fake base package standing in for mloda_plugins."""
     pkg_dir = base_dir / base_pkg_name
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text("")


### PR DESCRIPTION
## Summary

`PluginLoader._load_plugin()`, the bundled `mloda_plugins` scan used by `load_all_plugins()`, had the same optional-dependency misattribution bug previously fixed for entry-point discovery: it only caught `ModuleNotFoundError` (not the broader `ImportError`), and only matched the failing import's own top-level name against `OPTIONAL_PLUGIN_DEPENDENCIES`, with no fallback for a transitive dependency of an installed optional package.

A bundled plugin importing an installed-but-incomplete optional dependency (for example a package that is present but missing one of its own transitive dependencies) would abort `load_all_plugins()`, and therefore `PluginLoader.all()`, instead of being skipped.

## Change

`_load_plugin` now catches `ImportError` and, when the failure isn't directly attributable via the import's own name, walks the exception's traceback to its innermost frame to check whether the actual failure happened inside a known-optional root, mirroring the existing `load_entry_points` logic. A failure inside the plugin's own package always still propagates.

## Tests

- A bundled plugin importing an installed-but-broken optional root (missing one of its own transitive submodules) is skipped instead of aborting the scan.
- A plain `ImportError` (not just `ModuleNotFoundError`) from a declared-optional root is skipped, and one with an unknown root still propagates as `ImportError`.
- A broken plugin no longer aborts the rest of a group scan: a sibling good plugin still loads.

Closes #1358