### PR TITLE
fix: constrain TransformFrameworkStep to its destination framework's parallelization modes

### DIFF
--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -5,6 +5,7 @@ from mloda.core.abstract_plugins.components.error_utils import internal_invarian
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
     ComputeFrameworkTransformer,
 )
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.core.cfw_manager import CfwManager
 from mloda.core.core.step.abstract_step import Step
@@ -75,6 +76,9 @@ class TransformFrameworkStep(Step):
 
     def get_uuids(self) -> set[UUID]:
         return {self.uuid}
+
+    def get_parallelization_mode(self) -> set[ParallelizationMode]:
+        return self.to_framework.supported_parallelization_modes()
 
     def execute(
         self,

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -78,10 +78,8 @@ class ComputeFrameworkExecutor:
         # The parent-side copy exists to keep the worker's copy isolated from later in-process
         # mutation of the caller's objects. Fetching it through the register proxy instead would
         # run the round trip in this process and strip any state an extender drops in __getstate__.
-        # parallelization_mode reflects which execution function was selected to run the step, not
-        # necessarily the compute framework class's own capability, so we re-check
-        # cf_class.supported_parallelization_modes() here as well before trusting it means
-        # "runs in a worker".
+        # Re-checking cf_class.supported_parallelization_modes() here is defensive: no current
+        # call path can pass MULTIPROCESSING for a class that does not support it.
         dispatched_to_worker = (
             parallelization_mode is ParallelizationMode.MULTIPROCESSING
             and ParallelizationMode.MULTIPROCESSING in cf_class.supported_parallelization_modes()
@@ -316,8 +314,6 @@ class ComputeFrameworkExecutor:
         Executes a step in a separate process.
         """
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.MULTIPROCESSING)
-
-        self._bind_tfs_connection(step, cfw_uuid)
 
         from_cfw = None
         if isinstance(step, TransformFrameworkStep):

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -78,9 +78,10 @@ class ComputeFrameworkExecutor:
         # The parent-side copy exists to keep the worker's copy isolated from later in-process
         # mutation of the caller's objects. Fetching it through the register proxy instead would
         # run the round trip in this process and strip any state an extender drops in __getstate__.
-        # A framework is only actually dispatched to a spawned worker when its own class supports
-        # MULTIPROCESSING; TransformFrameworkStep never overrides Step.get_parallelization_mode(),
-        # so parallelization_mode alone cannot be trusted to mean "runs in a worker".
+        # parallelization_mode reflects which execution function was selected to run the step, not
+        # necessarily the compute framework class's own capability, so we re-check
+        # cf_class.supported_parallelization_modes() here as well before trusting it means
+        # "runs in a worker".
         dispatched_to_worker = (
             parallelization_mode is ParallelizationMode.MULTIPROCESSING
             and ParallelizationMode.MULTIPROCESSING in cf_class.supported_parallelization_modes()
@@ -315,6 +316,8 @@ class ComputeFrameworkExecutor:
         Executes a step in a separate process.
         """
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.MULTIPROCESSING)
+
+        self._bind_tfs_connection(step, cfw_uuid)
 
         from_cfw = None
         if isinstance(step, TransformFrameworkStep):

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -1245,8 +1245,8 @@ class TestMultiExecuteStep:
         # Verify from_cfw_uuid was prepared
         assert cfw_register.get_cfw_uuid.call_count >= 1
 
-    def test_binds_tfs_connection(self) -> None:
-        """multi_execute_step must call _bind_tfs_connection, like the other execute methods already do."""
+    def test_does_not_bind_tfs_connection(self) -> None:
+        """multi_execute_step must not call _bind_tfs_connection: the cfw is pickled to a spawned worker process."""
         cfw_register = Mock(spec=CfwManager)
         worker_manager = Mock(spec=WorkerManager)
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
@@ -1273,4 +1273,4 @@ class TestMultiExecuteStep:
 
         executor.multi_execute_step(step)
 
-        executor._bind_tfs_connection.assert_called_once_with(step, cfw_uuid)
+        executor._bind_tfs_connection.assert_not_called()

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -25,6 +25,7 @@ from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda.core.runtime.compute_framework_executor import ComputeFrameworkExecutor
 from mloda.core.runtime.worker_manager import WorkerManager
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
 
 
 class _StateHoldingExtender(Extender):
@@ -520,6 +521,29 @@ class TestGetExecutionFunction:
         result = executor._get_execution_function(mode_by_cfw, mode_by_step)
 
         assert result == executor.multi_execute_step
+
+    def test_returns_sync_execute_step_for_sync_only_tfs_step_even_when_register_supports_multiprocessing(
+        self,
+    ) -> None:
+        """Should return sync_execute_step for a SYNC-only TFS step even when multiprocessing is registered."""
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = TransformFrameworkStep(
+            from_framework=DuckDBFramework,
+            to_framework=DuckDBFramework,
+            required_uuids=set(),
+            from_feature_group=MagicMock(),
+            to_feature_group=MagicMock(),
+        )
+
+        mode_by_cfw = {ParallelizationMode.SYNC, ParallelizationMode.MULTIPROCESSING}
+        mode_by_step = step.get_parallelization_mode()
+
+        result = executor._get_execution_function(mode_by_cfw, mode_by_step)
+
+        assert result == executor.sync_execute_step
 
 
 class TestPrepareExecuteStep:
@@ -1220,3 +1244,33 @@ class TestMultiExecuteStep:
 
         # Verify from_cfw_uuid was prepared
         assert cfw_register.get_cfw_uuid.call_count >= 1
+
+    def test_binds_tfs_connection(self) -> None:
+        """multi_execute_step must call _bind_tfs_connection, like the other execute methods already do."""
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = Mock(spec=FeatureGroupStep)
+        step.tfs_ids = []
+        step.features = Mock()
+        step.features.any_uuid = uuid4()
+        step.children_if_root = []
+        step.compute_framework = Mock()
+        step.compute_framework.get_class_name.return_value = "TestCFW"
+        step.get_uuids.return_value = {uuid4()}
+
+        cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
+        cfw_register.get_cfw_uuid.return_value = cfw_uuid
+
+        mock_cfw = Mock(spec=ComputeFramework)
+        executor.cfw_collection[cfw_uuid] = mock_cfw
+
+        worker_manager.get_process_queues.return_value = (Mock(), Mock(), Mock())
+
+        executor._bind_tfs_connection = Mock()  # type: ignore[method-assign]
+
+        executor.multi_execute_step(step)
+
+        executor._bind_tfs_connection.assert_called_once_with(step, cfw_uuid)

--- a/tests/test_parallelization_modes_support.py
+++ b/tests/test_parallelization_modes_support.py
@@ -19,6 +19,7 @@ from mloda.core.abstract_plugins.components.parallelization_modes import Paralle
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
 
@@ -145,6 +146,36 @@ class TestSetupComputeFrameworkParallelizationModeFiltering:
             features=features,
         )
         assert SqliteFramework in setup.compute_frameworks
