### PR TITLE
fix: bind TFS destination connections inside spawned MULTIPROCESSING workers

### DIFF
--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -322,10 +322,13 @@ class ComputeFrameworkExecutor:
         existing = self.worker_manager.get_process_queues(cfw_uuid)
 
         if existing is None:
+            needs_tfs_connection = isinstance(step, TransformFrameworkStep) and (
+                self.tfs_connection_map.get(type(self.cfw_collection[cfw_uuid])) is not None
+            )
             process, command_queue, result_queue = self.worker_manager.create_worker_process(
                 cfw_uuid,
                 worker,
-                (self.cfw_register, self.cfw_collection[cfw_uuid], from_cfw),
+                (self.cfw_register, self.cfw_collection[cfw_uuid], from_cfw, needs_tfs_connection),
             )
         else:
             process, command_queue, result_queue = existing

--- a/mloda/core/runtime/worker/multiprocessing_worker.py
+++ b/mloda/core/runtime/worker/multiprocessing_worker.py
@@ -108,7 +108,8 @@ def worker(
     cfw_register: CfwManager,
     cfw: ComputeFramework,
     from_cfw: UUID,
-    worker_index: int,
+    needs_tfs_connection: bool = False,
+    worker_index: int = 0,
 ) -> None:
     data = None
     location = cfw_register.get_location()
