### PR TITLE
fix: constrain JoinStep to its destination framework's parallelization modes

### DIFF
--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -1,6 +1,7 @@
 from typing import Any
 from uuid import UUID, uuid4
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import ComputeFrameworkTransformer
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import ExtenderHook, _invoke_extender
 from mloda.core.abstract_plugins.hook_context import HookContext, instrument
@@ -36,6 +37,9 @@ class JoinStep(Step):
     def get_uuids(self) -> set[UUID]:
         """Only this step's uuid is a completion token; the link uuid is shared by both orientations."""
         return {self.uuid}
+
+    def get_parallelization_mode(self) -> set[ParallelizationMode]:
+        return self.destination_framework.supported_parallelization_modes()
 
     def _merge_data(self, cfw: ComputeFramework, from_cfw_data: Any) -> None:
         """Merges data from another ComputeFramework into the current one."""

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -545,6 +545,30 @@ class TestGetExecutionFunction:
 
         assert result == executor.sync_execute_step
 
+    def test_returns_sync_execute_step_for_sync_only_join_step_even_when_register_supports_multiprocessing(
+        self,
+    ) -> None:
+        """Should return sync_execute_step for a SYNC-only JoinStep even when multiprocessing is registered."""
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = JoinStep(
+            link=MagicMock(),
+            destination_framework=DuckDBFramework,
+            source_framework=DuckDBFramework,
+            required_uuids=set(),
+            destination_framework_uuids=set(),
+            source_framework_uuids=set(),
+        )
+
+        mode_by_cfw = {ParallelizationMode.SYNC, ParallelizationMode.MULTIPROCESSING}
+        mode_by_step = step.get_parallelization_mode()
+
+        result = executor._get_execution_function(mode_by_cfw, mode_by_step)
+
+        assert result == executor.sync_execute_step
+
 
 class TestPrepareExecuteStep:
     """Tests for prepare_execute_step method."""

--- a/tests/test_parallelization_modes_support.py
+++ b/tests/test_parallelization_modes_support.py
@@ -19,6 +19,7 @@ from mloda.core.abstract_plugins.components.parallelization_modes import Paralle
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -201,6 +202,72 @@ class TestTransformFrameworkStepGetParallelizationMode:
             required_uuids=set(),
             from_feature_group=MagicMock(),
             to_feature_group=MagicMock(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {
+            ParallelizationMode.SYNC,
+            ParallelizationMode.THREADING,
+            ParallelizationMode.MULTIPROCESSING,
+        }
+
+
+class TestJoinStepGetParallelizationMode:
+    """Tests for JoinStep.get_parallelization_mode() delegation."""
+
+    def test_get_parallelization_mode_delegates_to_duckdb_framework(self) -> None:
+        """JoinStep.get_parallelization_mode() with destination_framework=DuckDBFramework must return {SYNC}."""
+        step = JoinStep(
+            link=MagicMock(),
+            destination_framework=DuckDBFramework,
+            source_framework=SqliteFramework,
+            required_uuids=set(),
+            destination_framework_uuids=set(),
+            source_framework_uuids=set(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {ParallelizationMode.SYNC}
+
+    def test_get_parallelization_mode_delegates_to_sqlite_framework(self) -> None:
+        """JoinStep.get_parallelization_mode() with destination_framework=SqliteFramework must return {SYNC}."""
+        step = JoinStep(
+            link=MagicMock(),
+            destination_framework=SqliteFramework,
+            source_framework=DuckDBFramework,
+            required_uuids=set(),
+            destination_framework_uuids=set(),
+            source_framework_uuids=set(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {ParallelizationMode.SYNC}
+
+    def test_get_parallelization_mode_ignores_source_framework_when_it_supports_more(self) -> None:
+        """destination_framework=DuckDBFramework (SYNC only) must win even though source_framework=PyArrowTable
+        supports all three modes; this pins delegation to destination_framework, not source_framework."""
+        step = JoinStep(
+            link=MagicMock(),
+            destination_framework=DuckDBFramework,
+            source_framework=PyArrowTable,
+            required_uuids=set(),
+            destination_framework_uuids=set(),
+            source_framework_uuids=set(),
+        )
+
+        result = step.get_parallelization_mode()
+        assert result == {ParallelizationMode.SYNC}
+
+    def test_get_parallelization_mode_ignores_source_framework_when_it_supports_less(self) -> None:
+        """destination_framework=PyArrowTable (all three modes) must win even though source_framework=DuckDBFramework
+        is SYNC only; rules out both a source_framework read and an intersection of the two."""
+        step = JoinStep(
+            link=MagicMock(),
+            destination_framework=PyArrowTable,
+            source_framework=DuckDBFramework,
+            required_uuids=set(),
+            destination_framework_uuids=set(),
+            source_framework_uuids=set(),
         )
 
         result = step.get_parallelization_mode()


### PR DESCRIPTION
## Summary

`JoinStep` did not override `Step.get_parallelization_mode()`, so it reported the full `{SYNC, THREADING, MULTIPROCESSING}` set regardless of what its `destination_framework` actually supports. In a mixed-mode run (`parallelization_modes={SYNC, MULTIPROCESSING}`), `ComputeFrameworkExecutor._get_execution_function` could then dispatch a join targeting a SYNC-only destination framework (DuckDB, Sqlite) to a spawned worker process, pickling a live, unpicklable connection.

Mirrors the same fix already applied to `TransformFrameworkStep`.

## Changes

- `JoinStep.get_parallelization_mode()` now delegates to `self.destination_framework.supported_parallelization_modes()`.
- Adds tests pinning delegation to the destination framework specifically (not the source framework, not an intersection of both), plus an executor-level test confirming a SYNC-only-destination join stays on `sync_execute_step` even when the run registers `MULTIPROCESSING`.

Closes #1366