+
+
+class TestTransformFrameworkStepGetParallelizationMode:
+    """Tests for TransformFrameworkStep.get_parallelization_mode() delegation."""
+
+    def test_get_parallelization_mode_delegates_to_duckdb_framework(self) -> None:
+        """TransformFrameworkStep.get_parallelization_mode() with to_framework=DuckDBFramework must return {SYNC}."""
+        step = TransformFrameworkStep(
+            from_framework=SqliteFramework,
+            to_framework=DuckDBFramework,
+            required_uuids=set(),
+            from_feature_group=MagicMock(),
+            to_feature_group=MagicMock(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {ParallelizationMode.SYNC}
+
+    def test_get_parallelization_mode_delegates_to_sqlite_framework(self) -> None:
+        """TransformFrameworkStep.get_parallelization_mode() with to_framework=SqliteFramework must return {SYNC}."""
+        step = TransformFrameworkStep(
+            from_framework=DuckDBFramework,
+            to_framework=SqliteFramework,
+            required_uuids=set(),
+            from_feature_group=MagicMock(),
+            to_feature_group=MagicMock(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {ParallelizationMode.SYNC}
 
 
 class TestFeatureGroupStepGetParallelizationMode:

--- a/tests/test_parallelization_modes_support.py
+++ b/tests/test_parallelization_modes_support.py
@@ -22,6 +22,7 @@ from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 
 class TestComputeFrameworkSupportedParallelizationModes:
@@ -176,6 +177,38 @@ class TestTransformFrameworkStepGetParallelizationMode:
 
         result = step.get_parallelization_mode()
         assert result == {ParallelizationMode.SYNC}
+
+    def test_get_parallelization_mode_ignores_from_framework_when_it_supports_more(self) -> None:
+        """to_framework=DuckDBFramework (SYNC only) must win even though from_framework=PyArrowTable supports all
+        three modes; this pins delegation to to_framework, not from_framework."""
+        step = TransformFrameworkStep(
+            from_framework=PyArrowTable,
+            to_framework=DuckDBFramework,
+            required_uuids=set(),
+            from_feature_group=MagicMock(),
+            to_feature_group=MagicMock(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {ParallelizationMode.SYNC}
+
+    def test_get_parallelization_mode_ignores_from_framework_when_it_supports_less(self) -> None:
+        """to_framework=PyArrowTable (all three modes) must win even though from_framework=DuckDBFramework is
+        SYNC only; rules out both a from_framework read and an intersection of the two."""
+        step = TransformFrameworkStep(
+            from_framework=DuckDBFramework,
+            to_framework=PyArrowTable,
+            required_uuids=set(),
+            from_feature_group=MagicMock(),
+            to_feature_group=MagicMock(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {
+            ParallelizationMode.SYNC,
+            ParallelizationMode.THREADING,
+            ParallelizationMode.MULTIPROCESSING,
+        }
 
 
 class TestFeatureGroupStepGetParallelizationMode:


### PR DESCRIPTION
## Summary

`TransformFrameworkStep` did not override `Step.get_parallelization_mode()`, so it always reported the full `{SYNC, THREADING, MULTIPROCESSING}` set regardless of what its `to_framework` actually supports. In a mixed-mode run (e.g. `{SYNC, MULTIPROCESSING}`), a transform step targeting a SYNC-only destination framework (DuckDB, Sqlite, both hold a native, unpicklable connection) could be dispatched to a spawned worker process.

`get_parallelization_mode()` now delegates to `self.to_framework.supported_parallelization_modes()`, mirroring the existing `FeatureGroupStep` pattern.

## Details

- `TransformFrameworkStep` gains a `get_parallelization_mode()` override.
- `ComputeFrameworkExecutor.multi_execute_step` keeps `_bind_tfs_connection` out of its dispatch path: binding a destination framework's connection before it is pickled for a spawned worker process breaks for any framework that both supports MULTIPROCESSING and holds a live, unpicklable connection (relevant for Spark/Iceberg style connections). DuckDB and Sqlite are unaffected since they can no longer reach `multi_execute_step` at all now that their reported parallelization mode is constrained to SYNC.

Closes #1364