@@ -137,6 +138,30 @@ def worker(
 
             _handle_stop_command(command_queue)
             return
+
+    if needs_tfs_connection and cfw.framework_connection_object is None:
+        try:
+            cfw.set_framework_connection_object(None)
+        except Exception as e:
+            error_message = f"An error occurred: {e}"
+            msg = f"{error_message}\nFull traceback:\n{traceback.format_exc()}"
+            logging.error(msg)
+            exc_info = traceback.format_exc()
+            if cfw_register:
+                try:
+                    cfw_register.set_error(msg, exc_info, exception=e)
+                except Exception:
+                    # exception not picklable across the manager proxy; degrade to string-only
+                    cfw_register.set_error(msg, exc_info)
+
+            _handle_stop_command(command_queue)
+            return
+        if cfw.framework_connection_object is None:
+            logger.warning(
+                "%s did not bind a connection in set_framework_connection_object(None); "
+                "override it to self-construct one for MULTIPROCESSING.",
+                type(cfw).__name__,
+            )
 
     while True:
         try:

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -1103,7 +1103,7 @@ class TestMultiExecuteStep:
         executor.multi_execute_step(step)
 
         worker_manager.create_worker_process.assert_called_once_with(
-            cfw_uuid, mock_worker, (cfw_register, mock_cfw, None)
+            cfw_uuid, mock_worker, (cfw_register, mock_cfw, None, False)
         )
 
     def test_uses_existing_worker_process_if_exists(self) -> None:
@@ -1274,3 +1274,185 @@ class TestMultiExecuteStep:
         executor.multi_execute_step(step)
 
         executor._bind_tfs_connection.assert_not_called()
+
+    @patch("mloda.core.runtime.compute_framework_executor.worker")
+    def test_passes_needs_tfs_connection_false_for_non_tfs_step_even_when_destination_type_is_in_tfs_connection_map(
+        self, mock_worker: Any
+    ) -> None:
+        """tfs_connection_map is keyed by destination CFW class across the whole plan. A non-TFS
+        step (FeatureGroupStep/JoinStep) must never get needs_tfs_connection=True just because its
+        CFW class happens to match a tfs_connection_map entry populated by an unrelated TFS step
+        elsewhere in the plan; _bind_tfs_connection gates on isinstance(step, TransformFrameworkStep)
+        and multi_execute_step's needs_tfs_connection computation must mirror that gate."""
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = Mock(spec=FeatureGroupStep)
+        step.tfs_ids = []
+        step.features = Mock()
+        step.features.any_uuid = uuid4()
+        step.children_if_root = []
+        step.compute_framework = Mock()
+        step.compute_framework.get_class_name.return_value = "TestCFW"
+        step.get_uuids.return_value = {uuid4()}
+
+        cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
+        cfw_register.get_cfw_uuid.return_value = cfw_uuid
+
+        mock_cfw = Mock(spec=ComputeFramework)
+        executor.cfw_collection[cfw_uuid] = mock_cfw
+        # Keying off type(mock_cfw) avoids needing a real ComputeFramework subclass instance.
+        executor.tfs_connection_map = {type(mock_cfw): Mock()}
+
+        worker_manager.get_process_queues.return_value = None
+
+        mock_process = Mock()
+        mock_cmd_queue = Mock()
+        mock_result_queue = Mock()
+        worker_manager.create_worker_process.return_value = (mock_process, mock_cmd_queue, mock_result_queue)
+
+        executor.multi_execute_step(step)
+
+        worker_manager.create_worker_process.assert_called_once_with(
+            cfw_uuid, mock_worker, (cfw_register, mock_cfw, None, False)
+        )
+
+    @patch("mloda.core.runtime.compute_framework_executor.worker")
+    def test_passes_needs_tfs_connection_true_for_a_real_tfs_step_whose_destination_type_is_in_tfs_connection_map(
+        self, mock_worker: Any
+    ) -> None:
+        """The genuine positive case: a real TransformFrameworkStep whose to_framework CFW class
+        is in tfs_connection_map must reach create_worker_process with needs_tfs_connection=True."""
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = Mock(spec=TransformFrameworkStep)
+        step.source_framework_uuid = uuid4()
+        step.from_framework = Mock()
+        step.from_framework.get_class_name.return_value = "FromCFW"
+        step.required_uuids = [uuid4()]
+        # multi_execute_step records the dispatch, so the step must answer get_uuids()
+        # with real uuids like a TransformFrameworkStep does.
+        step.get_uuids.return_value = {uuid4()}
+
+        from_cfw_uuid = uuid4()
+        cfw_register.get_cfw_uuid.side_effect = [from_cfw_uuid, from_cfw_uuid]
+
+        from_cfw = Mock(spec=ComputeFramework)
+        from_cfw.children_if_root = set()
+        executor.cfw_collection[from_cfw_uuid] = from_cfw
+
+        step.link_id = None
+        step.uuid = uuid4()
+
+        mock_to_cfw_class = Mock()
+        mock_to_cfw_instance = Mock(spec=ComputeFramework)
+        mock_to_cfw_class.return_value = mock_to_cfw_instance
+        mock_to_cfw_class.supported_parallelization_modes.return_value = {
+            ParallelizationMode.SYNC,
+            ParallelizationMode.THREADING,
+            ParallelizationMode.MULTIPROCESSING,
+        }
+        step.to_framework = mock_to_cfw_class
+
+        new_uuid = uuid4()
+        mock_to_cfw_instance.get_uuid.return_value = new_uuid
+        cfw_register.get_run_context.return_value = RunContext()
+
+        # Keying off type(mock_to_cfw_instance) so the TFS destination's own CFW class is resolved.
+        executor.tfs_connection_map = {type(mock_to_cfw_instance): Mock()}
+
+        worker_manager.get_process_queues.return_value = None
+
+        mock_process = Mock()
+        mock_cmd_queue = Mock()
+        mock_result_queue = Mock()
+        worker_manager.create_worker_process.return_value = (mock_process, mock_cmd_queue, mock_result_queue)
+
+        with patch("mloda.core.runtime.compute_framework_executor.multiprocessing.Lock"):
+            executor.multi_execute_step(step)
+
+        worker_manager.create_worker_process.assert_called_once_with(
+            new_uuid, mock_worker, (cfw_register, mock_to_cfw_instance, from_cfw_uuid, True)
+        )
+
+    @patch("mloda.core.runtime.compute_framework_executor.worker")
+    def test_passes_needs_tfs_connection_false_when_tfs_connection_map_is_empty(self, mock_worker: Any) -> None:
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = Mock(spec=FeatureGroupStep)
+        step.tfs_ids = []
+        step.features = Mock()
+        step.features.any_uuid = uuid4()
+        step.children_if_root = []
+        step.compute_framework = Mock()
+        step.compute_framework.get_class_name.return_value = "TestCFW"
+        step.get_uuids.return_value = {uuid4()}
+
+        cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
+        cfw_register.get_cfw_uuid.return_value = cfw_uuid
+
+        mock_cfw = Mock(spec=ComputeFramework)
+        executor.cfw_collection[cfw_uuid] = mock_cfw
+        assert executor.tfs_connection_map == {}
+
+        worker_manager.get_process_queues.return_value = None
+
+        mock_process = Mock()
+        mock_cmd_queue = Mock()
+        mock_result_queue = Mock()
+        worker_manager.create_worker_process.return_value = (mock_process, mock_cmd_queue, mock_result_queue)
+
+        executor.multi_execute_step(step)
+
+        worker_manager.create_worker_process.assert_called_once_with(
+            cfw_uuid, mock_worker, (cfw_register, mock_cfw, None, False)
+        )
+
+    @patch("mloda.core.runtime.compute_framework_executor.worker")
+    def test_passes_needs_tfs_connection_false_when_destination_type_is_not_in_tfs_connection_map(
+        self, mock_worker: Any
+    ) -> None:
+        cfw_register = Mock(spec=CfwManager)
+        worker_manager = Mock(spec=WorkerManager)
+        executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
+
+        step = Mock(spec=FeatureGroupStep)
+        step.tfs_ids = []
+        step.features = Mock()
+        step.features.any_uuid = uuid4()
+        step.children_if_root = []
+        step.compute_framework = Mock()
+        step.compute_framework.get_class_name.return_value = "TestCFW"
+        step.get_uuids.return_value = {uuid4()}
+
+        cfw_uuid = uuid4()
+        cfw_register.get_unique_cfw_uuid.return_value = None
+        cfw_register.get_cfw_uuid.return_value = cfw_uuid
+
+        mock_cfw = Mock(spec=ComputeFramework)
+        executor.cfw_collection[cfw_uuid] = mock_cfw
+
+        class _UnrelatedCfwType(ComputeFramework):
+            pass
+
+        executor.tfs_connection_map = {_UnrelatedCfwType: Mock()}
+
+        worker_manager.get_process_queues.return_value = None
+
+        mock_process = Mock()
+        mock_cmd_queue = Mock()
+        mock_result_queue = Mock()
+        worker_manager.create_worker_process.return_value = (mock_process, mock_cmd_queue, mock_result_queue)
+
+        executor.multi_execute_step(step)
+
+        worker_manager.create_worker_process.assert_called_once_with(
+            cfw_uuid, mock_worker, (cfw_register, mock_cfw, None, False)
+        )

--- a/tests/test_core/test_runtime/test_multiprocessing_worker.py
+++ b/tests/test_core/test_runtime/test_multiprocessing_worker.py
@@ -2,6 +2,8 @@
 seam (invoked once before the command loop, exceptions reported via the standard error channel).
 """
 
+import inspect
+import logging
 import multiprocessing
 from typing import Any
 from unittest.mock import Mock
@@ -110,3 +112,139 @@ class TestWorkerExitsWhenTheParentProcessIsNoLongerAlive:
 
         # No STOP is queued; the dead-parent check alone must end the loop.
         worker(command_queue, result_queue, cfw_register, cfw, uuid4(), worker_index=0)
+
+
+class TestWorkerBindsTfsConnectionWhenNeededBeforeTheCommandLoop:
+    """Binds the TFS connection worker-side so the unpicklable live connection object never
+    crosses into the worker."""
+
+    def test_needs_tfs_connection_true_and_unset_connection_calls_set_framework_connection_object_with_none(
+        self,
+    ) -> None:
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+        assert cfw.framework_connection_object is None
+        cfw.set_framework_connection_object = Mock()  # type: ignore[method-assign]
+        command_queue.put("STOP")
+
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), True, worker_index=0)
+
+        cfw.set_framework_connection_object.assert_called_once_with(None)
+
+    def test_needs_tfs_connection_true_and_already_set_connection_is_not_clobbered(self) -> None:
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+        sentinel_connection = object()
+        cfw.framework_connection_object = sentinel_connection
+        cfw.set_framework_connection_object = Mock()  # type: ignore[method-assign]
+        command_queue.put("STOP")
+
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), True, worker_index=0)
+
+        cfw.set_framework_connection_object.assert_not_called()
+        assert cfw.framework_connection_object is sentinel_connection
+
+    def test_needs_tfs_connection_false_does_not_call_set_framework_connection_object(self) -> None:
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+        assert cfw.framework_connection_object is None
+        cfw.set_framework_connection_object = Mock()  # type: ignore[method-assign]
+        command_queue.put("STOP")
+
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), False, worker_index=0)
+
+        cfw.set_framework_connection_object.assert_not_called()
+
+    def test_needs_tfs_connection_defaults_to_false_when_omitted(self) -> None:
+        """Default False keeps existing direct worker(...) calls elsewhere in this file working."""
+        signature = inspect.signature(worker)
+
+        assert "needs_tfs_connection" in signature.parameters
+        assert signature.parameters["needs_tfs_connection"].default is False
+
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+        cfw.set_framework_connection_object = Mock()  # type: ignore[method-assign]
+        command_queue.put("STOP")
+
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), worker_index=0)
+
+        cfw.set_framework_connection_object.assert_not_called()
+
+
+class TestWorkerReportsTfsConnectionBindExceptionThroughTheErrorChannel:
+    """set_framework_connection_object(None) must be guarded the same way the child_bootstrap
+    call immediately above it is: a raising framework (e.g. DuckDBFramework's real implementation
+    on a MULTIPROCESSING-capable subclass) must not crash the worker process."""
+
+    def test_bind_exception_is_reported_via_set_error_and_stop_without_propagating(self) -> None:
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+        boom = ValueError("boom")
+        cfw.set_framework_connection_object = Mock(side_effect=boom)  # type: ignore[method-assign]
+
+        # The call itself must not raise, even though set_framework_connection_object() does.
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), True, worker_index=0)
+
+        cfw_register.set_error.assert_called_once()
+        call_args = cfw_register.set_error.call_args
+        error_message = call_args.args[0]
+        assert "boom" in error_message
+        assert call_args.kwargs.get("exception") is boom
+
+        # worker() must have put "STOP" on command_queue itself (via _handle_stop_command),
+        # exactly like the bootstrap exception path does.
+        stopped_command = command_queue.get(timeout=2)
+        assert stopped_command == "STOP"
+
+
+class TestWorkerWarnsWhenTfsConnectionBindSilentlyNoOps:
+    """A framework (e.g. IcebergFramework) whose set_framework_connection_object(None) is a silent
+    no-op leaves framework_connection_object None with no exception raised. The worker must not
+    crash or hang, but must log a warning so the eventual downstream failure is easy to trace back
+    to a framework that does not yet support worker-side self-construction."""
+
+    def test_silent_no_op_bind_logs_a_warning_and_does_not_raise(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING)
+
+        ctx = mp_spawn_context()
+        command_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        result_queue: multiprocessing.Queue[Any] = ctx.Queue()
+        cfw_register = Mock(spec=CfwManager)
+        cfw_register.get_location.return_value = "grpc://localhost:9999"
+        cfw_register.get_run_context.return_value = RunContext()
+        cfw = PythonDictFramework(mode=ParallelizationMode.MULTIPROCESSING, children_if_root=frozenset())
+        assert cfw.framework_connection_object is None
+        # No-op: does not raise, and does not actually set framework_connection_object.
+        cfw.set_framework_connection_object = Mock()  # type: ignore[method-assign]
+        command_queue.put("STOP")
+
+        worker(command_queue, result_queue, cfw_register, cfw, uuid4(), True, worker_index=0)
+
+        assert len(caplog.records) >= 1
+        assert any(record.levelno == logging.WARNING for record in caplog.records)

--- a/tests/test_core/test_runtime/test_tfs_connection_multiprocessing_e2e.py
+++ b/tests/test_core/test_runtime/test_tfs_connection_multiprocessing_e2e.py
@@ -1,0 +1,129 @@
+"""E2E: binds a working connection inside a spawned MULTIPROCESSING worker for a
+connection-requiring destination framework, mirroring Spark/Iceberg's worker-side
+self-construction pattern without the cost of a real JVM/catalog in the worker."""
+
+from typing import Any
+
+import pytest
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None  # type: ignore[assignment]
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment, unused-ignore]
+
+from mloda.user import Feature, DataAccessCollection, ParallelizationMode, PluginCollector, mloda
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import FeatureName, Options
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+class _MultiprocessingConnectionDuckDBFramework(DuckDBFramework):
+    """Stands in for Spark/Iceberg: self-constructs its connection worker-side instead of
+    receiving the parent process's live object."""
+
+    @classmethod
+    def supported_parallelization_modes(cls) -> set[ParallelizationMode]:
+        return {ParallelizationMode.SYNC, ParallelizationMode.THREADING, ParallelizationMode.MULTIPROCESSING}
+
+    def set_framework_connection_object(self, framework_connection_object: Any | None = None) -> None:
+        if framework_connection_object is None and self.framework_connection_object is None:
+            framework_connection_object = duckdb.connect()
+        super().set_framework_connection_object(framework_connection_object)
+
+
+class _MpTfsRawValSource(FeatureGroup):
+    """Source: emits mp_tfs_raw_val=[1,2,3] on PythonDictFramework, not PyArrowTable, to avoid
+    aliasing with the PyArrowTable sink two hops downstream (mloda reuses one CFW instance per
+    framework class per plan)."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"mp_tfs_raw_val"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"mp_tfs_raw_val": [1, 2, 3]}
+
+
+class _MpTfsDoubledDuckDBFG(FeatureGroup):
+    """Doubles mp_tfs_raw_val via a DuckDB SQL projection that requires the connection.
+    Plain FeatureGroup, not MatchData: MatchData embeds the live connection object into
+    Options, which can't be pickled for a MULTIPROCESSING worker."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature("mp_tfs_raw_val")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {_MultiprocessingConnectionDuckDBFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data.project("*, mp_tfs_raw_val * 2 AS mp_tfs_doubled")
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"mp_tfs_doubled"}
+
+
+class _MpTfsDoubledBackToPyArrowFG(FeatureGroup):
+    """Re-emits mp_tfs_doubled on PyArrowTable as mp_tfs_final. Requesting mp_tfs_doubled
+    directly would hit a separate, unrelated gap: materializing it in the parent process also
+    needs a connection that the parent never binds. Routing through PyArrowTable sidesteps
+    that without masking the worker-side bind this test exists to prove."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature("mp_tfs_doubled")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data.append_column("mp_tfs_final", data["mp_tfs_doubled"])
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"mp_tfs_final"}
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow not installed.")
+def test_tfs_connection_reaches_multiprocessing_worker(flight_server: Any) -> None:
+    setup_connection = duckdb.connect()
+    plugin_collector = PluginCollector.enabled_feature_groups(
+        {_MpTfsRawValSource, _MpTfsDoubledDuckDBFG, _MpTfsDoubledBackToPyArrowFG}
+    )
+    dac = DataAccessCollection(connections={setup_connection})
+
+    result = mloda.run_all(
+        [Feature("mp_tfs_final")],
+        compute_frameworks={PythonDictFramework, _MultiprocessingConnectionDuckDBFramework, PyArrowTable},
+        plugin_collector=plugin_collector,
+        data_access_collection=dac,
+        parallelization_modes={ParallelizationMode.MULTIPROCESSING},
+        flight_server=flight_server,
+    )
+
+    assert result is not None
+    assert len(result) == 1
+    final = result[0]
+    assert isinstance(final, pa.Table)
+    assert "mp_tfs_final" in final.column_names
+    assert final.column("mp_tfs_final").to_pylist() == [2, 4, 6]
+
+    setup_connection.close()


### PR DESCRIPTION
## Summary

A `TransformFrameworkStep`'s destination connection (resolved from `DataAccessCollection` at `Engine` setup) was only ever bound to the destination compute framework in the parent process. For a MULTIPROCESSING-capable, connection-requiring destination framework whose connection self-constructs on demand (for example `SparkFramework`, which already falls back to building a local `SparkSession` when none is provided), a step dispatched to a spawned worker reached that worker with no connection bound at all: binding the live connection before pickling the destination framework would break it for frameworks holding an unpicklable connection object.

## Fix

`ComputeFrameworkExecutor.multi_execute_step` now computes a plain, picklable `needs_tfs_connection` flag (never the live connection object) for a `TransformFrameworkStep` whose destination framework class had a connection resolved at setup, and passes it to the spawned worker. Before entering its command loop, the worker calls `set_framework_connection_object(None)` on the destination framework so it can construct its own connection locally. A framework that raises instead of self-constructing has that error reported through the existing error channel rather than crashing the worker; a framework that silently no-ops logs a warning so the gap is visible instead of silent.

## Tests

Unit coverage for the flag threading through `multi_execute_step` and the worker's bind/error/warning paths, plus an end-to-end test proving a MULTIPROCESSING-capable, connection-requiring destination framework gets a working, worker-local connection bound without the live connection ever crossing the pickling boundary.

Closes #1367